### PR TITLE
feat(EXCHANGE-BE-1): scaffold exchange-service + ExchangeService GetRateList/CalculateExchange - Fixes #41

### DIFF
--- a/exchange-service/Dockerfile
+++ b/exchange-service/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -buildvcs=false -o /exchange-service ./cmd/server
+
+FROM alpine:3.19
+RUN apk --no-cache add ca-certificates tzdata
+WORKDIR /app
+COPY --from=builder /exchange-service .
+EXPOSE 8088 9098
+CMD ["./exchange-service"]

--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
+)
+
+func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
+
+	cfg := config.Load()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", healthCheck)
+
+	httpServer := &http.Server{
+		Addr:    ":" + cfg.HTTPPort,
+		Handler: mux,
+	}
+
+	go func() {
+		slog.Info("Exchange service listening", "port", cfg.HTTPPort)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("HTTP server error", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+
+	slog.Info("Shutting down exchange-service gracefully")
+	if err := httpServer.Shutdown(context.Background()); err != nil {
+		slog.Error("HTTP shutdown error", "error", err)
+	}
+	slog.Info("exchange-service stopped")
+}
+
+func healthCheck(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, `{"status":"ok","service":"exchange-service"}`)
+}

--- a/exchange-service/go.mod
+++ b/exchange-service/go.mod
@@ -1,0 +1,5 @@
+module github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service
+
+go 1.26
+
+require github.com/joho/godotenv v1.5.1

--- a/exchange-service/go.sum
+++ b/exchange-service/go.sum
@@ -1,0 +1,2 @@
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=

--- a/exchange-service/internal/config/config.go
+++ b/exchange-service/internal/config/config.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/joho/godotenv"
+)
+
+type Config struct {
+	GRPCPort  string
+	HTTPPort  string
+	JWTSecret string
+}
+
+func Load() *Config {
+	_ = godotenv.Load()
+
+	cfg := &Config{
+		GRPCPort:  getEnv("GRPC_PORT", "9098"),
+		HTTPPort:  getEnv("HTTP_PORT", "8088"),
+		JWTSecret: getEnv("JWT_SECRET", "super-secret-jwt-key-change-in-production"),
+	}
+
+	slog.Info("Exchange-service config loaded",
+		"http_port", cfg.HTTPPort,
+		"grpc_port", cfg.GRPCPort,
+	)
+
+	return cfg
+}
+
+func getEnv(key, defaultVal string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+	return defaultVal
+}

--- a/exchange-service/internal/service/exchange_service.go
+++ b/exchange-service/internal/service/exchange_service.go
@@ -1,0 +1,61 @@
+package service
+
+import "fmt"
+
+// ExchangeRate represents a single currency pair with its rate.
+type ExchangeRate struct {
+	From string
+	To   string
+	Rate float64
+}
+
+// ExchangeResult holds the outcome of a currency conversion calculation.
+type ExchangeResult struct {
+	FromCurrency string
+	ToCurrency   string
+	InputAmount  float64
+	OutputAmount float64
+	Rate         float64
+}
+
+// RateProviderInterface allows mocking the underlying rate source in tests.
+type RateProviderInterface interface {
+	GetRate(from, to string) (float64, error)
+	GetAllRates() []ExchangeRate
+}
+
+type ExchangeService struct {
+	provider RateProviderInterface
+}
+
+func NewExchangeServiceWithProvider(provider RateProviderInterface) *ExchangeService {
+	return &ExchangeService{provider: provider}
+}
+
+// GetRateList returns all available currency pair exchange rates.
+func (s *ExchangeService) GetRateList() []ExchangeRate {
+	return s.provider.GetAllRates()
+}
+
+// CalculateExchange converts amount from one currency to another.
+func (s *ExchangeService) CalculateExchange(fromCurrency, toCurrency string, amount float64) (*ExchangeResult, error) {
+	if amount <= 0 {
+		return nil, fmt.Errorf("amount must be positive")
+	}
+	if fromCurrency == "" || toCurrency == "" {
+		return nil, fmt.Errorf("currency codes are required")
+	}
+
+	rate, err := s.provider.GetRate(fromCurrency, toCurrency)
+	if err != nil {
+		return nil, fmt.Errorf("exchange rate not available for %s→%s: %w", fromCurrency, toCurrency, err)
+	}
+
+	return &ExchangeResult{
+		FromCurrency: fromCurrency,
+		ToCurrency:   toCurrency,
+		InputAmount:  amount,
+		OutputAmount: amount * rate,
+		Rate:         rate,
+	}, nil
+}

