### PR TITLE
ORDER-BE-5: Order execution engine (cron partial fill)

### DIFF
--- a/exchange-service/internal/service/cron_service.go
+++ b/exchange-service/internal/service/cron_service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
 	"github.com/robfig/cron/v3"
 	"gorm.io/gorm"
 )
@@ -15,12 +16,24 @@ import (
 func StartCronJobs(db *gorm.DB) *cron.Cron {
 	c := cron.New()
 
-	// Refresh listing prices every 15 minutes
+	// Refresh listing prices every 15 minutes.
 	_, err := c.AddFunc("@every 15m", func() {
 		refreshListingPrices(db)
 	})
 	if err != nil {
 		slog.Error("Failed to add price refresh cron job", "error", err)
+	}
+
+	// Order execution engine: attempt to fill active orders every minute.
+	executor := NewOrderExecutor(
+		repository.NewOrderRepository(db),
+		repository.NewMarketRepository(db),
+	)
+	_, err = c.AddFunc("@every 1m", func() {
+		executor.Run()
+	})
+	if err != nil {
+		slog.Error("Failed to add order executor cron job", "error", err)
 	}
 
 	c.Start()

--- a/exchange-service/internal/service/order_executor.go
+++ b/exchange-service/internal/service/order_executor.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"log/slog"
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+const afterHoursDelay = 30 * time.Minute
+
+// OrderExecutor fills active orders on each cron tick.
+type OrderExecutor struct {
+	orderRepo  *repository.OrderRepository
+	marketRepo *repository.MarketRepository
+}
+
+func NewOrderExecutor(orderRepo *repository.OrderRepository, marketRepo *repository.MarketRepository) *OrderExecutor {
+	return &OrderExecutor{orderRepo: orderRepo, marketRepo: marketRepo}
+}
+
+// Run processes all approved, not-done orders and partially or fully fills them
+// when their execution conditions are met.
+func (e *OrderExecutor) Run() {
+	orders, err := e.orderRepo.ListPendingActiveOrders()
+	if err != nil {
+		slog.Error("order executor: failed to load active orders", "error", err)
+		return
+	}
+
+	for _, order := range orders {
+		// Only execute approved orders; pending ones wait for supervisor action.
+		if order.Status != "approved" {
+			continue
+		}
+
+		listing := &order.Asset // preloaded by ListPendingActiveOrders
+
+		// Check if order conditions are currently satisfied.
+		if !conditionsMet(&order, listing) {
+			continue
+		}
+
+		// After-hours orders: enforce a 30-minute gap between consecutive fills.
+		if order.AfterHours && time.Since(order.LastModification) < afterHoursDelay {
+			continue
+		}
+
+		// Determine fill quantity and price.
+		fillQty := fillQuantity(&order)
+		price := executeFillPrice(&order, listing)
+
+		// Persist the fill event.
+		txRecord := &models.OrderTransactionRecord{
+			OrderID:      order.ID,
+			Quantity:     fillQty,
+			PricePerUnit: price,
+			ExecutedAt:   time.Now().UTC(),
+		}
+		if err := e.orderRepo.CreateOrderTransaction(txRecord); err != nil {
+			slog.Error("order executor: failed to create transaction", "orderID", order.ID, "error", err)
+			continue
+		}
+
+		// Decrement remaining portions; marks order done if it reaches 0.
+		if err := e.orderRepo.DecrementRemainingPortions(order.ID, fillQty); err != nil {
+			slog.Error("order executor: failed to decrement portions", "orderID", order.ID, "error", err)
+			continue
+		}
+
+		slog.Info("order executor: filled",
+			"orderID", order.ID,
+			"type", order.OrderType,
+			"direction", order.Direction,
+			"filled", fillQty,
+			"price", price,
+			"remaining", order.RemainingPortions-fillQty,
+		)
+	}
+}
+
+// conditionsMet reports whether current market prices satisfy the order's
+// execution trigger.
+//
+//	market:     always executable
+//	limit buy:  ask <= limit_value
+//	limit sell: bid >= limit_value
+//	stop buy:   ask > stop_value  (then executes at market)
+//	stop sell:  bid < stop_value  (then executes at market)
+//	stop_limit: stop must trigger AND limit condition must be satisfied
+func conditionsMet(order *models.OrderRecord, listing *models.MarketListingRecord) bool {
+	switch order.OrderType {
+	case "market":
+		return true
+	case "limit":
+		if order.Direction == "buy" {
+			return listing.Ask <= *order.LimitValue
+		}
+		return listing.Bid >= *order.LimitValue
+	case "stop":
+		if order.Direction == "buy" {
+			return listing.Ask > *order.StopValue
+		}
+		return listing.Bid < *order.StopValue
+	case "stop_limit":
+		// Stop triggers activation; limit guards the fill price.
+		if order.Direction == "buy" {
+			return listing.Ask > *order.StopValue && listing.Ask <= *order.LimitValue
+		}
+		return listing.Bid < *order.StopValue && listing.Bid >= *order.LimitValue
+	}
+	return false
+}
+
+// fillQuantity returns how many units to fill in this cycle.
+// AON orders must fill the entire remaining quantity at once or not at all.
+// Regular orders fill a random portion: rand[1, remaining_portions].
+func fillQuantity(order *models.OrderRecord) int64 {
+	if order.IsAON {
+		return order.RemainingPortions
+	}
+	if order.RemainingPortions == 1 {
+		return 1
+	}
+	return rand.Int63n(order.RemainingPortions) + 1
+}
+
+// executeFillPrice returns the actual per-unit price for a fill.
+//
+//	market / stop:      current ask (buy) or bid (sell)
+//	limit / stop_limit: min(limit_value, ask) for buy; max(limit_value, bid) for sell
+func executeFillPrice(order *models.OrderRecord, listing *models.MarketListingRecord) float64 {
+	switch order.OrderType {
+	case "limit", "stop_limit":
+		if order.Direction == "buy" {
+			return math.Min(*order.LimitValue, listing.Ask)
+		}
+		return math.Max(*order.LimitValue, listing.Bid)
+	default: // market, stop
+		if order.Direction == "buy" {
+			return listing.Ask
+		}
+		return listing.Bid
+	}
+}


### PR DESCRIPTION
## Summary

- `OrderExecutor` fires every minute via cron
- Checks all 4 order type conditions against live ask/bid prices
- AON: full fill only; after-hours: 30-min gap between fills
- Random partial fill → `OrderTransactionRecord` → decrement remaining → mark done when 0

## Changes

| Task | Issue | Commit |
|------|-------|--------|
| Task 3.1: OrderExecutor | #157 | d41c0ef |
| Task 3.2: Wire into cron | #157 | d41c0ef |

## Test plan
- [ ] Market orders fill immediately every minute
- [ ] Limit orders fill only when ask/bid crosses limit
- [ ] Stop orders trigger when price crosses stop value
- [ ] AON orders fill entire quantity or not at all
- [ ] After-hours orders wait 30 min between fills
- [ ] `is_done=true` and `status="done"` set when remaining reaches 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)