### PR TITLE
feat: client auth, currency seed, payment seed, exchange integration,…

### DIFF
--- a/account-service/cmd/server/main.go
+++ b/account-service/cmd/server/main.go
@@ -35,6 +35,10 @@ func main() {
 		slog.Error("DB migration failed", "error", err)
 		os.Exit(1)
 	}
+	if err := database.SeedCurrencies(db); err != nil {
+		slog.Error("Currency seed failed", "error", err)
+		os.Exit(1)
+	}
 
 	accountH := handler.NewAccountHandler(db)
 

--- a/account-service/internal/database/seed.go
+++ b/account-service/internal/database/seed.go
@@ -1,0 +1,35 @@
+package database
+
+import (
+	"log/slog"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/internal/models"
+	"gorm.io/gorm"
+)
+
+func SeedCurrencies(db *gorm.DB) error {
+	currencies := []models.Currency{
+		{Kod: "RSD", Naziv: "Srpski dinar", Simbol: "RSD", Drzava: "Srbija", Aktivan: true},
+		{Kod: "EUR", Naziv: "Evro", Simbol: "€", Drzava: "Evropska unija", Aktivan: true},
+		{Kod: "USD", Naziv: "Američki dolar", Simbol: "$", Drzava: "SAD", Aktivan: true},
+		{Kod: "GBP", Naziv: "Britanska funta", Simbol: "£", Drzava: "Velika Britanija", Aktivan: true},
+		{Kod: "CHF", Naziv: "Švajcarski franak", Simbol: "CHF", Drzava: "Švajcarska", Aktivan: true},
+		{Kod: "JPY", Naziv: "Japanski jen", Simbol: "¥", Drzava: "Japan", Aktivan: true},
+		{Kod: "CAD", Naziv: "Kanadski dolar", Simbol: "C$", Drzava: "Kanada", Aktivan: true},
+		{Kod: "AUD", Naziv: "Australijski dolar", Simbol: "A$", Drzava: "Australija", Aktivan: true},
+	}
+
+	for _, c := range currencies {
+		var existing models.Currency
+		result := db.Where("kod = ?", c.Kod).First(&existing)
+		if result.Error == gorm.ErrRecordNotFound {
+			if err := db.Create(&c).Error; err != nil {
+				return err
+			}
+			slog.Info("Seeded currency", "kod", c.Kod)
+		}
+	}
+
+	slog.Info("Currency seed complete")
+	return nil
+}

