### PR TITLE
feat(PAYMENTS-BE-2): PaymentService CreatePayment + VerifyPayment

### DIFF
--- a/payment-service/internal/repository/account_repo.go
+++ b/payment-service/internal/repository/account_repo.go
@@ -1,0 +1,26 @@
+package repository
+
+import (
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/internal/models"
+	"gorm.io/gorm"
+)
+
+type AccountRepository struct {
+	db *gorm.DB
+}
+
+func NewAccountRepository(db *gorm.DB) *AccountRepository {
+	return &AccountRepository{db: db}
+}
+
+func (r *AccountRepository) FindByID(id uint) (*models.Account, error) {
+	var account models.Account
+	if err := r.db.First(&account, id).Error; err != nil {
+		return nil, err
+	}
+	return &account, nil
+}
+
+func (r *AccountRepository) UpdateFields(id uint, fields map[string]interface{}) error {
+	return r.db.Model(&models.Account{}).Where("id = ?", id).Updates(fields).Error
+}

--- a/payment-service/internal/repository/interfaces.go
+++ b/payment-service/internal/repository/interfaces.go
@@ -10,5 +10,20 @@ type PaymentRecipientRepositoryInterface interface {
 	Delete(id uint) error
 }
 
-// Compile-time interface compliance check.
+type AccountRepositoryInterface interface {
+	FindByID(id uint) (*models.Account, error)
+	UpdateFields(id uint, fields map[string]interface{}) error
+}
+
+type PaymentRepositoryInterface interface {
+	Create(p *models.Payment) error
+	FindByID(id uint) (*models.Payment, error)
+	Save(p *models.Payment) error
+	ListByAccountID(accountID uint, filter models.PaymentFilter) ([]models.Payment, int64, error)
+	ListByClientID(clientID uint, filter models.PaymentFilter) ([]models.Payment, int64, error)
+}
+
+// Compile-time interface compliance checks.
 var _ PaymentRecipientRepositoryInterface = (*PaymentRecipientRepository)(nil)
+var _ AccountRepositoryInterface = (*AccountRepository)(nil)
+var _ PaymentRepositoryInterface = (*PaymentRepository)(nil)

