### PR TITLE
feat(CLIENT-BE-3): assign default client permissions on CreateClient

### DIFF
--- a/client-service/internal/service/client_service.go
+++ b/client-service/internal/service/client_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/client-service/internal/config"
@@ -91,6 +92,17 @@ func (s *ClientService) CreateClient(input CreateClientInput) (*models.Client, e
 
 	if err := s.clientRepo.Create(client); err != nil {
 		return nil, err
+	}
+
+	// Assign default client permissions (client.basic)
+	defaultPerms, err := s.permRepo.FindByNamesForSubject(
+		[]string{models.PermClientBasic},
+		models.PermissionSubjectClient,
+	)
+	if err == nil && len(defaultPerms) > 0 {
+		if permErr := s.clientRepo.SetPermissions(client, defaultPerms); permErr != nil {
+			slog.Warn("failed to assign default permissions to new client", "client_id", client.ID, "error", permErr)
+		}
 	}
 
 	return client, nil

--- a/client-service/internal/service/client_service_test.go
+++ b/client-service/internal/service/client_service_test.go
@@ -225,6 +225,94 @@ func TestUpdateClient_DuplicateEmail(t *testing.T) {
 	}
 }
 
+func TestCreateClient_AssignsDefaultPermissions(t *testing.T) {
+	setPermsCalled := false
+	clientRepo := &mockClientRepo{
+		emailExistsFn: func(email string, excludeID uint) (bool, error) { return false, nil },
+		createFn:      func(client *models.Client) error { client.ID = 5; return nil },
+		setPermissionsFn: func(client *models.Client, perms []models.Permission) error {
+			setPermsCalled = true
+			if len(perms) == 0 {
+				t.Error("SetPermissions called with empty permissions slice")
+			}
+			return nil
+		},
+	}
+	permRepo := &mockPermRepo{
+		findByNamesForSubjectFn: func(names []string, subjectType string) ([]models.Permission, error) {
+			return []models.Permission{{Name: "client.basic"}}, nil
+		},
+	}
+	svc := newTestClientService(clientRepo, permRepo)
+
+	_, err := svc.CreateClient(validCreateClientInput())
+	if err != nil {
+		t.Fatalf("CreateClient() unexpected error: %v", err)
+	}
+	if !setPermsCalled {
+		t.Error("CreateClient() did not call SetPermissions — default client permissions not assigned")
+	}
+}
+
+func TestCreateClient_ReturnsClientWithID(t *testing.T) {
+	clientRepo := &mockClientRepo{
+		emailExistsFn: func(email string, excludeID uint) (bool, error) { return false, nil },
+		createFn:      func(client *models.Client) error { client.ID = 42; return nil },
+	}
+	permRepo := &mockPermRepo{
+		findByNamesForSubjectFn: func(names []string, subjectType string) ([]models.Permission, error) {
+			return []models.Permission{}, nil
+		},
+	}
+	svc := newTestClientService(clientRepo, permRepo)
+
+	got, err := svc.CreateClient(validCreateClientInput())
+	if err != nil {
+		t.Fatalf("CreateClient() unexpected error: %v", err)
+	}
+	if got.ID != 42 {
+		t.Errorf("CreateClient() returned client.ID = %d, want 42", got.ID)
+	}
+}
+
+func TestCreateClient_AccountOpeningFlow(t *testing.T) {
+	// Simulates employee creating a client during account opening:
+	// client is created, gets default permissions, and returns with a usable ID.
+	var createdClient *models.Client
+	clientRepo := &mockClientRepo{
+		emailExistsFn: func(email string, excludeID uint) (bool, error) { return false, nil },
+		createFn: func(client *models.Client) error {
+			client.ID = 99
+			createdClient = client
+			return nil
+		},
+		setPermissionsFn: func(client *models.Client, perms []models.Permission) error {
+			client.Permissions = perms
+			return nil
+		},
+	}
+	permRepo := &mockPermRepo{
+		findByNamesForSubjectFn: func(names []string, subjectType string) ([]models.Permission, error) {
+			if subjectType != models.PermissionSubjectClient {
+				t.Errorf("FindByNamesForSubject called with subjectType=%q, want %q", subjectType, models.PermissionSubjectClient)
+			}
+			return []models.Permission{{Name: models.PermClientBasic}}, nil
+		},
+	}
+	svc := newTestClientService(clientRepo, permRepo)
+
+	got, err := svc.CreateClient(validCreateClientInput())
+	if err != nil {
+		t.Fatalf("CreateClient() unexpected error: %v", err)
+	}
+	if got == nil || got.ID == 0 {
+		t.Fatal("CreateClient() returned client without ID")
+	}
+	if createdClient == nil {
+		t.Fatal("client was never passed to Create()")
+	}
+}
+
 func TestCreateClient_AcceptsNonBankEmail(t *testing.T) {
 	clientRepo := &mockClientRepo{
 		emailExistsFn: func(email string, excludeID uint) (bool, error) { return false, nil },


### PR DESCRIPTION
## Summary

- `CreateClient` now assigns `client.basic` permission to every new client after creation
- Uses `permRepo.FindByNamesForSubject` + `clientRepo.SetPermissions` (already in the repository interface)
- Permission assignment failure is non-fatal — logs a warning and still returns the created client

## Test plan
- [x] 13 unit tests passing (`go test ./internal/service/...`)
- New tests: `TestCreateClient_AssignsDefaultPermissions`, `TestCreateClient_ReturnsClientWithID`, `TestCreateClient_AccountOpeningFlow`

> Note: there is no separate CLIENT-BE-3 GitHub issue — this scope was part of CLIENT-BE-1 (#35, already closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)