### PR TITLE
feat(INFRA-BE-8): auth interceptor update — client JWT support

### DIFF
--- a/client-service/internal/middleware/auth_interceptor.go
+++ b/client-service/internal/middleware/auth_interceptor.go
@@ -13,12 +13,19 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// requiredPermissions defines the permission an employee must have to call each RPC.
 var requiredPermissions = map[string]string{
 	"/client.v1.ClientService/CreateClient":            models.PermAdmin,
 	"/client.v1.ClientService/GetClient":               models.PermAdmin,
 	"/client.v1.ClientService/ListClients":             models.PermAdmin,
 	"/client.v1.ClientService/UpdateClient":            models.PermAdmin,
 	"/client.v1.ClientService/UpdateClientPermissions": models.PermAdmin,
+}
+
+// clientRequiredPermissions defines which RPCs a client JWT can call and what permission is needed.
+var clientRequiredPermissions = map[string]string{
+	"/client.v1.ClientService/GetClient":    models.PermClientBasic,
+	"/client.v1.ClientService/UpdateClient": models.PermClientBasic,
 }
 
 type claimsContextKey struct{}
@@ -57,11 +64,22 @@ func AuthInterceptor(cfg *config.Config) grpc.UnaryServerInterceptor {
 			return nil, status.Error(codes.Unauthenticated, "wrong token type: expected access token")
 		}
 