--- a/auth-service/cmd/server/main.go
+++ b/auth-service/cmd/server/main.go
@@ -49,6 +49,7 @@ func main() {
 
 	notifSvc := infrasvc.NewNotificationService(cfg)
 	authH := handler.NewAuthHandler(cfg, db, notifSvc)
+	clientAuthH := handler.NewClientAuthHandler(cfg, db, notifSvc)
 
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
@@ -85,6 +86,7 @@ func main() {
 
 	httpMux := http.NewServeMux()
 	httpMux.HandleFunc("/health", healthCheck)
+	httpMux.Handle("/api/v1/auth/client/login", middleware.CORS(http.HandlerFunc(clientAuthH.Login)))
 	httpMux.Handle("/", middleware.CORS(gwMux))
 
 	httpServer := &http.Server{

--- a/auth-service/internal/handler/client_auth_handler.go
+++ b/auth-service/internal/handler/client_auth_handler.go
@@ -1,0 +1,75 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/auth-service/internal/config"
+	authsvc "github.com/RAF-SI-2025/EXBanka-3-Backend/auth-service/internal/service"
+	"gorm.io/gorm"
+)
+
+type ClientAuthHandler struct {
+	svc *authsvc.AuthService
+}
+
+func NewClientAuthHandler(cfg *config.Config, db *gorm.DB, notifSvc *authsvc.NotificationService) *ClientAuthHandler {
+	return &ClientAuthHandler{
+		svc: authsvc.NewAuthService(cfg, db, notifSvc),
+	}
+}
+
+type clientLoginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type clientLoginResponse struct {
+	AccessToken  string     `json:"accessToken"`
+	RefreshToken string     `json:"refreshToken"`
+	Client       clientInfo `json:"client"`
+}
+
+type clientInfo struct {
+	ID          uint     `json:"id"`
+	Ime         string   `json:"ime"`
+	Prezime     string   `json:"prezime"`
+	Email       string   `json:"email"`
+	Permissions []string `json:"permissions"`
+}
+
+func (h *ClientAuthHandler) Login(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req clientLoginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	accessToken, refreshToken, client, err := h.svc.ClientLogin(req.Email, req.Password)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+
+	resp := clientLoginResponse{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		Client: clientInfo{
+			ID:          client.ID,
+			Ime:         client.Ime,
+			Prezime:     client.Prezime,
+			Email:       client.Email,
+			Permissions: client.PermissionNames(),
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}

--- a/client-service/cmd/server/main.go
+++ b/client-service/cmd/server/main.go
@@ -41,6 +41,10 @@ func main() {
 		slog.Error("Permission seeding failed", "error", err)
 		os.Exit(1)
 	}
+	if err := database.SeedDefaultClient(db); err != nil {
+		slog.Error("Default client seed failed", "error", err)
+		os.Exit(1)
+	}
 
 	clientH := handler.NewClientHandler(cfg, db)
 

--- a/client-service/internal/database/seed_client.go
+++ b/client-service/internal/database/seed_client.go
@@ -1,0 +1,76 @@
+package database
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"log/slog"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/client-service/internal/models"
+	"golang.org/x/crypto/pbkdf2"
+	"gorm.io/gorm"
+)
+
+const (
+	defaultClientEmail    = "klijent@bank.com"
+	defaultClientPassword = "Klijent123!"
+)
+
+func generateSalt() (string, error) {
+	salt := make([]byte, 32)
+	if _, err := rand.Read(salt); err != nil {
+		return "", fmt.Errorf("failed to generate salt: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(salt), nil
+}
+
+func hashPassword(password, saltB64 string) (string, error) {
+	saltBytes, err := base64.StdEncoding.DecodeString(saltB64)
+	if err != nil {
+		return "", fmt.Errorf("invalid salt encoding: %w", err)
+	}
+	hash := pbkdf2.Key([]byte(password), saltBytes, 100_000, 32, sha256.New)
+	return base64.StdEncoding.EncodeToString(hash), nil
+}
+
+func SeedDefaultClient(db *gorm.DB) error {
+	var existing models.Client
+	if result := db.Where("email = ?", defaultClientEmail).First(&existing); result.Error == nil {
+		slog.Info("Default client already exists, skipping seed")
+		return nil
+	}
+
+	salt, err := generateSalt()
+	if err != nil {
+		return err
+	}
+	hashedPwd, err := hashPassword(defaultClientPassword, salt)
+	if err != nil {
+		return err
+	}
+
+	// Get client permissions
+	var clientPerms []models.Permission
+	db.Where("subject_type = ?", models.PermissionSubjectClient).Find(&clientPerms)
+
+	client := models.Client{
+		Ime:           "Petar",
+		Prezime:       "Jovanovic",
+		DatumRodjenja: 946684800, // 2000-01-01
+		Pol:           "M",
+		Email:         defaultClientEmail,
+		BrojTelefona:  "0641234567",
+		Adresa:        "Knez Mihailova 10, Beograd",
+		Password:      hashedPwd,
+		SaltPassword:  salt,
+		Permissions:   clientPerms,
+	}
+
+	if err := db.Create(&client).Error; err != nil {
+		return fmt.Errorf("failed to create default client: %w", err)
+	}
+
+	slog.Info("Default client created", "email", defaultClientEmail)
+	return nil
+}

--- a/payment-service/cmd/server/main.go
+++ b/payment-service/cmd/server/main.go
@@ -36,6 +36,10 @@ func main() {
 		slog.Error("DB migration failed", "error", err)
 		os.Exit(1)
 	}
+	if err := database.SeedSifrePlacanja(db); err != nil {
+		slog.Error("Sifre placanja seed failed", "error", err)
+		os.Exit(1)
+	}
 
 	recipientH := handler.NewPaymentRecipientHandler(db)
 	paymentH := handler.NewPaymentHandler(db)

--- a/payment-service/internal/database/seed.go
+++ b/payment-service/internal/database/seed.go
@@ -1,0 +1,41 @@
+package database
+
+import (
+	"log/slog"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/internal/models"
+	"gorm.io/gorm"
+)
+
+func SeedSifrePlacanja(db *gorm.DB) error {
+	sifre := []models.SifraPlacanja{
+		{Sifra: "221", Naziv: "Promet robe"},
+		{Sifra: "222", Naziv: "Promet usluga"},
+		{Sifra: "223", Naziv: "Zakup"},
+		{Sifra: "240", Naziv: "Komunalne usluge"},
+		{Sifra: "241", Naziv: "Struja"},
+		{Sifra: "242", Naziv: "Gas"},
+		{Sifra: "243", Naziv: "Voda"},
+		{Sifra: "244", Naziv: "Telefon/Internet"},
+		{Sifra: "253", Naziv: "Premije osiguranja"},
+		{Sifra: "254", Naziv: "Prenos sredstava"},
+		{Sifra: "265", Naziv: "Otplata kredita"},
+		{Sifra: "270", Naziv: "Donacija"},
+		{Sifra: "289", Naziv: "Ostale transakcije"},
+		{Sifra: "290", Naziv: "Interni prenos"},
+	}
+
+	for _, s := range sifre {
+		var existing models.SifraPlacanja
+		result := db.Where("sifra = ?", s.Sifra).First(&existing)
+		if result.Error == gorm.ErrRecordNotFound {
+			if err := db.Create(&s).Error; err != nil {
+				return err
+			}
+			slog.Info("Seeded sifra placanja", "sifra", s.Sifra, "naziv", s.Naziv)
+		}
+	}
+
+	slog.Info("Sifre placanja seed complete")
+	return nil
+}

--- a/transfer-service/cmd/server/main.go
+++ b/transfer-service/cmd/server/main.go
@@ -36,7 +36,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	transferH := handler.NewTransferHandler(db)
+	exchangeURL := envOrDefault("EXCHANGE_SERVICE_URL", "http://exchange-service:8088")
+	transferH := handler.NewTransferHandler(db, exchangeURL)
 
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
@@ -99,6 +100,13 @@ func main() {
 		slog.Error("HTTP shutdown error", "error", err)
 	}
 	slog.Info("transfer-service stopped")
+}
+
+func envOrDefault(key, defaultVal string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultVal
 }
 
 func healthCheck(w http.ResponseWriter, _ *http.Request) {

--- a/transfer-service/internal/handler/transfer_handler.go
+++ b/transfer-service/internal/handler/transfer_handler.go
@@ -26,10 +26,11 @@ type TransferHandler struct {
 	svc TransferServiceInterface
 }
 
-func NewTransferHandler(db *gorm.DB) *TransferHandler {
+func NewTransferHandler(db *gorm.DB, exchangeServiceURL string) *TransferHandler {
 	accountRepo := repository.NewAccountRepository(db)
 	transferRepo := repository.NewTransferRepository(db)
-	svc := service.NewTransferServiceWithRepos(accountRepo, transferRepo, nil)
+	exchangeSvc := service.NewHTTPExchangeRateService(exchangeServiceURL)
+	svc := service.NewTransferServiceWithRepos(accountRepo, transferRepo, exchangeSvc)
 	return &TransferHandler{svc: svc}
 }
 

--- a/transfer-service/internal/service/exchange_client.go
+++ b/transfer-service/internal/service/exchange_client.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// HTTPExchangeRateService calls the exchange-service HTTP API to get rates.
+type HTTPExchangeRateService struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+func NewHTTPExchangeRateService(baseURL string) *HTTPExchangeRateService {
+	return &HTTPExchangeRateService{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 5 * time.Second,
+		},
+	}
+}
+
+type rateListResponse struct {
+	Rates []rateItem `json:"rates"`
+}
+
+type rateItem struct {
+	FromCurrency string  `json:"fromCurrency"`
+	ToCurrency   string  `json:"toCurrency"`
+	Rate         float64 `json:"rate"`
+}
+
+func (s *HTTPExchangeRateService) GetRate(fromCurrencyKod, toCurrencyKod string) (float64, error) {
+	resp, err := s.httpClient.Get(s.baseURL + "/api/v1/exchange/rates")
+	if err != nil {
+		return 0, fmt.Errorf("failed to call exchange service: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("exchange service returned status %d", resp.StatusCode)
+	}
+
+	var result rateListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("failed to decode exchange response: %w", err)
+	}
+
+	for _, r := range result.Rates {
+		if r.FromCurrency == fromCurrencyKod && r.ToCurrency == toCurrencyKod {
+			return r.Rate, nil
+		}
+	}
+
+	return 0, fmt.Errorf("exchange rate not found: %s -> %s", fromCurrencyKod, toCurrencyKod)
+}


### PR DESCRIPTION
… client seed

- Add client login HTTP handler (POST /api/v1/auth/client/login)
- Add currency seed (8 currencies: RSD, EUR, USD, GBP, CHF, JPY, CAD, AUD)
- Add sifre placanja seed (14 payment codes per NBS standard)
- Fix transfer service exchange rate nil injection with HTTP client
- Add default client seed (klijent@bank.com / Klijent123!)