### PR TITLE
ORDER-BE-6: Supervisor approve/decline pending orders

### DIFF
--- a/exchange-service/internal/repository/order_repository.go
+++ b/exchange-service/internal/repository/order_repository.go
@@ -138,6 +138,20 @@ func (r *OrderRepository) IncrementUsedLimit(employeeID uint, delta float64) err
 		UpdateColumn("used_limit", gorm.Expr("used_limit + ?", delta)).Error
 }
 
+// GetSettlementDate returns the settlement date for a futures or options listing,
+// or nil if the asset type has no settlement date (stocks, forex).
+func (r *OrderRepository) GetSettlementDate(assetID uint) (*time.Time, error) {
+	var futures models.FuturesContractRecord
+	if err := r.db.Where("listing_id = ?", assetID).First(&futures).Error; err == nil {
+		return &futures.SettlementDate, nil
+	}
+	var option models.OptionRecord
+	if err := r.db.Where("listing_id = ?", assetID).First(&option).Error; err == nil {
+		return &option.SettlementDate, nil
+	}
+	return nil, nil // not a dated instrument
+}
+
 // --- Account helpers (reads from shared DB, account-service tables) ---
 
 // GetAccountBalance returns the raspolozivo_stanje (available balance) and currency_kod for an account.

--- a/exchange-service/internal/service/order_service.go
+++ b/exchange-service/internal/service/order_service.go
@@ -174,6 +174,70 @@ func (s *OrderService) resolveStatus(input CreateOrderInput, totalPrice float64)
 	return "approved", false, nil
 }
 
+// ApproveOrder approves a pending order on behalf of a supervisor.
+// If the order's asset has a past settlement date it is auto-declined instead.
+// For employee orders the agent's usedLimit is incremented on approval since it
+// was withheld while the order was pending.
+func (s *OrderService) ApproveOrder(orderID, supervisorID uint) error {
+	order, err := s.orderRepo.GetOrderByID(orderID)
+	if err != nil {
+		return fmt.Errorf("failed to load order: %w", err)
+	}
+	if order == nil {
+		return fmt.Errorf("order not found")
+	}
+	if order.Status != "pending" {
+		return fmt.Errorf("order is not pending (status: %s)", order.Status)
+	}
+
+	// Auto-decline if the underlying asset's settlement date has passed.
+	expired, err := s.isSettlementExpired(order.AssetID)
+	if err != nil {
+		return fmt.Errorf("failed to check settlement date: %w", err)
+	}
+	if expired {
+		return s.orderRepo.UpdateOrderStatus(orderID, "declined", &supervisorID)
+	}
+
+	// Increment the agent's usedLimit now that the order is officially approved.
+	if order.UserType == "employee" {
+		totalPrice := round2(float64(order.ContractSize) * order.PricePerUnit * float64(order.Quantity))
+		if err := s.orderRepo.IncrementUsedLimit(order.UserID, totalPrice); err != nil {
+			return fmt.Errorf("failed to update actuary used limit: %w", err)
+		}
+	}
+
+	return s.orderRepo.UpdateOrderStatus(orderID, "approved", &supervisorID)
+}
+
+// DeclineOrder declines a pending order on behalf of a supervisor.
+func (s *OrderService) DeclineOrder(orderID, supervisorID uint) error {
+	order, err := s.orderRepo.GetOrderByID(orderID)
+	if err != nil {
+		return fmt.Errorf("failed to load order: %w", err)
+	}
+	if order == nil {
+		return fmt.Errorf("order not found")
+	}
+	if order.Status != "pending" {
+		return fmt.Errorf("order is not pending (status: %s)", order.Status)
+	}
+	return s.orderRepo.UpdateOrderStatus(orderID, "declined", &supervisorID)
+}
+
+// isSettlementExpired returns true when the listing is a futures or options
+// contract whose settlement date has already passed.
+func (s *OrderService) isSettlementExpired(assetID uint) (bool, error) {
+	settlDate, err := s.orderRepo.GetSettlementDate(assetID)
+	if err != nil {
+		return false, err
+	}
+	if settlDate == nil {
+		return false, nil // not a dated instrument
+	}
+	return time.Now().After(*settlDate), nil
+}
+
 // GetOrder returns a single order by ID.
 func (s *OrderService) GetOrder(id uint) (*models.OrderRecord, error) {
 	order, err := s.orderRepo.GetOrderByID(id)


### PR DESCRIPTION
## Summary

- `ApproveOrder`: auto-declines expired futures/options, increments agent usedLimit, sets approved_by
- `DeclineOrder`: simple status flip for pending orders
- `GetSettlementDate` repo helper checks futures/options tables for expiry

## Changes

| Task | Issue | Commit |
|------|-------|--------|
| Task 4.1: Approve/Decline | #159 | 3696429 |

## Test plan
- [ ] Approving a non-pending order returns error
- [ ] Approving a futures order past settlement date → auto-declined
- [ ] Approving increments agent usedLimit
- [ ] Declining a pending order sets status=declined

🤖 Generated with [Claude Code](https://claude.com/claude-code)