### PR TITLE
feat(AUTH-BE-1): client authentication with JWT client_id and TokenSource

### DIFF
--- a/auth-service/internal/models/client.go
+++ b/auth-service/internal/models/client.go
@@ -1,0 +1,23 @@
+package models
+
+import "time"
+
+type Client struct {
+	ID           uint         `gorm:"primaryKey;autoIncrement" json:"id"`
+	Ime          string       `gorm:"not null" json:"ime"`
+	Prezime      string       `gorm:"not null" json:"prezime"`
+	Email        string       `gorm:"uniqueIndex;not null" json:"email"`
+	Password     string       `gorm:"not null" json:"-"`
+	SaltPassword string       `gorm:"not null;column:salt_password" json:"-"`
+	Permissions  []Permission `gorm:"many2many:client_permissions;" json:"permissions,omitempty"`
+	CreatedAt    time.Time    `json:"created_at"`
+	UpdatedAt    time.Time    `json:"updated_at"`
+}
+
+func (c *Client) PermissionNames() []string {
+	names := make([]string, 0, len(c.Permissions))
+	for _, p := range c.Permissions {
+		names = append(names, p.Name)
+	}
+	return names
+}

--- a/auth-service/internal/repository/client_repo.go
+++ b/auth-service/internal/repository/client_repo.go
@@ -1,0 +1,25 @@
+package repository
+
+import (
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/auth-service/internal/models"
+	"gorm.io/gorm"
+)
+
+type ClientRepository struct {
+	db *gorm.DB
+}
+
+func NewClientRepository(db *gorm.DB) *ClientRepository {
+	return &ClientRepository{db: db}
+}
+
+func (r *ClientRepository) FindByEmail(email string) (*models.Client, error) {
+	var client models.Client
+	err := r.db.Preload("Permissions").Where("email = ?", email).First(&client).Error
+	if err != nil {
+		return nil, err
+	}
+	return &client, nil
+}
+
+var _ ClientRepositoryInterface = (*ClientRepository)(nil)

--- a/auth-service/internal/repository/interfaces.go
+++ b/auth-service/internal/repository/interfaces.go
@@ -16,6 +16,11 @@ type TokenRepositoryInterface interface {
 	InvalidateEmployeeTokens(employeeID uint, tokenType string) error
 }
 
+// ClientRepositoryInterface defines the methods used by AuthService for client authentication.
+type ClientRepositoryInterface interface {
+	FindByEmail(email string) (*models.Client, error)
+}
+
 // Compile-time checks: ensure concrete repositories satisfy their interfaces.
 var _ EmployeeRepositoryInterface = (*EmployeeRepository)(nil)
 var _ TokenRepositoryInterface = (*TokenRepository)(nil)

