### PR TITLE
PORTFOLIO-BE-1: Portfolio holdings tracking on order fill

### DIFF
--- a/exchange-service/internal/repository/portfolio_repository.go
+++ b/exchange-service/internal/repository/portfolio_repository.go
@@ -1,0 +1,128 @@
+package repository
+
+import (
+	"errors"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"gorm.io/gorm"
+)
+
+type PortfolioRepository struct {
+	db *gorm.DB
+}
+
+func NewPortfolioRepository(db *gorm.DB) *PortfolioRepository {
+	return &PortfolioRepository{db: db}
+}
+
+// GetHoldingByUserAndAsset returns the holding for a user+asset pair, or nil if not found.
+func (r *PortfolioRepository) GetHoldingByUserAndAsset(userID uint, userType string, assetID uint) (*models.PortfolioHoldingRecord, error) {
+	var h models.PortfolioHoldingRecord
+	err := r.db.Where("user_id = ? AND user_type = ? AND asset_id = ?", userID, userType, assetID).
+		First(&h).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &h, nil
+}
+
+// GetHoldingByID returns a holding by primary key with Asset preloaded.
+func (r *PortfolioRepository) GetHoldingByID(id uint) (*models.PortfolioHoldingRecord, error) {
+	var h models.PortfolioHoldingRecord
+	if err := r.db.Preload("Asset").Preload("Asset.Exchange").First(&h, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &h, nil
+}
+
+// ListHoldingsForUser returns all holdings for a user with Asset preloaded.
+func (r *PortfolioRepository) ListHoldingsForUser(userID uint, userType string) ([]models.PortfolioHoldingRecord, error) {
+	var records []models.PortfolioHoldingRecord
+	if err := r.db.Preload("Asset").Preload("Asset.Exchange").
+		Where("user_id = ? AND user_type = ? AND quantity > 0", userID, userType).
+		Order("created_at ASC").Find(&records).Error; err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+// RecordBuyFill atomically upserts the portfolio holding for a buy fill.
+// Creates a new holding if none exists; otherwise increases quantity and
+// recalculates the weighted average buy price.
+func (r *PortfolioRepository) RecordBuyFill(userID uint, userType string, assetID, accountID uint, filledQty float64, fillPrice float64) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		var h models.PortfolioHoldingRecord
+		err := tx.Where("user_id = ? AND user_type = ? AND asset_id = ?", userID, userType, assetID).
+			First(&h).Error
+
+		now := time.Now().UTC()
+
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// New holding.
+			h = models.PortfolioHoldingRecord{
+				UserID:      userID,
+				UserType:    userType,
+				AssetID:     assetID,
+				AccountID:   accountID,
+				Quantity:    filledQty,
+				AvgBuyPrice: fillPrice,
+				CreatedAt:   now,
+				UpdatedAt:   now,
+			}
+			return tx.Create(&h).Error
+		}
+		if err != nil {
+			return err
+		}
+
+		// Weighted average: (old_qty * old_avg + new_qty * new_price) / total_qty
+		newQty := h.Quantity + filledQty
+		newAvg := (h.Quantity*h.AvgBuyPrice + filledQty*fillPrice) / newQty
+
+		return tx.Model(&h).Updates(map[string]interface{}{
+			"quantity":      newQty,
+			"avg_buy_price": newAvg,
+			"updated_at":    now,
+		}).Error
+	})
+}
+
+// RecordSellFill atomically decreases the holding quantity and accumulates
+// realized profit. Returns the realized profit for this fill.
+func (r *PortfolioRepository) RecordSellFill(userID uint, userType string, assetID uint, filledQty float64, sellPrice float64) (realizedProfit float64, err error) {
+	err = r.db.Transaction(func(tx *gorm.DB) error {
+		var h models.PortfolioHoldingRecord
+		if txErr := tx.Where("user_id = ? AND user_type = ? AND asset_id = ?", userID, userType, assetID).
+			First(&h).Error; txErr != nil {
+			return txErr
+		}
+
+		realizedProfit = (sellPrice - h.AvgBuyPrice) * filledQty
+		newQty := h.Quantity - filledQty
+		if newQty < 0 {
+			newQty = 0
+		}
+
+		return tx.Model(&h).Updates(map[string]interface{}{
+			"quantity":        newQty,
+			"realized_profit": h.RealizedProfit + realizedProfit,
+			"updated_at":      time.Now().UTC(),
+		}).Error
+	})
+	return
+}
+
+// SetHoldingPublic toggles the is_public flag on a holding (used for OTC shares).
+func (r *PortfolioRepository) SetHoldingPublic(id uint, isPublic bool) error {
+	return r.db.Model(&models.PortfolioHoldingRecord{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"is_public":  isPublic,
+		"updated_at": time.Now().UTC(),
+	}).Error
+}

--- a/exchange-service/internal/service/cron_service.go
+++ b/exchange-service/internal/service/cron_service.go
@@ -25,9 +25,11 @@ func StartCronJobs(db *gorm.DB) *cron.Cron {
 	}
 
 	// Order execution engine: attempt to fill active orders every minute.