-		if requiredPerm, exists := requiredPermissions[info.FullMethod]; exists {
-			isAdmin := util.HasPermission(claims, models.PermAdmin)
-			hasPerm := util.HasPermission(claims, requiredPerm)
-			if !isAdmin && !hasPerm {
+		if claims.TokenSource == "client" {
+			requiredPerm, exists := clientRequiredPermissions[info.FullMethod]
+			if !exists {
+				return nil, status.Error(codes.PermissionDenied, "endpoint not accessible to clients")
+			}
+			if !util.HasPermission(claims, requiredPerm) {
 				return nil, status.Errorf(codes.PermissionDenied, "permission %q required", requiredPerm)
+			}
+		} else {
+			// employee (or legacy token without TokenSource)
+			if requiredPerm, exists := requiredPermissions[info.FullMethod]; exists {
+				isAdmin := util.HasPermission(claims, models.PermAdmin)
+				hasPerm := util.HasPermission(claims, requiredPerm)
+				if !isAdmin && !hasPerm {
+					return nil, status.Errorf(codes.PermissionDenied, "permission %q required", requiredPerm)
+				}
 			}
 		}
 

--- a/client-service/internal/middleware/auth_interceptor_test.go
+++ b/client-service/internal/middleware/auth_interceptor_test.go
@@ -1,0 +1,118 @@
+package middleware_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/client-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/client-service/internal/middleware"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/client-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/client-service/internal/util"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const testSecret = "test-secret"
+
+func newTestConfig() *config.Config {
+	return &config.Config{JWTSecret: testSecret}
+}
+
+func employeeToken(t *testing.T, perms []string) string {
+	t.Helper()
+	tok, err := util.GenerateAccessToken(1, "admin@bank.com", "admin", perms, testSecret, 60)
+	if err != nil {
+		t.Fatalf("generate employee token: %v", err)
+	}
+	return tok
+}
+
+func clientToken(t *testing.T, perms []string) string {
+	t.Helper()
+	tok, err := util.GenerateClientAccessToken(1, "client@gmail.com", perms, testSecret, 60)
+	if err != nil {
+		t.Fatalf("generate client token: %v", err)
+	}
+	return tok
+}
+
+func callInterceptor(t *testing.T, cfg *config.Config, method, token string) error {
+	t.Helper()
+	interceptor := middleware.AuthInterceptor(cfg)
+	md := metadata.Pairs("authorization", "Bearer "+token)
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	info := &grpc.UnaryServerInfo{FullMethod: method}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, nil
+	}
+	_, err := interceptor(ctx, nil, info, handler)
+	return err
+}
+
+func TestAuthInterceptor_EmployeeJWT_PassesForAdminEndpoint(t *testing.T) {
+	cfg := newTestConfig()
+	tok := employeeToken(t, []string{models.PermAdmin})
+	err := callInterceptor(t, cfg, "/client.v1.ClientService/GetClient", tok)
+	if err != nil {
+		t.Errorf("expected no error for admin employee token, got %v", err)
+	}
+}
+
+func TestAuthInterceptor_ClientJWT_PassesForClientEndpoint(t *testing.T) {
+	cfg := newTestConfig()
+	tok := clientToken(t, []string{models.PermClientBasic})
+	err := callInterceptor(t, cfg, "/client.v1.ClientService/GetClient", tok)
+	if err != nil {
+		t.Errorf("expected no error for client JWT on GetClient, got %v", err)
+	}
+}
+
+func TestAuthInterceptor_ClientJWT_RejectedForAdminOnlyEndpoint(t *testing.T) {
+	cfg := newTestConfig()
+	tok := clientToken(t, []string{models.PermClientBasic})
+	err := callInterceptor(t, cfg, "/client.v1.ClientService/CreateClient", tok)
+	if err == nil {
+		t.Fatal("expected PermissionDenied for client JWT on CreateClient, got nil")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", st.Code())
+	}
+}
+
+func TestAuthInterceptor_ExpiredToken_Rejected(t *testing.T) {
+	cfg := newTestConfig()
+	expired, err := util.GenerateAccessToken(1, "admin@bank.com", "admin", []string{models.PermAdmin}, testSecret, -1)
+	if err != nil {
+		t.Fatalf("generate expired token: %v", err)
+	}
+	err = callInterceptor(t, cfg, "/client.v1.ClientService/GetClient", expired)
+	if err == nil {
+		t.Fatal("expected error for expired token, got nil")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Unauthenticated {
+		t.Errorf("expected Unauthenticated, got %v", st.Code())
+	}
+}
+
+func TestAuthInterceptor_MissingToken_Rejected(t *testing.T) {
+	cfg := newTestConfig()
+	interceptor := middleware.AuthInterceptor(cfg)
+	md := metadata.Pairs()
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	info := &grpc.UnaryServerInfo{FullMethod: "/client.v1.ClientService/GetClient"}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, nil
+	}
+	_, err := interceptor(ctx, nil, info, handler)
+	if err == nil {
+		t.Fatal("expected error for missing token, got nil")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Unauthenticated {
+		t.Errorf("expected Unauthenticated, got %v", st.Code())
+	}
+}

--- a/client-service/internal/util/jwt.go
+++ b/client-service/internal/util/jwt.go
@@ -9,10 +9,12 @@ import (
 
 type Claims struct {
 	EmployeeID  uint     `json:"employee_id"`
+	ClientID    uint     `json:"client_id"`    // 0 for employee tokens
 	Email       string   `json:"email"`
-	Username    string   `json:"username"`
+	Username    string   `json:"username"`     // empty for client tokens
 	Permissions []string `json:"permissions"`
-	TokenType   string   `json:"token_type"`
+	TokenType   string   `json:"token_type"`   // "access" | "refresh"
+	TokenSource string   `json:"token_source"` // "employee" | "client"
 	jwt.RegisteredClaims
 }
 
@@ -23,6 +25,7 @@ func GenerateAccessToken(employeeID uint, email, username string, permissions []
 		Username:    username,
 		Permissions: permissions,
 		TokenType:   "access",
+		TokenSource: "employee",
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(durationMinutes) * time.Minute)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -34,16 +37,46 @@ func GenerateAccessToken(employeeID uint, email, username string, permissions []
 
 func GenerateRefreshToken(employeeID uint, email, username string, secret string, durationHours int) (string, error) {
 	claims := Claims{
-		EmployeeID: employeeID,
-		Email:      email,
-		Username:   username,
-		TokenType:  "refresh",
+		EmployeeID:  employeeID,
+		Email:       email,
+		Username:    username,
+		TokenType:   "refresh",
+		TokenSource: "employee",
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(durationHours) * time.Hour)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 		},
 	}
 
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
+}
+
+func GenerateClientAccessToken(clientID uint, email string, permissions []string, secret string, durationMinutes int) (string, error) {
+	claims := Claims{
+		ClientID:    clientID,
+		Email:       email,
+		Permissions: permissions,
+		TokenType:   "access",
+		TokenSource: "client",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(durationMinutes) * time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
+}
+
+func GenerateClientRefreshToken(clientID uint, email string, secret string, durationHours int) (string, error) {
+	claims := Claims{
+		ClientID:    clientID,
+		Email:       email,
+		TokenType:   "refresh",
+		TokenSource: "client",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(durationHours) * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
 	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
 }
 

--- a/employee-service/internal/middleware/auth_interceptor.go
+++ b/employee-service/internal/middleware/auth_interceptor.go
@@ -59,6 +59,11 @@ func AuthInterceptor(cfg *config.Config) grpc.UnaryServerInterceptor {
 			return nil, status.Error(codes.Unauthenticated, "wrong token type: expected access token")
 		}
 
+		// Client JWTs are not allowed on the employee service.
+		if claims.TokenSource == "client" {
+			return nil, status.Error(codes.PermissionDenied, "client tokens not allowed on employee service")
+		}
+
 		if requiredPerm, exists := requiredPermissions[info.FullMethod]; exists {
 			isAdmin := util.HasPermission(claims, models.PermAdmin)
 			hasPerm := util.HasPermission(claims, requiredPerm)

--- a/employee-service/internal/middleware/auth_interceptor_test.go
+++ b/employee-service/internal/middleware/auth_interceptor_test.go
@@ -1,0 +1,122 @@
+package middleware_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/middleware"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/util"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const testSecret = "test-secret"
+
+func newTestConfig() *config.Config {
+	return &config.Config{JWTSecret: testSecret}
+}
+
+func employeeToken(t *testing.T, perms []string) string {
+	t.Helper()
+	tok, err := util.GenerateAccessToken(1, "admin@bank.com", "admin", perms, testSecret, 60)
+	if err != nil {
+		t.Fatalf("generate employee token: %v", err)
+	}
+	return tok
+}
+
+func clientToken(t *testing.T, perms []string) string {
+	t.Helper()
+	tok, err := util.GenerateClientAccessToken(1, "client@gmail.com", perms, testSecret, 60)
+	if err != nil {
+		t.Fatalf("generate client token: %v", err)
+	}
+	return tok
+}
+
+func callInterceptor(t *testing.T, cfg *config.Config, method, token string) error {
+	t.Helper()
+	interceptor := middleware.AuthInterceptor(cfg)
+	md := metadata.Pairs("authorization", "Bearer "+token)
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	info := &grpc.UnaryServerInfo{FullMethod: method}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, nil
+	}
+	_, err := interceptor(ctx, nil, info, handler)
+	return err
+}
+
+func TestAuthInterceptor_EmployeeJWT_PassesForEmployeeEndpoint(t *testing.T) {
+	cfg := newTestConfig()
+	tok := employeeToken(t, []string{models.PermAdmin})
+	err := callInterceptor(t, cfg, "/employee.v1.EmployeeService/GetEmployee", tok)
+	if err != nil {
+		t.Errorf("expected no error for admin employee token, got %v", err)
+	}
+}
+
+func TestAuthInterceptor_ClientJWT_RejectedOnEmployeeService(t *testing.T) {
+	cfg := newTestConfig()
+	tok := clientToken(t, []string{models.PermClientBasic})
+	err := callInterceptor(t, cfg, "/employee.v1.EmployeeService/GetEmployee", tok)
+	if err == nil {
+		t.Fatal("expected PermissionDenied for client JWT on employee service, got nil")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", st.Code())
+	}
+}
+
+func TestAuthInterceptor_ExpiredToken_Rejected(t *testing.T) {
+	cfg := newTestConfig()
+	expired, err := util.GenerateAccessToken(1, "admin@bank.com", "admin", []string{models.PermAdmin}, testSecret, -1)
+	if err != nil {
+		t.Fatalf("generate expired token: %v", err)
+	}
+	err = callInterceptor(t, cfg, "/employee.v1.EmployeeService/GetEmployee", expired)
+	if err == nil {
+		t.Fatal("expected error for expired token, got nil")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Unauthenticated {
+		t.Errorf("expected Unauthenticated, got %v", st.Code())
+	}
+}
+
+func TestAuthInterceptor_MissingToken_Rejected(t *testing.T) {
+	cfg := newTestConfig()
+	interceptor := middleware.AuthInterceptor(cfg)
+	md := metadata.Pairs()
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	info := &grpc.UnaryServerInfo{FullMethod: "/employee.v1.EmployeeService/GetEmployee"}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, nil
+	}
+	_, err := interceptor(ctx, nil, info, handler)
+	if err == nil {
+		t.Fatal("expected error for missing token, got nil")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Unauthenticated {
+		t.Errorf("expected Unauthenticated, got %v", st.Code())
+	}
+}
+
+func TestAuthInterceptor_EmployeeJWT_PermissionDeniedWithoutRequiredPerm(t *testing.T) {
+	cfg := newTestConfig()
+	tok := employeeToken(t, []string{models.PermEmployeeRead}) // not admin, not create
+	err := callInterceptor(t, cfg, "/employee.v1.EmployeeService/CreateEmployee", tok)
+	if err == nil {
+		t.Fatal("expected PermissionDenied for employee without create permission, got nil")
+	}
+	st, _ := status.FromError(err)
+	if st.Code() != codes.PermissionDenied {
+		t.Errorf("expected PermissionDenied, got %v", st.Code())
+	}
+}

--- a/employee-service/internal/util/jwt.go
+++ b/employee-service/internal/util/jwt.go
@@ -9,10 +9,12 @@ import (
 
 type Claims struct {
 	EmployeeID  uint     `json:"employee_id"`
+	ClientID    uint     `json:"client_id"`    // 0 for employee tokens
 	Email       string   `json:"email"`
-	Username    string   `json:"username"`
+	Username    string   `json:"username"`     // empty for client tokens
 	Permissions []string `json:"permissions"`
-	TokenType   string   `json:"token_type"`
+	TokenType   string   `json:"token_type"`   // "access" | "refresh"
+	TokenSource string   `json:"token_source"` // "employee" | "client"
 	jwt.RegisteredClaims
 }
 
@@ -23,6 +25,7 @@ func GenerateAccessToken(employeeID uint, email, username string, permissions []
 		Username:    username,
 		Permissions: permissions,
 		TokenType:   "access",
+		TokenSource: "employee",
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(durationMinutes) * time.Minute)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -34,16 +37,46 @@ func GenerateAccessToken(employeeID uint, email, username string, permissions []
 
 func GenerateRefreshToken(employeeID uint, email, username string, secret string, durationHours int) (string, error) {
 	claims := Claims{
-		EmployeeID: employeeID,
-		Email:      email,
-		Username:   username,
-		TokenType:  "refresh",
+		EmployeeID:  employeeID,
+		Email:       email,
+		Username:    username,
+		TokenType:   "refresh",
+		TokenSource: "employee",
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(durationHours) * time.Hour)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 		},
 	}
 
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
+}
+
+func GenerateClientAccessToken(clientID uint, email string, permissions []string, secret string, durationMinutes int) (string, error) {
+	claims := Claims{
+		ClientID:    clientID,
+		Email:       email,
+		Permissions: permissions,
+		TokenType:   "access",
+		TokenSource: "client",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(durationMinutes) * time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
+}
+
+func GenerateClientRefreshToken(clientID uint, email string, secret string, durationHours int) (string, error) {
+	claims := Claims{
+		ClientID:    clientID,
+		Email:       email,
+		TokenType:   "refresh",
+		TokenSource: "client",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Duration(durationHours) * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
 	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(secret))
 }
 


### PR DESCRIPTION
## Summary

- Extend `Claims` struct in `client-service` and `employee-service` `util/jwt.go` with `ClientID` and `TokenSource` fields
- Add `GenerateClientAccessToken` and `GenerateClientRefreshToken` to both services
- Update `client-service` `AuthInterceptor`: client JWTs allowed on `GetClient` and `UpdateClient` (requires `client.basic`); blocked from employee-only endpoints
- Update `employee-service` `AuthInterceptor`: reject all client JWTs with `PermissionDenied`
- Add `auth_interceptor_test.go` for both services (5 tests each, all passing)

Part of Sprint 2 scope (INFRA-BE-8).