--- a/auth-service/internal/service/auth_service.go
+++ b/auth-service/internal/service/auth_service.go
@@ -17,6 +17,7 @@ import (
 type AuthService struct {
 	cfg          *config.Config
 	employeeRepo repository.EmployeeRepositoryInterface
+	clientRepo   repository.ClientRepositoryInterface
 	tokenRepo    repository.TokenRepositoryInterface
 	notifSvc     *NotificationService
 }
@@ -25,6 +26,7 @@ func NewAuthService(cfg *config.Config, db *gorm.DB, notifSvc *NotificationServi
 	return &AuthService{
 		cfg:          cfg,
 		employeeRepo: repository.NewEmployeeRepository(db),
+		clientRepo:   repository.NewClientRepository(db),
 		tokenRepo:    repository.NewTokenRepository(db),
 		notifSvc:     notifSvc,
 	}
@@ -32,10 +34,11 @@ func NewAuthService(cfg *config.Config, db *gorm.DB, notifSvc *NotificationServi
 
 // NewAuthServiceWithRepos constructs an AuthService with injected repository interfaces,
 // allowing mock implementations to be used in unit tests.
-func NewAuthServiceWithRepos(cfg *config.Config, employeeRepo repository.EmployeeRepositoryInterface, tokenRepo repository.TokenRepositoryInterface, notifSvc *NotificationService) *AuthService {
+func NewAuthServiceWithRepos(cfg *config.Config, employeeRepo repository.EmployeeRepositoryInterface, clientRepo repository.ClientRepositoryInterface, tokenRepo repository.TokenRepositoryInterface, notifSvc *NotificationService) *AuthService {
 	return &AuthService{
 		cfg:          cfg,
 		employeeRepo: employeeRepo,
+		clientRepo:   clientRepo,
 		tokenRepo:    tokenRepo,
 		notifSvc:     notifSvc,
 	}
@@ -190,6 +193,39 @@ func (s *AuthService) RequestPasswordReset(email string) error {
 
 	_ = s.notifSvc.SendResetPasswordEmail(emp.Email, emp.Ime+" "+emp.Prezime, tokenStr)
 	return nil
+}
+
+// ClientLogin authenticates a client by email/password and returns JWT tokens with client_id.
+func (s *AuthService) ClientLogin(email, password string) (string, string, *models.Client, error) {
+	client, err := s.clientRepo.FindByEmail(email)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", "", nil, fmt.Errorf("invalid credentials")
+		}
+		return "", "", nil, err
+	}
+
+	ok, err := util.VerifyPassword(password, client.SaltPassword, client.Password)
+	if err != nil {
+		return "", "", nil, err
+	}
+	if !ok {
+		return "", "", nil, fmt.Errorf("invalid credentials")
+	}
+
+	perms := client.PermissionNames()
+
+	accessToken, err := util.GenerateClientAccessToken(client.ID, client.Email, perms, s.cfg.JWTSecret, s.cfg.JWTAccessDuration)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	refreshToken, err := util.GenerateClientRefreshToken(client.ID, client.Email, s.cfg.JWTSecret, s.cfg.JWTRefreshDuration)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	return accessToken, refreshToken, client, nil
 }
 
 func (s *AuthService) ResetPassword(tokenStr, password, passwordConfirm string) error {

--- a/auth-service/internal/service/auth_service_test.go
+++ b/auth-service/internal/service/auth_service_test.go
@@ -69,24 +69,37 @@ func (m *mockTokenRepo) InvalidateEmployeeTokens(employeeID uint, tokenType stri
 	return nil
 }
 
+// ---- mock client repository ----
+
+type mockClientRepo struct {
+	findByEmailFn func(email string) (*models.Client, error)
+}
+
+func (m *mockClientRepo) FindByEmail(email string) (*models.Client, error) {
+	if m.findByEmailFn != nil {
+		return m.findByEmailFn(email)
+	}
+	return nil, errors.New("not implemented")
+}
+
 // ---- compile-time interface checks ----
 
 var _ repository.EmployeeRepositoryInterface = (*mockEmployeeRepo)(nil)
 var _ repository.TokenRepositoryInterface = (*mockTokenRepo)(nil)
+var _ repository.ClientRepositoryInterface = (*mockClientRepo)(nil)
 
 // ---- test helper ----
 
 // newTestAuthService creates an AuthService for unit testing.
 // notifSvc is nil — safe because unit tests only exercise paths that return
 // before the notification call (password mismatch, policy failure, etc.).
-// Tests that reach SendConfirmationEmail/SendResetPasswordEmail need a real notifSvc.
 func newTestAuthService(empRepo repository.EmployeeRepositoryInterface, tokRepo repository.TokenRepositoryInterface) *service.AuthService {
 	cfg := &config.Config{
 		JWTSecret:          "test-secret",
 		JWTAccessDuration:  15,
 		JWTRefreshDuration: 24 * 60,
 	}
-	return service.NewAuthServiceWithRepos(cfg, empRepo, tokRepo, nil)
+	return service.NewAuthServiceWithRepos(cfg, empRepo, &mockClientRepo{}, tokRepo, nil)
 }
 
 // ---- tests ----
@@ -241,6 +254,146 @@ func TestActivateAccount_InvalidPasswordPolicy(t *testing.T) {
 	err := svc.ActivateAccount("sometoken", "weak", "weak")
 	if err == nil {
 		t.Fatal("ActivateAccount() expected error for weak password, got nil")
+	}
+}
+
+// ---- ClientLogin tests ----
+
+func newTestAuthServiceWithClient(empRepo repository.EmployeeRepositoryInterface, clientRepo repository.ClientRepositoryInterface, tokRepo repository.TokenRepositoryInterface) *service.AuthService {
+	cfg := &config.Config{
+		JWTSecret:          "test-secret",
+		JWTAccessDuration:  15,
+		JWTRefreshDuration: 24 * 60,
+	}
+	return service.NewAuthServiceWithRepos(cfg, empRepo, clientRepo, tokRepo, nil)
+}
+
+func TestClientLogin_Success(t *testing.T) {
+	salt, _ := util.GenerateSalt()
+	hash, _ := util.HashPassword("ClientPass12", salt)
+
+	client := &models.Client{
+		ID:           10,
+		Email:        "user@gmail.com",
+		Password:     hash,
+		SaltPassword: salt,
+		Permissions:  []models.Permission{},
+	}
+
+	svc := newTestAuthServiceWithClient(
+		&mockEmployeeRepo{},
+		&mockClientRepo{findByEmailFn: func(email string) (*models.Client, error) { return client, nil }},
+		&mockTokenRepo{},
+	)
+
+	access, refresh, gotClient, err := svc.ClientLogin("user@gmail.com", "ClientPass12")
+	if err != nil {
+		t.Fatalf("ClientLogin() unexpected error: %v", err)
+	}
+	if access == "" {
+		t.Error("ClientLogin() returned empty access token")
+	}
+	if refresh == "" {
+		t.Error("ClientLogin() returned empty refresh token")
+	}
+	if gotClient == nil || gotClient.ID != 10 {
+		t.Error("ClientLogin() returned wrong client")
+	}
+}
+
+func TestClientLogin_WrongPassword(t *testing.T) {
+	salt, _ := util.GenerateSalt()
+	hash, _ := util.HashPassword("CorrectPass12", salt)
+
+	client := &models.Client{
+		ID:           11,
+		Email:        "user@gmail.com",
+		Password:     hash,
+		SaltPassword: salt,
+	}
+
+	svc := newTestAuthServiceWithClient(
+		&mockEmployeeRepo{},
+		&mockClientRepo{findByEmailFn: func(email string) (*models.Client, error) { return client, nil }},
+		&mockTokenRepo{},
+	)
+
+	_, _, _, err := svc.ClientLogin("user@gmail.com", "WrongPass99")
+	if err == nil {
+		t.Fatal("ClientLogin() expected error for wrong password, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid credentials") {
+		t.Errorf("ClientLogin() error = %q, want contains %q", err.Error(), "invalid credentials")
+	}
+}
+
+func TestClientLogin_NonExistentEmail(t *testing.T) {
+	svc := newTestAuthServiceWithClient(
+		&mockEmployeeRepo{},
+		&mockClientRepo{findByEmailFn: func(email string) (*models.Client, error) {
+			return nil, gorm.ErrRecordNotFound
+		}},
+		&mockTokenRepo{},
+	)
+
+	_, _, _, err := svc.ClientLogin("nobody@gmail.com", "AnyPass12")
+	if err == nil {
+		t.Fatal("ClientLogin() expected error for non-existent email, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid credentials") {
+		t.Errorf("ClientLogin() error = %q, want contains %q", err.Error(), "invalid credentials")
+	}
+}
+
+func TestClientLogin_JWTContainsClientID(t *testing.T) {
+	salt, _ := util.GenerateSalt()
+	hash, _ := util.HashPassword("ClientPass12", salt)
+
+	client := &models.Client{ID: 42, Email: "user@gmail.com", Password: hash, SaltPassword: salt, Permissions: []models.Permission{}}
+
+	svc := newTestAuthServiceWithClient(
+		&mockEmployeeRepo{},
+		&mockClientRepo{findByEmailFn: func(email string) (*models.Client, error) { return client, nil }},
+		&mockTokenRepo{},
+	)
+
+	access, _, _, err := svc.ClientLogin("user@gmail.com", "ClientPass12")
+	if err != nil {
+		t.Fatalf("ClientLogin() unexpected error: %v", err)
+	}
+
+	claims, err := util.ParseToken(access, "test-secret")
+	if err != nil {
+		t.Fatalf("ParseToken() error: %v", err)
+	}
+	if claims.ClientID != 42 {
+		t.Errorf("JWT ClientID = %d, want 42", claims.ClientID)
+	}
+}
+
+func TestClientLogin_JWTTokenSourceIsClient(t *testing.T) {
+	salt, _ := util.GenerateSalt()
+	hash, _ := util.HashPassword("ClientPass12", salt)
+
+	client := &models.Client{ID: 7, Email: "user@gmail.com", Password: hash, SaltPassword: salt, Permissions: []models.Permission{}}
+
+	svc := newTestAuthServiceWithClient(
+		&mockEmployeeRepo{},
+		&mockClientRepo{findByEmailFn: func(email string) (*models.Client, error) { return client, nil }},
+		&mockTokenRepo{},
+	)
+
+	access, _, _, err := svc.ClientLogin("user@gmail.com", "ClientPass12")
+	if err != nil {
+		t.Fatalf("ClientLogin() unexpected error: %v", err)
+	}
+
+	claims, err := util.ParseToken(access, "test-secret")
+	if err != nil {
+		t.Fatalf("ParseToken() error: %v", err)
+	}
+	if claims.TokenSource != "client" {
+		t.Errorf("JWT TokenSource = %q, want %q", claims.TokenSource, "client")
 	}
 }
 

--- a/auth-service/internal/util/jwt.go
+++ b/auth-service/internal/util/jwt.go
@@ -9,10 +9,12 @@ import (
 
 type Claims struct {
 	EmployeeID  uint     `json:"employee_id"`
+	ClientID    uint     `json:"client_id"`    // 0 for employee tokens
 	Email       string   `json:"email"`
-	Username    string   `json:"username"`
+	Username    string   `json:"username"`     // empty for client tokens
 	Permissions []string `json:"permissions"`
-	TokenType   string   `json:"token_type"`
+	TokenType   string   `json:"token_type"`   // "access" | "refresh"
+	TokenSource string   `json:"token_source"` // "employee" | "client"
 	jwt.RegisteredClaims
 }
 
@@ -23,6 +25,7 @@ func GenerateAccessToken(employeeID uint, email, username string, permissions []
 		Username:    username,
 		Permissions: permissions,
 		TokenType:   "access",
+		TokenSource: "employee",
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(durationMinutes) * time.Minute)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -34,16 +37,46 @@ func GenerateAccessToken(employeeID uint, email, username string, permissions []
 
 func GenerateRefreshToken(employeeID uint, email, username string, secret string, durationHours int) (string, error) {
 	claims := Claims{
-		EmployeeID: employeeID,
-		Email:      email,
-		Username:   username,
-		TokenType:  "refresh",
+		EmployeeID:  employeeID,
+		Email:       email,
+		Username:    username,
+		TokenType:   "refresh",
+		TokenSource: "employee",
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(durationHours) * time.Hour)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 		},
 	}
 
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
+}
+
+func GenerateClientAccessToken(clientID uint, email string, permissions []string, secret string, durationMinutes int) (string, error) {
+	claims := Claims{
+		ClientID:    clientID,
+		Email:       email,
+		Permissions: permissions,
+		TokenType:   "access",
+		TokenSource: "client",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(durationMinutes) * time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
+}
+
+func GenerateClientRefreshToken(clientID uint, email string, secret string, durationHours int) (string, error) {
+	claims := Claims{
+		ClientID:    clientID,
+		Email:       email,
+		TokenType:   "refresh",
+		TokenSource: "client",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(durationHours) * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
 	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
 }
 


### PR DESCRIPTION
## Summary

- Added `models/client.go`: Client model for auth-service (email, password, permissions)
- Extended JWT `Claims` with `ClientID uint` and `TokenSource string` (`"employee"` | `"client"`)
- Added `GenerateClientAccessToken` and `GenerateClientRefreshToken` to `util/jwt.go`
- Added `ClientRepositoryInterface` + `ClientRepository.FindByEmail`
- Added `ClientLogin(email, password)`: verifies credentials, returns JWT with `client_id` and `token_source: "client"`
- Updated `NewAuthServiceWithRepos` signature to include `clientRepo`

## Test plan
- [x] 13 unit tests passing (`go test ./internal/...`)
- New tests: `TestClientLogin_Success`, `TestClientLogin_WrongPassword`, `TestClientLogin_NonExistentEmail`, `TestClientLogin_JWTContainsClientID`, `TestClientLogin_JWTTokenSourceIsClient`

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)