--- a/exchange-service/internal/service/exchange_service_test.go
+++ b/exchange-service/internal/service/exchange_service_test.go
@@ -1,0 +1,150 @@
+package service_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+// --- mock rate provider ---
+
+type mockRateProvider struct {
+	rates    map[string]map[string]float64
+	allRates []service.ExchangeRate
+	fetchErr error
+}
+
+func (m *mockRateProvider) GetRate(from, to string) (float64, error) {
+	if m.fetchErr != nil {
+		return 0, m.fetchErr
+	}
+	if from == to {
+		return 1.0, nil
+	}
+	if r, ok := m.rates[from]; ok {
+		if rate, ok := r[to]; ok {
+			return rate, nil
+		}
+	}
+	return 0, errors.New("unknown currency pair")
+}
+
+func (m *mockRateProvider) GetAllRates() []service.ExchangeRate {
+	return m.allRates
+}
+
+func newMockProvider() *mockRateProvider {
+	return &mockRateProvider{
+		rates: map[string]map[string]float64{
+			"EUR": {"RSD": 117.0, "USD": 1.08, "CHF": 0.96},
+			"USD": {"EUR": 0.926, "RSD": 108.33},
+			"RSD": {"EUR": 0.00855, "USD": 0.00923},
+		},
+		allRates: []service.ExchangeRate{
+			{From: "EUR", To: "RSD", Rate: 117.0},
+			{From: "EUR", To: "USD", Rate: 1.08},
+			{From: "USD", To: "EUR", Rate: 0.926},
+			{From: "RSD", To: "EUR", Rate: 0.00855},
+		},
+	}
+}
+
+// --- tests ---
+
+func TestGetRateList_ReturnsNonEmptyList(t *testing.T) {
+	svc := service.NewExchangeServiceWithProvider(newMockProvider())
+
+	rates := svc.GetRateList()
+
+	if len(rates) == 0 {
+		t.Fatal("expected non-empty rate list, got empty")
+	}
+}
+
+func TestGetRateList_ContainsCurrencyPairs(t *testing.T) {
+	svc := service.NewExchangeServiceWithProvider(newMockProvider())
+
+	rates := svc.GetRateList()
+
+	found := false
+	for _, r := range rates {
+		if r.From == "EUR" && r.To == "RSD" {
+			found = true
+			if r.Rate != 117.0 {
+				t.Errorf("expected EUR→RSD rate=117.0, got %f", r.Rate)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected EUR→RSD pair in rate list")
+	}
+}
+
+func TestCalculateExchange_EURtoRSD_CorrectConversion(t *testing.T) {
+	svc := service.NewExchangeServiceWithProvider(newMockProvider())
+
+	result, err := svc.CalculateExchange("EUR", "RSD", 100)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.OutputAmount != 11700 {
+		t.Errorf("expected 11700 RSD, got %f", result.OutputAmount)
+	}
+	if result.Rate != 117.0 {
+		t.Errorf("expected rate=117.0, got %f", result.Rate)
+	}
+	if result.FromCurrency != "EUR" || result.ToCurrency != "RSD" {
+		t.Errorf("unexpected currencies: %s→%s", result.FromCurrency, result.ToCurrency)
+	}
+}
+
+func TestCalculateExchange_SameCurrency_ReturnsSameAmount(t *testing.T) {
+	svc := service.NewExchangeServiceWithProvider(newMockProvider())
+
+	result, err := svc.CalculateExchange("EUR", "EUR", 250)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.OutputAmount != 250 {
+		t.Errorf("expected same amount 250, got %f", result.OutputAmount)
+	}
+	if result.Rate != 1.0 {
+		t.Errorf("expected rate=1.0 for same currency, got %f", result.Rate)
+	}
+}
+
+func TestCalculateExchange_InvalidCurrency_ReturnsError(t *testing.T) {
+	svc := service.NewExchangeServiceWithProvider(newMockProvider())
+
+	_, err := svc.CalculateExchange("EUR", "XYZ", 100)
+
+	if err == nil {
+		t.Fatal("expected error for unknown currency, got nil")
+	}
+}
+
+func TestCalculateExchange_NegativeAmount_ReturnsError(t *testing.T) {
+	svc := service.NewExchangeServiceWithProvider(newMockProvider())
+
+	_, err := svc.CalculateExchange("EUR", "RSD", -50)
+
+	if err == nil {
+		t.Fatal("expected error for negative amount, got nil")
+	}
+}
+
+func TestCalculateExchange_ProviderError_ReturnsError(t *testing.T) {
+	provider := newMockProvider()
+	provider.fetchErr = errors.New("API unavailable")
+	svc := service.NewExchangeServiceWithProvider(provider)
+
+	_, err := svc.CalculateExchange("EUR", "USD", 100)
+
+	if err == nil {
+		t.Fatal("expected error when provider fails, got nil")
+	}
+}


### PR DESCRIPTION
Implements Issue #29 (EXCHANGE-BE-1/GH#41):

- Scaffold exchange-service (ports 8088/9098, no DB — read-only)
- `ExchangeRate`, `ExchangeResult`, `RateProviderInterface` types
- `ExchangeService.GetRateList()` and `CalculateExchange(from, to, amount)`
- 6 unit tests with mock provider (all GREEN)
- Dockerfile exposing 8088/9098

Fixes #41