+	portfolioSvc := NewPortfolioService(repository.NewPortfolioRepository(db))
 	executor := NewOrderExecutor(
 		repository.NewOrderRepository(db),
 		repository.NewMarketRepository(db),
+		portfolioSvc,
 	)
 	_, err = c.AddFunc("@every 1m", func() {
 		executor.Run()

--- a/exchange-service/internal/service/order_executor.go
+++ b/exchange-service/internal/service/order_executor.go
@@ -14,12 +14,13 @@ const afterHoursDelay = 30 * time.Minute
 
 // OrderExecutor fills active orders on each cron tick.
 type OrderExecutor struct {
-	orderRepo  *repository.OrderRepository
-	marketRepo *repository.MarketRepository
+	orderRepo     *repository.OrderRepository
+	marketRepo    *repository.MarketRepository
+	portfolioSvc  *PortfolioService
 }
 
-func NewOrderExecutor(orderRepo *repository.OrderRepository, marketRepo *repository.MarketRepository) *OrderExecutor {
-	return &OrderExecutor{orderRepo: orderRepo, marketRepo: marketRepo}
+func NewOrderExecutor(orderRepo *repository.OrderRepository, marketRepo *repository.MarketRepository, portfolioSvc *PortfolioService) *OrderExecutor {
+	return &OrderExecutor{orderRepo: orderRepo, marketRepo: marketRepo, portfolioSvc: portfolioSvc}
 }
 
 // Run processes all approved, not-done orders and partially or fully fills them
@@ -69,6 +70,12 @@ func (e *OrderExecutor) Run() {
 		if err := e.orderRepo.DecrementRemainingPortions(order.ID, fillQty); err != nil {
 			slog.Error("order executor: failed to decrement portions", "orderID", order.ID, "error", err)
 			continue
+		}
+
+		// Update portfolio holdings to reflect the fill.
+		if err := e.portfolioSvc.RecordFill(&order, fillQty, price); err != nil {
+			slog.Error("order executor: failed to update portfolio", "orderID", order.ID, "error", err)
+			// Non-fatal: order fill is committed; portfolio can be reconciled later.
 		}
 
 		slog.Info("order executor: filled",

--- a/exchange-service/internal/service/portfolio_service.go
+++ b/exchange-service/internal/service/portfolio_service.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// PortfolioService maintains PortfolioHoldingRecords in response to order fills.
+type PortfolioService struct {
+	portfolioRepo *repository.PortfolioRepository
+}
+
+func NewPortfolioService(portfolioRepo *repository.PortfolioRepository) *PortfolioService {
+	return &PortfolioService{portfolioRepo: portfolioRepo}
+}
+
+// RecordFill updates the caller's portfolio after an order fill.
+//
+// Buy fill: upsert holding — increase quantity, recalculate weighted avg buy price.
+// Sell fill: decrease quantity, accumulate realized profit on the holding.
+//
+// The effective quantity stored is fillQty × contractSize so that contracts
+// (futures, options) are tracked at the underlying unit level.
+func (s *PortfolioService) RecordFill(order *models.OrderRecord, fillQty int64, fillPrice float64) error {
+	effectiveQty := float64(fillQty) * float64(order.ContractSize)
+
+	if order.Direction == "buy" {
+		if err := s.portfolioRepo.RecordBuyFill(
+			order.UserID,
+			order.UserType,
+			order.AssetID,
+			order.AccountID,
+			effectiveQty,
+			fillPrice,
+		); err != nil {
+			return fmt.Errorf("portfolio: failed to record buy fill for order %d: %w", order.ID, err)
+		}
+		return nil
+	}
+
+	// Sell: decrease holding and accumulate realized profit.
+	_, err := s.portfolioRepo.RecordSellFill(
+		order.UserID,
+		order.UserType,
+		order.AssetID,
+		effectiveQty,
+		fillPrice,
+	)
+	if err != nil {
+		return fmt.Errorf("portfolio: failed to record sell fill for order %d: %w", order.ID, err)
+	}
+	return nil
+}
+
+// GetHoldingByID returns a single holding by ID.
+func (s *PortfolioService) GetHoldingByID(id uint) (*models.PortfolioHoldingRecord, error) {
+	h, err := s.portfolioRepo.GetHoldingByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if h == nil {
+		return nil, fmt.Errorf("holding not found")
+	}
+	return h, nil
+}
+
+// ListHoldings returns all active holdings for a user.
+func (s *PortfolioService) ListHoldings(userID uint, userType string) ([]models.PortfolioHoldingRecord, error) {
+	return s.portfolioRepo.ListHoldingsForUser(userID, userType)
+}
+
+// SetPublic toggles the is_public flag on a holding.
+func (s *PortfolioService) SetPublic(holdingID uint, isPublic bool) error {
+	return s.portfolioRepo.SetHoldingPublic(holdingID, isPublic)
+}


### PR DESCRIPTION
## Summary

- `PortfolioRepository`: transactional buy upsert (weighted avg price) and sell update (decrease qty + realized profit)
- `PortfolioService.RecordFill`: called from `OrderExecutor` after each fill
- Effective qty = `fillQty × contractSize` for contracts

## Changes

| Task | Issue | Commit |
|------|-------|--------|
| Task 6.1: Portfolio holdings tracking | #165 | c81b976 |

## Test plan
- [ ] Buy fill creates new holding if not exists
- [ ] Buy fill on existing holding updates qty and recalculates weighted avg price
- [ ] Sell fill decreases qty and accumulates realized profit
- [ ] Portfolio failure does not roll back the order fill

🤖 Generated with [Claude Code](https://claude.com/claude-code)