### PR TITLE
[ACCOUNT-BE-3] AccountService: kreiranje računa (tekući/devizni, lični/poslovni)

### DIFF
--- a/account-service/internal/models/filters.go
+++ b/account-service/internal/models/filters.go
@@ -1,0 +1,12 @@
+package models
+
+// AccountFilter holds optional filter/pagination parameters for account queries.
+type AccountFilter struct {
+	ClientName string
+	Tip        string
+	Vrsta      string
+	Status     string
+	CurrencyID *uint
+	Page       int
+	PageSize   int
+}

--- a/account-service/internal/repository/account_repo.go
+++ b/account-service/internal/repository/account_repo.go
@@ -1,0 +1,91 @@
+package repository
+
+import (
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/internal/models"
+	"gorm.io/gorm"
+)
+
+type AccountRepository struct {
+	db *gorm.DB
+}
+
+func NewAccountRepository(db *gorm.DB) *AccountRepository {
+	return &AccountRepository{db: db}
+}
+
+func (r *AccountRepository) Create(account *models.Account) error {
+	return r.db.Create(account).Error
+}
+
+func (r *AccountRepository) FindByID(id uint) (*models.Account, error) {
+	var account models.Account
+	if err := r.db.Preload("Currency").Preload("Client").Preload("Firma").First(&account, id).Error; err != nil {
+		return nil, err
+	}
+	return &account, nil
+}
+
+func (r *AccountRepository) FindByBrojRacuna(broj string) (*models.Account, error) {
+	var account models.Account
+	if err := r.db.Preload("Currency").Where("broj_racuna = ?", broj).First(&account).Error; err != nil {
+		return nil, err
+	}
+	return &account, nil
+}
+
+func (r *AccountRepository) ListByClientID(clientID uint) ([]models.Account, error) {
+	var accounts []models.Account
+	if err := r.db.Preload("Currency").Where("client_id = ?", clientID).Find(&accounts).Error; err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
+func (r *AccountRepository) ListAll(filter models.AccountFilter) ([]models.Account, int64, error) {
+	var accounts []models.Account
+	var total int64
+
+	query := r.db.Model(&models.Account{}).Preload("Currency").Preload("Client").Preload("Firma")
+
+	if filter.Tip != "" {
+		query = query.Where("tip = ?", filter.Tip)
+	}
+	if filter.Vrsta != "" {
+		query = query.Where("vrsta = ?", filter.Vrsta)
+	}
+	if filter.Status != "" {
+		query = query.Where("status = ?", filter.Status)
+	}
+	if filter.CurrencyID != nil {
+		query = query.Where("currency_id = ?", *filter.CurrencyID)
+	}
+	if filter.ClientName != "" {
+		query = query.Joins("JOIN clients ON clients.id = accounts.client_id").
+			Where("clients.ime ILIKE ? OR clients.prezime ILIKE ?",
+				"%"+filter.ClientName+"%", "%"+filter.ClientName+"%")
+	}
+
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	page := filter.Page
+	if page < 1 {
+		page = 1
+	}
+	pageSize := filter.PageSize
+	if pageSize < 1 {
+		pageSize = 10
+	}
+	offset := (page - 1) * pageSize
+
+	if err := query.Offset(offset).Limit(pageSize).Find(&accounts).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return accounts, total, nil
+}
+
+func (r *AccountRepository) UpdateFields(id uint, fields map[string]interface{}) error {
+	return r.db.Model(&models.Account{}).Where("id = ?", id).Updates(fields).Error
+}

--- a/account-service/internal/repository/currency_repo.go
+++ b/account-service/internal/repository/currency_repo.go
@@ -1,0 +1,38 @@
+package repository
+
+import (
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/internal/models"
+	"gorm.io/gorm"
+)
+
+type CurrencyRepository struct {
+	db *gorm.DB
+}
+
+func NewCurrencyRepository(db *gorm.DB) *CurrencyRepository {
+	return &CurrencyRepository{db: db}
+}
+
+func (r *CurrencyRepository) FindByID(id uint) (*models.Currency, error) {
+	var currency models.Currency
+	if err := r.db.First(&currency, id).Error; err != nil {
+		return nil, err
+	}
+	return &currency, nil
+}
+
+func (r *CurrencyRepository) FindByKod(kod string) (*models.Currency, error) {
+	var currency models.Currency
+	if err := r.db.Where("kod = ?", kod).First(&currency).Error; err != nil {
+		return nil, err
+	}
+	return &currency, nil
+}
+
+func (r *CurrencyRepository) FindAll() ([]models.Currency, error) {
+	var currencies []models.Currency
+	if err := r.db.Find(&currencies).Error; err != nil {
+		return nil, err
+	}
+	return currencies, nil
+}

--- a/account-service/internal/repository/interfaces.go
+++ b/account-service/internal/repository/interfaces.go
@@ -2,6 +2,21 @@ package repository
 
 import "github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/internal/models"
 
+type AccountRepositoryInterface interface {
+	Create(account *models.Account) error
+	FindByID(id uint) (*models.Account, error)
+	FindByBrojRacuna(broj string) (*models.Account, error)
+	ListByClientID(clientID uint) ([]models.Account, error)
+	ListAll(filter models.AccountFilter) ([]models.Account, int64, error)
+	UpdateFields(id uint, fields map[string]interface{}) error
+}
+
+type CurrencyRepositoryInterface interface {
+	FindByID(id uint) (*models.Currency, error)
+	FindByKod(kod string) (*models.Currency, error)
+	FindAll() ([]models.Currency, error)
+}
+
 type FirmaRepositoryInterface interface {
 	Create(firma *models.Firma) error
 	FindByID(id uint) (*models.Firma, error)
@@ -17,3 +32,5 @@ type SifraDelatnostiRepositoryInterface interface {
 // Compile-time interface compliance checks.
 var _ FirmaRepositoryInterface = (*FirmaRepository)(nil)
 var _ SifraDelatnostiRepositoryInterface = (*SifraDelatnostiRepository)(nil)
+var _ AccountRepositoryInterface = (*AccountRepository)(nil)
+var _ CurrencyRepositoryInterface = (*CurrencyRepository)(nil)

--- a/account-service/internal/service/account_service.go
+++ b/account-service/internal/service/account_service.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/internal/util"
+)
+
+// AccountRepositoryInterface is defined here to avoid circular imports with repository package.
+type AccountRepositoryInterface interface {
+	Create(account *models.Account) error
+	FindByID(id uint) (*models.Account, error)
+	FindByBrojRacuna(broj string) (*models.Account, error)
+	ListByClientID(clientID uint) ([]models.Account, error)
+	ListAll(filter models.AccountFilter) ([]models.Account, int64, error)
+	UpdateFields(id uint, fields map[string]interface{}) error
+}
+
+// CurrencyRepositoryInterface is defined here to avoid circular imports.
+type CurrencyRepositoryInterface interface {
+	FindByID(id uint) (*models.Currency, error)
+	FindByKod(kod string) (*models.Currency, error)
+	FindAll() ([]models.Currency, error)
+}
+
+type CreateAccountInput struct {
+	ClientID   *uint
+	FirmaID    *uint
+	CurrencyID uint
+	Tip        string
+	Vrsta      string
+	Naziv      string
+}
+
+type AccountService struct {
+	accountRepo  AccountRepositoryInterface
+	currencyRepo CurrencyRepositoryInterface
+}
+
+func NewAccountServiceWithRepos(accountRepo AccountRepositoryInterface, currencyRepo CurrencyRepositoryInterface) *AccountService {
+	return &AccountService{
+		accountRepo:  accountRepo,
+		currencyRepo: currencyRepo,
+	}
+}
+
+func (s *AccountService) CreateAccount(input CreateAccountInput) (*models.Account, error) {
+	if input.Tip != "tekuci" && input.Tip != "devizni" {
+		return nil, fmt.Errorf("invalid account type: %s (must be tekuci or devizni)", input.Tip)
+	}
+	if input.Vrsta != "licni" && input.Vrsta != "poslovni" {
+		return nil, fmt.Errorf("invalid account kind: %s (must be licni or poslovni)", input.Vrsta)
+	}
+	if input.Vrsta == "poslovni" && input.FirmaID == nil {
+		return nil, fmt.Errorf("poslovni account requires a firma")
+	}
+	if input.Tip == "devizni" {
+		currency, err := s.currencyRepo.FindByID(input.CurrencyID)
+		if err != nil {
+			return nil, fmt.Errorf("currency not found: %w", err)
+		}
+		if currency.Kod == "RSD" {
+			return nil, fmt.Errorf("devizni account cannot use RSD currency")
+		}
+	}
+
+	account := &models.Account{
+		BrojRacuna:        util.GenerateAccountNumber(),
+		ClientID:          input.ClientID,
+		FirmaID:           input.FirmaID,
+		CurrencyID:        input.CurrencyID,
+		Tip:               input.Tip,
+		Vrsta:             input.Vrsta,
+		Naziv:             input.Naziv,
+		Stanje:            0,
+		RaspolozivoStanje: 0,
+		DnevniLimit:       100000,
+		MesecniLimit:      1000000,
+		Status:            "aktivan",
+	}
+
+	if err := s.accountRepo.Create(account); err != nil {
+		return nil, err
+	}
+	return account, nil
+}

--- a/account-service/internal/service/account_service_test.go
+++ b/account-service/internal/service/account_service_test.go
@@ -1,0 +1,156 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/internal/service"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/internal/util"
+)
+
+// --- mocks ---
+
+type mockAccountRepo struct {
+	created *models.Account
+	err     error
+}
+
+func (m *mockAccountRepo) Create(a *models.Account) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.created = a
+	return nil
+}
+func (m *mockAccountRepo) FindByID(_ uint) (*models.Account, error) { return nil, nil }
+func (m *mockAccountRepo) FindByBrojRacuna(_ string) (*models.Account, error) {
+	return nil, nil
+}
+func (m *mockAccountRepo) ListByClientID(_ uint) ([]models.Account, error) { return nil, nil }
+func (m *mockAccountRepo) ListAll(_ models.AccountFilter) ([]models.Account, int64, error) {
+	return nil, 0, nil
+}
+func (m *mockAccountRepo) UpdateFields(_ uint, _ map[string]interface{}) error { return nil }
+
+type mockCurrencyRepo struct {
+	currency *models.Currency
+	err      error
+}
+
+func (m *mockCurrencyRepo) FindByID(_ uint) (*models.Currency, error) {
+	return m.currency, m.err
+}
+func (m *mockCurrencyRepo) FindByKod(_ string) (*models.Currency, error) { return nil, nil }
+func (m *mockCurrencyRepo) FindAll() ([]models.Currency, error)          { return nil, nil }
+
+func ptr(u uint) *uint { return &u }
+
+// --- tests ---
+
+func TestCreateAccount_TekuciLicni_Success(t *testing.T) {
+	svc := service.NewAccountServiceWithRepos(&mockAccountRepo{}, &mockCurrencyRepo{})
+
+	acc, err := svc.CreateAccount(service.CreateAccountInput{
+		ClientID:   ptr(1),
+		CurrencyID: 1,
+		Tip:        "tekuci",
+		Vrsta:      "licni",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if acc == nil {
+		t.Fatal("expected non-nil account")
+	}
+}
+
+func TestCreateAccount_DevizniLicni_NonRSD_Success(t *testing.T) {
+	currencyRepo := &mockCurrencyRepo{currency: &models.Currency{ID: 2, Kod: "EUR"}}
+	svc := service.NewAccountServiceWithRepos(&mockAccountRepo{}, currencyRepo)
+
+	acc, err := svc.CreateAccount(service.CreateAccountInput{
+		ClientID:   ptr(1),
+		CurrencyID: 2,
+		Tip:        "devizni",
+		Vrsta:      "licni",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if acc == nil {
+		t.Fatal("expected non-nil account")
+	}
+}
+
+func TestCreateAccount_DevizniWithRSD_ReturnsError(t *testing.T) {
+	currencyRepo := &mockCurrencyRepo{currency: &models.Currency{ID: 1, Kod: "RSD"}}
+	svc := service.NewAccountServiceWithRepos(&mockAccountRepo{}, currencyRepo)
+
+	_, err := svc.CreateAccount(service.CreateAccountInput{
+		ClientID:   ptr(1),
+		CurrencyID: 1,
+		Tip:        "devizni",
+		Vrsta:      "licni",
+	})
+	if err == nil {
+		t.Fatal("expected error for devizni+RSD, got nil")
+	}
+}
+
+func TestCreateAccount_PoslovniWithoutFirma_ReturnsError(t *testing.T) {
+	svc := service.NewAccountServiceWithRepos(&mockAccountRepo{}, &mockCurrencyRepo{})
+
+	_, err := svc.CreateAccount(service.CreateAccountInput{
+		ClientID:   ptr(1),
+		CurrencyID: 1,
+		Tip:        "tekuci",
+		Vrsta:      "poslovni",
+		FirmaID:    nil,
+	})
+	if err == nil {
+		t.Fatal("expected error for poslovni without firmaID, got nil")
+	}
+}
+
+func TestCreateAccount_GeneratesValid18DigitBrojRacuna(t *testing.T) {
+	svc := service.NewAccountServiceWithRepos(&mockAccountRepo{}, &mockCurrencyRepo{})
+
+	acc, err := svc.CreateAccount(service.CreateAccountInput{
+		ClientID:   ptr(1),
+		CurrencyID: 1,
+		Tip:        "tekuci",
+		Vrsta:      "licni",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(acc.BrojRacuna) != 18 {
+		t.Errorf("expected 18-digit BrojRacuna, got length %d: %s", len(acc.BrojRacuna), acc.BrojRacuna)
+	}
+	if !util.ValidateAccountNumber(acc.BrojRacuna) {
+		t.Errorf("generated BrojRacuna failed validation: %s", acc.BrojRacuna)
+	}
+}
+
+func TestCreateAccount_SetsDefaultLimits(t *testing.T) {
+	svc := service.NewAccountServiceWithRepos(&mockAccountRepo{}, &mockCurrencyRepo{})
+
+	acc, err := svc.CreateAccount(service.CreateAccountInput{
+		ClientID:   ptr(1),
+		CurrencyID: 1,
+		Tip:        "tekuci",
+		Vrsta:      "licni",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if acc.DnevniLimit != 100000 {
+		t.Errorf("expected DnevniLimit=100000, got %v", acc.DnevniLimit)
+	}
+	if acc.MesecniLimit != 1000000 {
+		t.Errorf("expected MesecniLimit=1000000, got %v", acc.MesecniLimit)
+	}
+	if acc.Status != "aktivan" {
+		t.Errorf("expected Status=aktivan, got %s", acc.Status)
+	}
+}

--- a/account-service/internal/util/account_number.go
+++ b/account-service/internal/util/account_number.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+)
+
+const BankCode = "000"
+
+// GenerateAccountNumber generates a random valid 18-digit account number.
+// Format: BBB (3-digit bank code) + CCCCCCCCCCCCCC (13-digit account) + KK (2-digit check digits).
+// Check digits satisfy: full_number mod 97 == 1 (ISO 7064 MOD 97-10).
+func GenerateAccountNumber() string {
+	accountPart := fmt.Sprintf("%013d", rand.Int63n(9_000_000_000_000)+1_000_000_000_000)
+	base := BankCode + accountPart
+	return base + checkDigits(base)
+}
+
+// ValidateAccountNumber returns true if the number is a valid 18-digit account number.
+func ValidateAccountNumber(number string) bool {
+	if len(number) != 18 {
+		return false
+	}
+	for _, c := range number {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	n, err := strconv.ParseUint(number, 10, 64)
+	if err != nil {
+		return false
+	}
+	return n%97 == 1
+}
+
+func checkDigits(base string) string {
+	n, _ := strconv.ParseUint(base+"00", 10, 64)
+	kk := 98 - n%97
+	return fmt.Sprintf("%02d", kk)
+}


### PR DESCRIPTION
Implements `CreateAccount` service with full business rule validation:
- Validates `tip` (tekuci/devizni) and `vrsta` (licni/poslovni)
- Poslovni accounts require `firmaID`
- Devizni accounts reject RSD currency
- Generates valid 18-digit ISO 7064 MOD 97-10 account numbers
- Sets default limits: DnevniLimit=100000, MesecniLimit=1000000
- Adds `AccountRepository`, `CurrencyRepository`, and `AccountFilter` model
- 6 unit tests all passing

Fixes #31