### PR TITLE
feat(exchange): add PortfolioHolding and TaxRecord models

### DIFF
--- a/exchange-service/internal/database/database.go
+++ b/exchange-service/internal/database/database.go
@@ -41,6 +41,8 @@ func Migrate(db *gorm.DB) error {
 		&models.OptionRecord{},
 		&models.OrderRecord{},
 		&models.OrderTransactionRecord{},
+		&models.PortfolioHoldingRecord{},
+		&models.TaxRecord{},
 	); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}

--- a/exchange-service/internal/models/market_entities.go
+++ b/exchange-service/internal/models/market_entities.go
@@ -208,3 +208,39 @@ type OrderTransactionRecord struct {
 }
 
 func (OrderTransactionRecord) TableName() string { return "order_transactions" }
+
+// Portfolio holdings — persistent, built from executed order transactions.
+
+type PortfolioHoldingRecord struct {
+	ID             uint                `gorm:"primaryKey"`
+	UserID         uint                `gorm:"column:user_id;not null;index:idx_portfolio_user_asset"`
+	UserType       string              `gorm:"column:user_type;not null"` // "client" or "employee"
+	AssetID        uint                `gorm:"column:asset_id;not null;index:idx_portfolio_user_asset"`
+	Asset          MarketListingRecord `gorm:"foreignKey:AssetID;constraint:OnUpdate:CASCADE,OnDelete:RESTRICT;"`
+	Quantity       float64             `gorm:"not null;default:0"`
+	AvgBuyPrice    float64             `gorm:"column:avg_buy_price;not null;default:0"`
+	IsPublic       bool                `gorm:"column:is_public;not null;default:false"`
+	AccountID      uint                `gorm:"column:account_id;not null"`
+	RealizedProfit float64             `gorm:"column:realized_profit;not null;default:0"`
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+func (PortfolioHoldingRecord) TableName() string { return "portfolio_holdings" }
+
+// TaxRecord tracks capital gains tax (15%) owed per user per month.
+
+type TaxRecord struct {
+	ID        uint      `gorm:"primaryKey"`
+	UserID    uint      `gorm:"column:user_id;not null;index:idx_tax_user_period"`
+	UserType  string    `gorm:"column:user_type;not null"`
+	AssetID   uint      `gorm:"column:asset_id;not null"`
+	Period    string    `gorm:"not null;index:idx_tax_user_period"` // "YYYY-MM", e.g. "2026-04"
+	ProfitRSD float64   `gorm:"column:profit_rsd;not null"`
+	TaxRSD    float64   `gorm:"column:tax_rsd;not null"` // 15% of profit_rsd
+	Status    string    `gorm:"not null;default:'unpaid'"` // unpaid, paid
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+func (TaxRecord) TableName() string { return "tax_records" }


### PR DESCRIPTION
Add persistent PortfolioHoldingRecord and TaxRecord GORM models to exchange-service for Sprint 5 order execution and tax tracking.

- PortfolioHoldingRecord: tracks real user holdings built from executed order transactions (user_id, asset_id, quantity, avg_buy_price, is_public, account_id, realized_profit)
- TaxRecord: tracks 15% capital gains tax per user per period (YYYY-MM), status unpaid/paid
- Both models added to AutoMigrate in database.go