### PR TITLE
ORDER-BE-7: Order cancellation (full and partial) with refund

### DIFF
--- a/exchange-service/internal/repository/order_repository.go
+++ b/exchange-service/internal/repository/order_repository.go
@@ -138,6 +138,31 @@ func (r *OrderRepository) IncrementUsedLimit(employeeID uint, delta float64) err
 		UpdateColumn("used_limit", gorm.Expr("used_limit + ?", delta)).Error
 }
 
+// FullCancelOrder marks an order as cancelled and fully done.
+func (r *OrderRepository) FullCancelOrder(id uint) error {
+	return r.db.Model(&models.OrderRecord{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"status":             "cancelled",
+		"is_done":            true,
+		"remaining_portions": 0,
+		"last_modification":  time.Now().UTC(),
+	}).Error
+}
+
+// SetRemainingPortions updates remaining_portions for a partial cancel.
+func (r *OrderRepository) SetRemainingPortions(id uint, newRemaining int64) error {
+	return r.db.Model(&models.OrderRecord{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"remaining_portions": newRemaining,
+		"last_modification":  time.Now().UTC(),
+	}).Error
+}
+
+// RefundToAccount adds the refund amount back to the account's available balance.
+func (r *OrderRepository) RefundToAccount(accountID uint, amount float64) error {
+	return r.db.Table("accounts").
+		Where("id = ?", accountID).
+		UpdateColumn("raspolozivo_stanje", gorm.Expr("raspolozivo_stanje + ?", amount)).Error
+}
+
 // GetSettlementDate returns the settlement date for a futures or options listing,
 // or nil if the asset type has no settlement date (stocks, forex).
 func (r *OrderRepository) GetSettlementDate(assetID uint) (*time.Time, error) {

--- a/exchange-service/internal/service/order_service.go
+++ b/exchange-service/internal/service/order_service.go
@@ -225,6 +225,50 @@ func (s *OrderService) DeclineOrder(orderID, supervisorID uint) error {
 	return s.orderRepo.UpdateOrderStatus(orderID, "declined", &supervisorID)
 }
 
+// CancelOrder cancels the unfilled portion of an active order.
+//
+// newRemaining == 0  → full cancel: is_done=true, status="cancelled"
+// newRemaining  > 0  → partial cancel: reduce remaining_portions, keep status
+//
+// The value of the cancelled quantity is refunded to the order's account.
+func (s *OrderService) CancelOrder(orderID, requesterID uint, newRemaining int64) error {
+	order, err := s.orderRepo.GetOrderByID(orderID)
+	if err != nil {
+		return fmt.Errorf("failed to load order: %w", err)
+	}
+	if order == nil {
+		return fmt.Errorf("order not found")
+	}
+	if order.IsDone {
+		return fmt.Errorf("order is already done and cannot be cancelled")
+	}
+	if newRemaining < 0 || newRemaining >= order.RemainingPortions {
+		return fmt.Errorf("newRemaining must be between 0 and %d (exclusive)", order.RemainingPortions)
+	}
+
+	cancelledQty := order.RemainingPortions - newRemaining
+	refundAmount := round2(float64(cancelledQty) * float64(order.ContractSize) * order.PricePerUnit)
+
+	if newRemaining == 0 {
+		// Full cancel.
+		if err := s.orderRepo.FullCancelOrder(orderID); err != nil {
+			return fmt.Errorf("failed to cancel order: %w", err)
+		}
+	} else {
+		// Partial cancel: just trim remaining_portions.
+		if err := s.orderRepo.SetRemainingPortions(orderID, newRemaining); err != nil {
+			return fmt.Errorf("failed to update remaining portions: %w", err)
+		}
+	}
+
+	// Refund the cancelled portion back to the account.
+	if err := s.orderRepo.RefundToAccount(order.AccountID, refundAmount); err != nil {
+		return fmt.Errorf("failed to refund account: %w", err)
+	}
+
+	return nil
+}
+
 // isSettlementExpired returns true when the listing is a futures or options
 // contract whose settlement date has already passed.
 func (s *OrderService) isSettlementExpired(assetID uint) (bool, error) {


### PR DESCRIPTION
## Summary

- Full cancel: `is_done=true`, `status=cancelled`
- Partial cancel: trims `remaining_portions`
- Refund: `cancelledQty × contractSize × pricePerUnit` credited to `accounts.raspolozivo_stanje` via direct DB update

## Changes

| Task | Issue | Commit |
|------|-------|--------|
| Task 4.2: CancelOrder | #161 | 0fb8596 |

## Test plan
- [ ] Cannot cancel an already-done order
- [ ] Full cancel sets is_done=true and status=cancelled
- [ ] Partial cancel reduces remaining_portions without closing order
- [ ] Refund amount credited to account balance

🤖 Generated with [Claude Code](https://claude.com/claude-code)