### PR TITLE
feat(exchange): add order repository and service for market orders (T…

### DIFF
--- a/exchange-service/internal/repository/order_repository.go
+++ b/exchange-service/internal/repository/order_repository.go
@@ -1,0 +1,152 @@
+package repository
+
+import (
+	"errors"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"gorm.io/gorm"
+)
+
+type OrderRepository struct {
+	db *gorm.DB
+}
+
+func NewOrderRepository(db *gorm.DB) *OrderRepository {
+	return &OrderRepository{db: db}
+}
+
+// CreateOrder persists a new order record.
+func (r *OrderRepository) CreateOrder(order *models.OrderRecord) error {
+	return r.db.Create(order).Error
+}
+
+// GetOrderByID returns an order with its transactions preloaded.
+func (r *OrderRepository) GetOrderByID(id uint) (*models.OrderRecord, error) {
+	var record models.OrderRecord
+	if err := r.db.Preload("Asset").Preload("Asset.Exchange").Preload("Transactions").
+		First(&record, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &record, nil
+}
+
+// ListOrdersForUser returns all orders for a given user, optionally filtered by status.
+func (r *OrderRepository) ListOrdersForUser(userID uint, userType, statusFilter string) ([]models.OrderRecord, error) {
+	q := r.db.Preload("Asset").Preload("Asset.Exchange").
+		Where("user_id = ? AND user_type = ?", userID, userType)
+	if statusFilter != "" {
+		q = q.Where("status = ?", statusFilter)
+	}
+	var records []models.OrderRecord
+	if err := q.Order("created_at DESC").Find(&records).Error; err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+// ListPendingActiveOrders returns all orders that are approved/pending and not done,
+// used by the execution engine cron.
+func (r *OrderRepository) ListPendingActiveOrders() ([]models.OrderRecord, error) {
+	var records []models.OrderRecord
+	if err := r.db.Preload("Asset").Preload("Asset.Exchange").
+		Where("is_done = false AND status IN ?", []string{"approved", "pending"}).
+		Find(&records).Error; err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+// UpdateOrderStatus sets the status and optionally the approved_by field.
+func (r *OrderRepository) UpdateOrderStatus(id uint, status string, approvedBy *uint) error {
+	updates := map[string]interface{}{
+		"status":            status,
+		"last_modification": time.Now().UTC(),
+	}
+	if approvedBy != nil {
+		updates["approved_by"] = *approvedBy
+	}
+	return r.db.Model(&models.OrderRecord{}).Where("id = ?", id).Updates(updates).Error
+}
+
+// DecrementRemainingPortions reduces remaining_portions and marks done if 0.
+func (r *OrderRepository) DecrementRemainingPortions(id uint, filled int64) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		var order models.OrderRecord
+		if err := tx.First(&order, id).Error; err != nil {
+			return err
+		}
+		order.RemainingPortions -= filled
+		order.LastModification = time.Now().UTC()
+		if order.RemainingPortions <= 0 {
+			order.RemainingPortions = 0
+			order.IsDone = true
+			order.Status = "done"
+		}
+		return tx.Save(&order).Error
+	})
+}
+
+// CreateOrderTransaction persists a fill event.
+func (r *OrderRepository) CreateOrderTransaction(tx *models.OrderTransactionRecord) error {
+	return r.db.Create(tx).Error
+}
+
+// ListTransactionsForOrder returns all transactions for an order.
+func (r *OrderRepository) ListTransactionsForOrder(orderID uint) ([]models.OrderTransactionRecord, error) {
+	var records []models.OrderTransactionRecord
+	if err := r.db.Where("order_id = ?", orderID).Order("executed_at ASC").Find(&records).Error; err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+// --- Actuary helpers (reads from shared DB, employee-service tables) ---
+
+// ActuaryProfile is a lightweight read of the actuary_profiles table.
+type ActuaryProfile struct {
+	EmployeeID   uint
+	Limit        *float64
+	UsedLimit    float64
+	NeedApproval bool
+}
+
+// GetActuaryProfile fetches the actuary profile for an employee directly from the shared DB.
+// Returns nil if the employee has no actuary profile (i.e. is not an agent/supervisor).
+func (r *OrderRepository) GetActuaryProfile(employeeID uint) (*ActuaryProfile, error) {
+	var profile ActuaryProfile
+	err := r.db.Table("actuary_profiles").
+		Select("employee_id, trading_limit as limit, used_limit, need_approval").
+		Where("employee_id = ?", employeeID).
+		First(&profile).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &profile, nil
+}
+
+// IncrementUsedLimit atomically adds delta to used_limit for an employee.
+func (r *OrderRepository) IncrementUsedLimit(employeeID uint, delta float64) error {
+	return r.db.Table("actuary_profiles").
+		Where("employee_id = ?", employeeID).
+		UpdateColumn("used_limit", gorm.Expr("used_limit + ?", delta)).Error
+}
+
+// --- Account helpers (reads from shared DB, account-service tables) ---
+
+// GetAccountBalance returns the raspolozivo_stanje (available balance) and currency_kod for an account.
+func (r *OrderRepository) GetAccountBalance(accountID uint) (balance float64, currencyKod string, err error) {
+	row := r.db.Table("accounts").
+		Select("accounts.raspolozivo_stanje, currencies.kod").
+		Joins("LEFT JOIN currencies ON currencies.id = accounts.currency_id").
+		Where("accounts.id = ?", accountID).
+		Row()
+	err = row.Scan(&balance, &currencyKod)
+	return
+}

--- a/exchange-service/internal/service/order_service.go
+++ b/exchange-service/internal/service/order_service.go
@@ -1,0 +1,253 @@
+package service
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+const (
+	// Market order commission: min(14% * price, $7)
+	marketCommissionRate = 0.14
+	marketCommissionCap  = 7.0
+
+	// Limit order commission: min(24% * price, $12)
+	limitCommissionRate = 0.24
+	limitCommissionCap  = 12.0
+)
+
+// OrderService handles order creation, approval, and cancellation.
+type OrderService struct {
+	orderRepo  *repository.OrderRepository
+	marketRepo *repository.MarketRepository
+}
+
+func NewOrderService(orderRepo *repository.OrderRepository, marketRepo *repository.MarketRepository) *OrderService {
+	return &OrderService{
+		orderRepo:  orderRepo,
+		marketRepo: marketRepo,
+	}
+}
+
+// CreateOrderInput holds all fields required to place an order.
+type CreateOrderInput struct {
+	UserID       uint
+	UserType     string   // "client" or "employee"
+	AssetTicker  string
+	OrderType    string   // "market", "limit", "stop", "stop_limit"
+	Direction    string   // "buy" or "sell"
+	Quantity     int64
+	ContractSize int64    // defaults to 1 if 0
+	LimitValue   *float64 // required for limit / stop_limit
+	StopValue    *float64 // required for stop / stop_limit
+	IsAON        bool
+	IsMargin     bool
+	AccountID    uint
+	AfterHours   bool
+}
+
+// CreateOrderResult is the full order record returned after creation.
+type CreateOrderResult struct {
+	Order      *models.OrderRecord
+	Commission float64
+	TotalPrice float64
+}
+
+// CreateOrder validates input and persists a new order.
+// For Task 2.1 this handles market orders; limit/stop types are validated and persisted
+// but their execution conditions are evaluated by the cron executor (Phase 3).
+func (s *OrderService) CreateOrder(input CreateOrderInput) (*CreateOrderResult, error) {
+	if err := validateOrderInput(input); err != nil {
+		return nil, err
+	}
+
+	contractSize := input.ContractSize
+	if contractSize <= 0 {
+		contractSize = 1
+	}
+
+	// Fetch the listing to get current prices.
+	listing, err := s.marketRepo.GetListingRecordByTicker(input.AssetTicker)
+	if err != nil || listing == nil {
+		return nil, fmt.Errorf("asset not found: %s", input.AssetTicker)
+	}
+
+	// Determine execution price per unit based on direction.
+	pricePerUnit := executionPrice(listing, input.Direction)
+
+	// Total order value (before commission).
+	totalPrice := round2(float64(contractSize) * pricePerUnit * float64(input.Quantity))
+
+	// Commission depends on order type.
+	commission := calcCommission(input.OrderType, totalPrice)
+
+	// Determine initial order status.
+	status, needsApproval, err := s.resolveStatus(input, totalPrice)
+	if err != nil {
+		return nil, err
+	}
+
+	// For agent orders that don't need approval, increment their usedLimit.
+	if input.UserType == "employee" && !needsApproval {
+		if err := s.orderRepo.IncrementUsedLimit(input.UserID, totalPrice); err != nil {
+			return nil, fmt.Errorf("failed to update actuary used limit: %w", err)
+		}
+	}
+
+	now := time.Now().UTC()
+	order := &models.OrderRecord{
+		UserID:            input.UserID,
+		UserType:          input.UserType,
+		AssetID:           listing.ID,
+		OrderType:         input.OrderType,
+		Direction:         input.Direction,
+		Quantity:          input.Quantity,
+		ContractSize:      contractSize,
+		PricePerUnit:      pricePerUnit,
+		LimitValue:        input.LimitValue,
+		StopValue:         input.StopValue,
+		IsAON:             input.IsAON,
+		IsMargin:          input.IsMargin,
+		Status:            status,
+		IsDone:            false,
+		RemainingPortions: input.Quantity,
+		AfterHours:        input.AfterHours,
+		AccountID:         input.AccountID,
+		LastModification:  now,
+		CreatedAt:         now,
+	}
+
+	if err := s.orderRepo.CreateOrder(order); err != nil {
+		return nil, fmt.Errorf("failed to persist order: %w", err)
+	}
+
+	return &CreateOrderResult{
+		Order:      order,
+		Commission: commission,
+		TotalPrice: totalPrice,
+	}, nil
+}
+
+// resolveStatus determines the initial status and whether supervisor approval is needed.
+func (s *OrderService) resolveStatus(input CreateOrderInput, totalPrice float64) (status string, needsApproval bool, err error) {
+	// Client orders are always auto-approved.
+	if input.UserType == "client" {
+		return "approved", false, nil
+	}
+
+	// Employee orders: check actuary profile.
+	profile, err := s.orderRepo.GetActuaryProfile(input.UserID)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to read actuary profile: %w", err)
+	}
+
+	// No actuary profile means basic employee — cannot place orders.
+	if profile == nil {
+		return "", false, fmt.Errorf("employee does not have trading permissions")
+	}
+
+	// Supervisor: no limit, always approved without supervisor review of self.
+	if profile.Limit == nil {
+		return "approved", false, nil
+	}
+
+	// Agent: check if approval required.
+	remaining := *profile.Limit - profile.UsedLimit
+	if profile.NeedApproval || profile.UsedLimit >= *profile.Limit || totalPrice > remaining {
+		return "pending", true, nil
+	}
+
+	return "approved", false, nil
+}
+
+// GetOrder returns a single order by ID.
+func (s *OrderService) GetOrder(id uint) (*models.OrderRecord, error) {
+	order, err := s.orderRepo.GetOrderByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if order == nil {
+		return nil, fmt.Errorf("order not found")
+	}
+	return order, nil
+}
+
+// ListOrdersForUser returns orders for a user with optional status filter.
+func (s *OrderService) ListOrdersForUser(userID uint, userType, statusFilter string) ([]models.OrderRecord, error) {
+	return s.orderRepo.ListOrdersForUser(userID, userType, statusFilter)
+}
+
+// ListTransactionsForOrder returns all fill events for an order.
+func (s *OrderService) ListTransactionsForOrder(orderID uint) ([]models.OrderTransactionRecord, error) {
+	return s.orderRepo.ListTransactionsForOrder(orderID)
+}
+
+// --- Helpers ---
+
+func validateOrderInput(input CreateOrderInput) error {
+	if input.UserID == 0 {
+		return fmt.Errorf("user ID is required")
+	}
+	if input.UserType != "client" && input.UserType != "employee" {
+		return fmt.Errorf("user type must be 'client' or 'employee'")
+	}
+	if input.AssetTicker == "" {
+		return fmt.Errorf("asset ticker is required")
+	}
+	if input.Direction != "buy" && input.Direction != "sell" {
+		return fmt.Errorf("direction must be 'buy' or 'sell'")
+	}
+	if input.Quantity <= 0 {
+		return fmt.Errorf("quantity must be positive")
+	}
+	if input.AccountID == 0 {
+		return fmt.Errorf("account ID is required")
+	}
+
+	switch input.OrderType {
+	case "market":
+		// no extra fields required
+	case "limit":
+		if input.LimitValue == nil {
+			return fmt.Errorf("limit_value is required for limit orders")
+		}
+	case "stop":
+		if input.StopValue == nil {
+			return fmt.Errorf("stop_value is required for stop orders")
+		}
+	case "stop_limit":
+		if input.StopValue == nil || input.LimitValue == nil {
+			return fmt.Errorf("stop_value and limit_value are required for stop_limit orders")
+		}
+	default:
+		return fmt.Errorf("order type must be one of: market, limit, stop, stop_limit")
+	}
+
+	return nil
+}
+
+// executionPrice returns the execution price per unit for a market order.
+// Buy fills at ask; sell fills at bid.
+func executionPrice(listing *models.MarketListingRecord, direction string) float64 {
+	if direction == "buy" {
+		return listing.Ask
+	}
+	return listing.Bid
+}
+
+// calcCommission computes the commission for an order.
+// Market: min(14% * price, $7)
+// Limit/Stop/Stop-Limit: min(24% * price, $12)
+func calcCommission(orderType string, totalPrice float64) float64 {
+	if orderType == "market" {
+		return math.Min(marketCommissionRate*totalPrice, marketCommissionCap)
+	}
+	return math.Min(limitCommissionRate*totalPrice, limitCommissionCap)
+}
+
+func round2(v float64) float64 {
+	return math.Round(v*100) / 100
+}


### PR DESCRIPTION
…ask 2.1)

- OrderRepository: CRUD for orders/transactions, cross-service DB reads for actuary profiles and account balances
- OrderService: CreateOrder with market order support, commission calculation (min(14%×price,$7)), and actuary limit/approval logic