### PR TITLE
PORTFOLIO-BE-2: P&L computation and tax record on sell

### DIFF
--- a/exchange-service/internal/repository/tax_repository.go
+++ b/exchange-service/internal/repository/tax_repository.go
@@ -1,0 +1,49 @@
+package repository
+
+import (
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"gorm.io/gorm"
+)
+
+type TaxRepository struct {
+	db *gorm.DB
+}
+
+func NewTaxRepository(db *gorm.DB) *TaxRepository {
+	return &TaxRepository{db: db}
+}
+
+// CreateTaxRecord persists a new tax record.
+func (r *TaxRepository) CreateTaxRecord(record *models.TaxRecord) error {
+	return r.db.Create(record).Error
+}
+
+// ListTaxRecordsForUser returns all tax records for a user, optionally filtered by period ("YYYY-MM").
+func (r *TaxRepository) ListTaxRecordsForUser(userID uint, userType, period string) ([]models.TaxRecord, error) {
+	q := r.db.Where("user_id = ? AND user_type = ?", userID, userType)
+	if period != "" {
+		q = q.Where("period = ?", period)
+	}
+	var records []models.TaxRecord
+	if err := q.Order("period DESC").Find(&records).Error; err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+// SumUnpaidTaxForUser returns the total unpaid tax amount for a user in a given period.
+func (r *TaxRepository) SumUnpaidTaxForUser(userID uint, userType, period string) (float64, error) {
+	var total float64
+	err := r.db.Model(&models.TaxRecord{}).
+		Where("user_id = ? AND user_type = ? AND period = ? AND status = 'unpaid'", userID, userType, period).
+		Select("COALESCE(SUM(tax_rsd), 0)").
+		Scan(&total).Error
+	return total, err
+}
+
+// MarkTaxRecordsPaid marks all unpaid records for a user+period as paid.
+func (r *TaxRepository) MarkTaxRecordsPaid(userID uint, userType, period string) error {
+	return r.db.Model(&models.TaxRecord{}).
+		Where("user_id = ? AND user_type = ? AND period = ? AND status = 'unpaid'", userID, userType, period).
+		Update("status", "paid").Error
+}

--- a/exchange-service/internal/service/cron_service.go
+++ b/exchange-service/internal/service/cron_service.go
@@ -25,7 +25,7 @@ func StartCronJobs(db *gorm.DB) *cron.Cron {
 	}
 
 	// Order execution engine: attempt to fill active orders every minute.
-	portfolioSvc := NewPortfolioService(repository.NewPortfolioRepository(db))
+	portfolioSvc := NewPortfolioService(repository.NewPortfolioRepository(db), repository.NewTaxRepository(db))
 	executor := NewOrderExecutor(
 		repository.NewOrderRepository(db),
 		repository.NewMarketRepository(db),

--- a/exchange-service/internal/service/portfolio_service.go
+++ b/exchange-service/internal/service/portfolio_service.go
@@ -2,38 +2,50 @@ package service
 
 import (
 	"fmt"
+	"math"
+	"time"
 
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
 )
 
-// PortfolioService maintains PortfolioHoldingRecords in response to order fills.
+const capitalGainsTaxRate = 0.15
+
+// PortfolioService maintains PortfolioHoldingRecords in response to order fills
+// and exposes P&L views over the live holdings.
 type PortfolioService struct {
 	portfolioRepo *repository.PortfolioRepository
+	taxRepo       *repository.TaxRepository
 }
 
-func NewPortfolioService(portfolioRepo *repository.PortfolioRepository) *PortfolioService {
-	return &PortfolioService{portfolioRepo: portfolioRepo}
+func NewPortfolioService(portfolioRepo *repository.PortfolioRepository, taxRepo *repository.TaxRepository) *PortfolioService {
+	return &PortfolioService{portfolioRepo: portfolioRepo, taxRepo: taxRepo}
 }
 
-// RecordFill updates the caller's portfolio after an order fill.
+// HoldingWithPnL enriches a PortfolioHoldingRecord with live unrealized P&L
+// computed from the holding's preloaded Asset.Price.
+type HoldingWithPnL struct {
+	Holding          *models.PortfolioHoldingRecord
+	CurrentPrice     float64
+	UnrealizedPnL    float64 // (currentPrice - avgBuyPrice) * quantity
+	UnrealizedPnLPct float64 // as a percentage of cost basis
+	MarketValue      float64 // currentPrice * quantity
+}
+
+// RecordFill updates the portfolio after an order fill and creates a TaxRecord
+// for any realised profit on a sell.
 //
 // Buy fill: upsert holding — increase quantity, recalculate weighted avg buy price.
-// Sell fill: decrease quantity, accumulate realized profit on the holding.
+// Sell fill: decrease quantity, accumulate realized profit, create TaxRecord if profit > 0.
 //
-// The effective quantity stored is fillQty × contractSize so that contracts
-// (futures, options) are tracked at the underlying unit level.
+// Effective quantity = fillQty × contractSize.
 func (s *PortfolioService) RecordFill(order *models.OrderRecord, fillQty int64, fillPrice float64) error {
 	effectiveQty := float64(fillQty) * float64(order.ContractSize)
 
 	if order.Direction == "buy" {
 		if err := s.portfolioRepo.RecordBuyFill(
-			order.UserID,
-			order.UserType,
-			order.AssetID,
-			order.AccountID,
-			effectiveQty,
-			fillPrice,
+			order.UserID, order.UserType, order.AssetID, order.AccountID,
+			effectiveQty, fillPrice,
 		); err != nil {
 			return fmt.Errorf("portfolio: failed to record buy fill for order %d: %w", order.ID, err)
 		}
@@ -41,17 +53,66 @@ func (s *PortfolioService) RecordFill(order *models.OrderRecord, fillQty int64, 
 	}
 
 	// Sell: decrease holding and accumulate realized profit.
-	_, err := s.portfolioRepo.RecordSellFill(
-		order.UserID,
-		order.UserType,
-		order.AssetID,
-		effectiveQty,
-		fillPrice,
+	realizedProfit, err := s.portfolioRepo.RecordSellFill(
+		order.UserID, order.UserType, order.AssetID, effectiveQty, fillPrice,
 	)
 	if err != nil {
 		return fmt.Errorf("portfolio: failed to record sell fill for order %d: %w", order.ID, err)
 	}
+
+	// Create a TaxRecord for any capital gain.
+	// profit_rsd and tax_rsd store the profit in the asset's native currency;
+	// Phase 7 (TaxService) applies the RSD conversion before collection.
+	if realizedProfit > 0 {
+		tax := realizedProfit * capitalGainsTaxRate
+		now := time.Now().UTC()
+		record := &models.TaxRecord{
+			UserID:    order.UserID,
+			UserType:  order.UserType,
+			AssetID:   order.AssetID,
+			Period:    now.Format("2006-01"),
+			ProfitRSD: roundPnL(realizedProfit),
+			TaxRSD:    roundPnL(tax),
+			Status:    "unpaid",
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		if err := s.taxRepo.CreateTaxRecord(record); err != nil {
+			// Non-fatal: tax record failure should not block the fill.
+			// Phase 7 cron can reconcile from realized_profit on the holding.
+			_ = err
+		}
+	}
+
 	return nil
+}
+
+// ListHoldingsWithPnL returns all active holdings for a user enriched with
+// live unrealized P&L computed from the preloaded Asset.Price.
+func (s *PortfolioService) ListHoldingsWithPnL(userID uint, userType string) ([]HoldingWithPnL, error) {
+	holdings, err := s.portfolioRepo.ListHoldingsForUser(userID, userType)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]HoldingWithPnL, 0, len(holdings))
+	for i := range holdings {
+		result = append(result, computePnL(&holdings[i]))
+	}
+	return result, nil
+}
+
+// GetHoldingWithPnL returns a single holding enriched with live P&L.
+func (s *PortfolioService) GetHoldingWithPnL(id uint) (*HoldingWithPnL, error) {
+	h, err := s.portfolioRepo.GetHoldingByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if h == nil {
+		return nil, fmt.Errorf("holding not found")
+	}
+	pnl := computePnL(h)
+	return &pnl, nil
 }
 
 // GetHoldingByID returns a single holding by ID.
@@ -74,4 +135,30 @@ func (s *PortfolioService) ListHoldings(userID uint, userType string) ([]models.
 // SetPublic toggles the is_public flag on a holding.
 func (s *PortfolioService) SetPublic(holdingID uint, isPublic bool) error {
 	return s.portfolioRepo.SetHoldingPublic(holdingID, isPublic)
+}
+
+// --- helpers ---
+
+// computePnL enriches a holding with unrealized P&L using the preloaded asset price.
+func computePnL(h *models.PortfolioHoldingRecord) HoldingWithPnL {
+	currentPrice := h.Asset.Price
+	unrealized := roundPnL((currentPrice - h.AvgBuyPrice) * h.Quantity)
+	marketValue := roundPnL(currentPrice * h.Quantity)
+
+	pct := 0.0
+	if h.AvgBuyPrice > 0 {
+		pct = roundPnL(((currentPrice - h.AvgBuyPrice) / h.AvgBuyPrice) * 100)
+	}
+
+	return HoldingWithPnL{
+		Holding:          h,
+		CurrentPrice:     currentPrice,
+		UnrealizedPnL:    unrealized,
+		UnrealizedPnLPct: pct,
+		MarketValue:      marketValue,
+	}
+}
+
+func roundPnL(v float64) float64 {
+	return math.Round(v*100) / 100
 }


### PR DESCRIPTION
## Summary

- Sell fills now create a `TaxRecord` (15% of realised profit) when profit > 0
- `HoldingWithPnL` view model: unrealizedPnL, unrealizedPnLPct, marketValue computed from live asset price
- `TaxRepository`: create, list, sum unpaid, mark paid

## Changes

| Task | Issue | Commit |
|------|-------|--------|
| Task 6.2: P&L + TaxRecord | #167 | 226604e |

## Test plan
- [ ] Sell fill with profit > 0 creates TaxRecord with 15% tax
- [ ] Sell fill with loss creates no TaxRecord
- [ ] ListHoldingsWithPnL returns correct unrealized P&L per holding
- [ ] TaxRecord failure does not block sell fill

🤖 Generated with [Claude Code](https://claude.com/claude-code)