--- a/payment-service/internal/repository/payment_repo.go
+++ b/payment-service/internal/repository/payment_repo.go
@@ -1,0 +1,94 @@
+package repository
+
+import (
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/internal/models"
+	"gorm.io/gorm"
+)
+
+type PaymentRepository struct {
+	db *gorm.DB
+}
+
+func NewPaymentRepository(db *gorm.DB) *PaymentRepository {
+	return &PaymentRepository{db: db}
+}
+
+func (r *PaymentRepository) Create(p *models.Payment) error {
+	return r.db.Create(p).Error
+}
+
+func (r *PaymentRepository) FindByID(id uint) (*models.Payment, error) {
+	var p models.Payment
+	if err := r.db.First(&p, id).Error; err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (r *PaymentRepository) Save(p *models.Payment) error {
+	return r.db.Save(p).Error
+}
+
+func (r *PaymentRepository) ListByAccountID(accountID uint, filter models.PaymentFilter) ([]models.Payment, int64, error) {
+	query := r.db.Model(&models.Payment{}).Where("racun_posiljaoca_id = ?", accountID)
+	query = applyPaymentFilters(query, filter)
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	query = applyPagination(query, filter.Page, filter.PageSize)
+	var payments []models.Payment
+	if err := query.Find(&payments).Error; err != nil {
+		return nil, 0, err
+	}
+	return payments, total, nil
+}
+
+func (r *PaymentRepository) ListByClientID(clientID uint, filter models.PaymentFilter) ([]models.Payment, int64, error) {
+	subQuery := r.db.Model(&models.Account{}).Select("id").Where("client_id = ?", clientID)
+	query := r.db.Model(&models.Payment{}).Where("racun_posiljaoca_id IN (?)", subQuery)
+	query = applyPaymentFilters(query, filter)
+
+	var total int64
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	query = applyPagination(query, filter.Page, filter.PageSize)
+	var payments []models.Payment
+	if err := query.Find(&payments).Error; err != nil {
+		return nil, 0, err
+	}
+	return payments, total, nil
+}
+
+func applyPaymentFilters(query *gorm.DB, filter models.PaymentFilter) *gorm.DB {
+	if filter.Status != "" {
+		query = query.Where("status = ?", filter.Status)
+	}
+	if filter.DateFrom != nil {
+		query = query.Where("vreme_transakcije >= ?", filter.DateFrom)
+	}
+	if filter.DateTo != nil {
+		query = query.Where("vreme_transakcije <= ?", filter.DateTo)
+	}
+	if filter.MinAmount != nil {
+		query = query.Where("iznos >= ?", *filter.MinAmount)
+	}
+	if filter.MaxAmount != nil {
+		query = query.Where("iznos <= ?", *filter.MaxAmount)
+	}
+	return query
+}
+
+func applyPagination(query *gorm.DB, page, pageSize int) *gorm.DB {
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	if page <= 0 {
+		page = 1
+	}
+	return query.Offset((page - 1) * pageSize).Limit(pageSize)
+}

--- a/payment-service/internal/service/payment_service.go
+++ b/payment-service/internal/service/payment_service.go
@@ -1,0 +1,144 @@
+package service
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/internal/models"
+)
+
+// Repository interfaces defined here to avoid circular imports.
+
+type PaymentAccountRepositoryInterface interface {
+	FindByID(id uint) (*models.Account, error)
+	UpdateFields(id uint, fields map[string]interface{}) error
+}
+
+type PaymentRepositoryInterface interface {
+	Create(p *models.Payment) error
+	FindByID(id uint) (*models.Payment, error)
+	Save(p *models.Payment) error
+	ListByAccountID(accountID uint, filter models.PaymentFilter) ([]models.Payment, int64, error)
+	ListByClientID(clientID uint, filter models.PaymentFilter) ([]models.Payment, int64, error)
+}
+
+type RecipientRepositoryInterface interface {
+	Create(r *models.PaymentRecipient) error
+}
+
+type CreatePaymentInput struct {
+	RacunPosiljaocaID uint
+	RacunPrimaocaBroj string
+	Iznos             float64
+	SifraPlacanja     string
+	PozivNaBroj       string
+	Svrha             string
+	RecipientID       *uint
+	// If set, creates a new saved recipient during payment
+	AddRecipient      bool
+	RecipientNaziv    string
+}
+
+type PaymentService struct {
+	accountRepo   PaymentAccountRepositoryInterface
+	paymentRepo   PaymentRepositoryInterface
+	recipientRepo RecipientRepositoryInterface
+}
+
+func NewPaymentServiceWithRepos(
+	accountRepo PaymentAccountRepositoryInterface,
+	paymentRepo PaymentRepositoryInterface,
+	recipientRepo RecipientRepositoryInterface,
+) *PaymentService {
+	return &PaymentService{
+		accountRepo:   accountRepo,
+		paymentRepo:   paymentRepo,
+		recipientRepo: recipientRepo,
+	}
+}
+
+func (s *PaymentService) CreatePayment(input CreatePaymentInput) (*models.Payment, error) {
+	if input.Iznos <= 0 {
+		return nil, fmt.Errorf("payment amount must be positive")
+	}
+
+	sender, err := s.accountRepo.FindByID(input.RacunPosiljaocaID)
+	if err != nil {
+		return nil, fmt.Errorf("sender account not found: %w", err)
+	}
+
+	if sender.RaspolozivoStanje < input.Iznos {
+		return nil, fmt.Errorf("insufficient balance: available %.2f, requested %.2f",
+			sender.RaspolozivoStanje, input.Iznos)
+	}
+
+	code := fmt.Sprintf("%06d", rand.Intn(1_000_000))
+
+	// Optionally save the receiver as a recipient
+	if input.AddRecipient && s.recipientRepo != nil && sender.ClientID != nil {
+		recipient := &models.PaymentRecipient{
+			ClientID:   *sender.ClientID,
+			Naziv:      input.RecipientNaziv,
+			BrojRacuna: input.RacunPrimaocaBroj,
+		}
+		_ = s.recipientRepo.Create(recipient)
+		if recipient.ID != 0 {
+			input.RecipientID = &recipient.ID
+		}
+	}
+
+	payment := &models.Payment{
+		RacunPosiljaocaID: input.RacunPosiljaocaID,
+		RacunPrimaocaBroj: input.RacunPrimaocaBroj,
+		Iznos:             input.Iznos,
+		SifraPlacanja:     input.SifraPlacanja,
+		PozivNaBroj:       input.PozivNaBroj,
+		Svrha:             input.Svrha,
+		Status:            "u_obradi",
+		VerifikacioniKod:  code,
+		RecipientID:       input.RecipientID,
+		VremeTransakcije:  time.Now(),
+	}
+
+	if err := s.paymentRepo.Create(payment); err != nil {
+		return nil, fmt.Errorf("failed to create payment: %w", err)
+	}
+
+	return payment, nil
+}
+
+func (s *PaymentService) VerifyPayment(paymentID uint, verificationCode string) (*models.Payment, error) {
+	payment, err := s.paymentRepo.FindByID(paymentID)
+	if err != nil {
+		return nil, fmt.Errorf("payment not found: %w", err)
+	}
+
+	if payment.Status != "u_obradi" {
+		return nil, fmt.Errorf("payment is not pending: status=%s", payment.Status)
+	}
+
+	if payment.VerifikacioniKod != verificationCode {
+		return nil, fmt.Errorf("invalid verification code")
+	}
+
+	// Deduct amount from sender
+	sender, err := s.accountRepo.FindByID(payment.RacunPosiljaocaID)
+	if err != nil {
+		return nil, fmt.Errorf("sender account not found: %w", err)
+	}
+
+	if err := s.accountRepo.UpdateFields(sender.ID, map[string]interface{}{
+		"stanje":             sender.Stanje - payment.Iznos,
+		"raspolozivo_stanje": sender.RaspolozivoStanje - payment.Iznos,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to deduct balance: %w", err)
+	}
+
+	payment.Status = "uspesno"
+	if err := s.paymentRepo.Save(payment); err != nil {
+		return nil, fmt.Errorf("failed to update payment status: %w", err)
+	}
+
+	return payment, nil
+}

--- a/payment-service/internal/service/payment_service_test.go
+++ b/payment-service/internal/service/payment_service_test.go
@@ -1,0 +1,273 @@
+package service_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/internal/service"
+)
+
+// --- mocks ---
+
+type mockAccountRepo struct {
+	accounts      map[uint]*models.Account
+	updatedID     uint
+	updatedFields map[string]interface{}
+	findErr       error
+}
+
+func (m *mockAccountRepo) FindByID(id uint) (*models.Account, error) {
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+	if a, ok := m.accounts[id]; ok {
+		return a, nil
+	}
+	return nil, errors.New("account not found")
+}
+
+func (m *mockAccountRepo) UpdateFields(id uint, fields map[string]interface{}) error {
+	m.updatedID = id
+	m.updatedFields = fields
+	return nil
+}
+
+type mockPaymentRepo struct {
+	created   *models.Payment
+	saved     *models.Payment
+	findByID  map[uint]*models.Payment
+	nextID    uint
+	createErr error
+	saveErr   error
+	findErr   error
+}
+
+func newMockPaymentRepo() *mockPaymentRepo {
+	return &mockPaymentRepo{findByID: make(map[uint]*models.Payment), nextID: 1}
+}
+
+func (m *mockPaymentRepo) Create(p *models.Payment) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	p.ID = m.nextID
+	m.nextID++
+	m.created = p
+	m.findByID[p.ID] = p
+	return nil
+}
+
+func (m *mockPaymentRepo) FindByID(id uint) (*models.Payment, error) {
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+	if p, ok := m.findByID[id]; ok {
+		return p, nil
+	}
+	return nil, errors.New("payment not found")
+}
+
+func (m *mockPaymentRepo) Save(p *models.Payment) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.saved = p
+	m.findByID[p.ID] = p
+	return nil
+}
+
+func (m *mockPaymentRepo) ListByAccountID(accountID uint, filter models.PaymentFilter) ([]models.Payment, int64, error) {
+	return nil, 0, nil
+}
+
+func (m *mockPaymentRepo) ListByClientID(clientID uint, filter models.PaymentFilter) ([]models.Payment, int64, error) {
+	return nil, 0, nil
+}
+
+type mockNewRecipientRepo struct {
+	created *models.PaymentRecipient
+	nextID  uint
+}
+
+func (m *mockNewRecipientRepo) Create(r *models.PaymentRecipient) error {
+	m.nextID++
+	r.ID = m.nextID
+	m.created = r
+	return nil
+}
+
+func rsdAccount(id uint, balance float64, clientID *uint) *models.Account {
+	return &models.Account{
+		ID: id, RaspolozivoStanje: balance, Stanje: balance,
+		DnevniLimit: 100000, ClientID: clientID,
+	}
+}
+
+// --- tests ---
+
+func TestCreatePayment_Success_StatusUObradi(t *testing.T) {
+	accountRepo := &mockAccountRepo{accounts: map[uint]*models.Account{
+		1: rsdAccount(1, 5000, nil),
+	}}
+	paymentRepo := newMockPaymentRepo()
+	svc := service.NewPaymentServiceWithRepos(accountRepo, paymentRepo, nil)
+
+	p, err := svc.CreatePayment(service.CreatePaymentInput{
+		RacunPosiljaocaID: 1,
+		RacunPrimaocaBroj: "000000000000000098",
+		Iznos:             500,
+		Svrha:             "Test",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Status != "u_obradi" {
+		t.Errorf("expected status=u_obradi, got %s", p.Status)
+	}
+}
+
+func TestCreatePayment_GeneratesSixDigitCode(t *testing.T) {
+	accountRepo := &mockAccountRepo{accounts: map[uint]*models.Account{
+		1: rsdAccount(1, 5000, nil),
+	}}
+	paymentRepo := newMockPaymentRepo()
+	svc := service.NewPaymentServiceWithRepos(accountRepo, paymentRepo, nil)
+
+	p, err := svc.CreatePayment(service.CreatePaymentInput{
+		RacunPosiljaocaID: 1,
+		RacunPrimaocaBroj: "000000000000000098",
+		Iznos:             100,
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(p.VerifikacioniKod) != 6 {
+		t.Errorf("expected 6-digit code, got %q (len=%d)", p.VerifikacioniKod, len(p.VerifikacioniKod))
+	}
+	for _, c := range p.VerifikacioniKod {
+		if c < '0' || c > '9' {
+			t.Errorf("code contains non-digit character: %q", p.VerifikacioniKod)
+			break
+		}
+	}
+}
+
+func TestCreatePayment_InsufficientBalance_ReturnsError(t *testing.T) {
+	accountRepo := &mockAccountRepo{accounts: map[uint]*models.Account{
+		1: rsdAccount(1, 100, nil),
+	}}
+	svc := service.NewPaymentServiceWithRepos(accountRepo, newMockPaymentRepo(), nil)
+
+	_, err := svc.CreatePayment(service.CreatePaymentInput{
+		RacunPosiljaocaID: 1,
+		RacunPrimaocaBroj: "000000000000000098",
+		Iznos:             500,
+	})
+
+	if err == nil {
+		t.Fatal("expected insufficient balance error, got nil")
+	}
+}
+
+func TestVerifyPayment_CorrectCode_SetsStatusUspesno(t *testing.T) {
+	accountRepo := &mockAccountRepo{accounts: map[uint]*models.Account{
+		1: rsdAccount(1, 5000, nil),
+	}}
+	paymentRepo := newMockPaymentRepo()
+	svc := service.NewPaymentServiceWithRepos(accountRepo, paymentRepo, nil)
+
+	created, _ := svc.CreatePayment(service.CreatePaymentInput{
+		RacunPosiljaocaID: 1,
+		RacunPrimaocaBroj: "000000000000000098",
+		Iznos:             200,
+	})
+
+	verified, err := svc.VerifyPayment(created.ID, created.VerifikacioniKod)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if verified.Status != "uspesno" {
+		t.Errorf("expected status=uspesno, got %s", verified.Status)
+	}
+}
+
+func TestVerifyPayment_WrongCode_ReturnsError(t *testing.T) {
+	accountRepo := &mockAccountRepo{accounts: map[uint]*models.Account{
+		1: rsdAccount(1, 5000, nil),
+	}}
+	paymentRepo := newMockPaymentRepo()
+	svc := service.NewPaymentServiceWithRepos(accountRepo, paymentRepo, nil)
+
+	created, _ := svc.CreatePayment(service.CreatePaymentInput{
+		RacunPosiljaocaID: 1,
+		RacunPrimaocaBroj: "000000000000000098",
+		Iznos:             200,
+	})
+
+	_, err := svc.VerifyPayment(created.ID, "000000")
+
+	if err == nil {
+		t.Fatal("expected wrong code error, got nil")
+	}
+}
+
+func TestVerifyPayment_DeductsSenderBalance(t *testing.T) {
+	accountRepo := &mockAccountRepo{accounts: map[uint]*models.Account{
+		1: rsdAccount(1, 5000, nil),
+	}}
+	paymentRepo := newMockPaymentRepo()
+	svc := service.NewPaymentServiceWithRepos(accountRepo, paymentRepo, nil)
+
+	created, _ := svc.CreatePayment(service.CreatePaymentInput{
+		RacunPosiljaocaID: 1,
+		RacunPrimaocaBroj: "000000000000000098",
+		Iznos:             300,
+	})
+	svc.VerifyPayment(created.ID, created.VerifikacioniKod)
+
+	if accountRepo.updatedID != 1 {
+		t.Errorf("expected account 1 to be updated, got %d", accountRepo.updatedID)
+	}
+	newBalance, ok := accountRepo.updatedFields["raspolozivo_stanje"].(float64)
+	if !ok {
+		t.Fatal("raspolozivo_stanje not updated")
+	}
+	if newBalance != 4700 {
+		t.Errorf("expected new balance=4700, got %f", newBalance)
+	}
+}
+
+func TestCreatePayment_WithAddRecipient_CreatesRecipient(t *testing.T) {
+	clientID := uint(7)
+	accountRepo := &mockAccountRepo{accounts: map[uint]*models.Account{
+		1: rsdAccount(1, 5000, &clientID),
+	}}
+	paymentRepo := newMockPaymentRepo()
+	recipientRepo := &mockNewRecipientRepo{}
+	svc := service.NewPaymentServiceWithRepos(accountRepo, paymentRepo, recipientRepo)
+
+	_, err := svc.CreatePayment(service.CreatePaymentInput{
+		RacunPosiljaocaID: 1,
+		RacunPrimaocaBroj: "000000000000000098",
+		Iznos:             100,
+		AddRecipient:      true,
+		RecipientNaziv:    "Novi Primalac",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if recipientRepo.created == nil {
+		t.Fatal("expected recipient to be created, got nil")
+	}
+	if recipientRepo.created.ClientID != clientID {
+		t.Errorf("expected recipient ClientID=%d, got %d", clientID, recipientRepo.created.ClientID)
+	}
+	if recipientRepo.created.Naziv != "Novi Primalac" {
+		t.Errorf("expected recipient Naziv=Novi Primalac, got %s", recipientRepo.created.Naziv)
+	}
+}


### PR DESCRIPTION
## Summary
- Added `AccountRepository` and `PaymentRepository` with full interface compliance checks
- `PaymentService.CreatePayment`: validates balance, generates 6-digit verification code, sets status=u_obradi
- `PaymentService.VerifyPayment`: validates code, deducts sender balance, sets status=uspesno
- Optional `AddRecipient` flag saves receiver as saved recipient during payment
- 7 unit tests — all GREEN

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)