### PR TITLE
PORTFOLIO-BE-3: Option exercise

### DIFF
--- a/exchange-service/internal/repository/market_repository.go
+++ b/exchange-service/internal/repository/market_repository.go
@@ -141,6 +141,31 @@ func (r *MarketRepository) GetOptionsByStockListingID(stockListingID uint) ([]mo
 	return records, nil
 }
 
+// GetListingRecordByID returns a market listing by primary key.
+func (r *MarketRepository) GetListingRecordByID(id uint) (*models.MarketListingRecord, error) {
+	var record models.MarketListingRecord
+	if err := r.db.Preload("Exchange").First(&record, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &record, nil
+}
+
+// GetOptionByListingID returns the OptionRecord whose own listing_id matches
+// (i.e. the option contract's listing, not its underlying stock listing).
+func (r *MarketRepository) GetOptionByListingID(listingID uint) (*models.OptionRecord, error) {
+	var record models.OptionRecord
+	if err := r.db.Preload("Listing").Where("listing_id = ?", listingID).First(&record).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &record, nil
+}
+
 func (r *MarketRepository) GetListingRecordByTicker(ticker string) (*models.MarketListingRecord, error) {
 	var record models.MarketListingRecord
 	if err := r.db.Preload("Exchange").Where("ticker = ?", ticker).First(&record).Error; err != nil {

--- a/exchange-service/internal/repository/portfolio_repository.go
+++ b/exchange-service/internal/repository/portfolio_repository.go
@@ -119,6 +119,22 @@ func (r *PortfolioRepository) RecordSellFill(userID uint, userType string, asset
 	return
 }
 
+// ExerciseOptionHolding zeroes out an option holding's quantity and adds the
+// exercise profit to its cumulative realized_profit.
+func (r *PortfolioRepository) ExerciseOptionHolding(id uint, exerciseProfit float64) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		var h models.PortfolioHoldingRecord
+		if err := tx.First(&h, id).Error; err != nil {
+			return err
+		}
+		return tx.Model(&h).Updates(map[string]interface{}{
+			"quantity":        0,
+			"realized_profit": h.RealizedProfit + exerciseProfit,
+			"updated_at":      time.Now().UTC(),
+		}).Error
+	})
+}
+
 // SetHoldingPublic toggles the is_public flag on a holding (used for OTC shares).
 func (r *PortfolioRepository) SetHoldingPublic(id uint, isPublic bool) error {
 	return r.db.Model(&models.PortfolioHoldingRecord{}).Where("id = ?", id).Updates(map[string]interface{}{

--- a/exchange-service/internal/service/cron_service.go
+++ b/exchange-service/internal/service/cron_service.go
@@ -25,12 +25,15 @@ func StartCronJobs(db *gorm.DB) *cron.Cron {
 	}
 
 	// Order execution engine: attempt to fill active orders every minute.
-	portfolioSvc := NewPortfolioService(repository.NewPortfolioRepository(db), repository.NewTaxRepository(db))
-	executor := NewOrderExecutor(
-		repository.NewOrderRepository(db),
-		repository.NewMarketRepository(db),
-		portfolioSvc,
+	orderRepo := repository.NewOrderRepository(db)
+	marketRepo := repository.NewMarketRepository(db)
+	portfolioSvc := NewPortfolioService(
+		repository.NewPortfolioRepository(db),
+		repository.NewTaxRepository(db),
+		marketRepo,
+		orderRepo,
 	)
+	executor := NewOrderExecutor(orderRepo, marketRepo, portfolioSvc)
 	_, err = c.AddFunc("@every 1m", func() {
 		executor.Run()
 	})

--- a/exchange-service/internal/service/portfolio_service.go
+++ b/exchange-service/internal/service/portfolio_service.go
@@ -9,6 +9,9 @@ import (
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
 )
 
+// optionContractSize is the number of underlying shares per option contract.
+const optionContractSize = 100
+
 const capitalGainsTaxRate = 0.15
 
 // PortfolioService maintains PortfolioHoldingRecords in response to order fills
@@ -16,10 +19,22 @@ const capitalGainsTaxRate = 0.15
 type PortfolioService struct {
 	portfolioRepo *repository.PortfolioRepository
 	taxRepo       *repository.TaxRepository
+	marketRepo    *repository.MarketRepository
+	orderRepo     *repository.OrderRepository
 }
 
-func NewPortfolioService(portfolioRepo *repository.PortfolioRepository, taxRepo *repository.TaxRepository) *PortfolioService {
-	return &PortfolioService{portfolioRepo: portfolioRepo, taxRepo: taxRepo}
+func NewPortfolioService(
+	portfolioRepo *repository.PortfolioRepository,
+	taxRepo *repository.TaxRepository,
+	marketRepo *repository.MarketRepository,
+	orderRepo *repository.OrderRepository,
+) *PortfolioService {
+	return &PortfolioService{
+		portfolioRepo: portfolioRepo,
+		taxRepo:       taxRepo,
+		marketRepo:    marketRepo,
+		orderRepo:     orderRepo,
+	}
 }
 
 // HoldingWithPnL enriches a PortfolioHoldingRecord with live unrealized P&L
@@ -135,6 +150,151 @@ func (s *PortfolioService) ListHoldings(userID uint, userType string) ([]models.
 // SetPublic toggles the is_public flag on a holding.
 func (s *PortfolioService) SetPublic(holdingID uint, isPublic bool) error {
 	return s.portfolioRepo.SetHoldingPublic(holdingID, isPublic)
+}
+
+// ExerciseOption exercises an in-the-money option held in the portfolio.
+//
+// Validations:
+//   - Holding must be an option (listing type == "option")
+//   - Settlement date must not have passed
+//   - Option must be in-the-money (CALL: market > strike; PUT: market < strike)
+//
+// On exercise:
+//   - Creates a synthetic market order + transaction for the underlying stock
+//   - Updates the underlying stock holding (buy for CALL, sell for PUT) at strike price
+//   - Zeroes out the option holding quantity, adds exercise profit to realized_profit
+//   - Creates a TaxRecord if exercise profit > 0
+func (s *PortfolioService) ExerciseOption(holdingID, actuaryID uint) error {
+	// 1. Load the option holding.
+	holding, err := s.portfolioRepo.GetHoldingByID(holdingID)
+	if err != nil || holding == nil {
+		return fmt.Errorf("holding not found")
+	}
+	if holding.Asset.Type != "option" {
+		return fmt.Errorf("holding %d is not an option contract", holdingID)
+	}
+	if holding.Quantity <= 0 {
+		return fmt.Errorf("option holding has no remaining quantity")
+	}
+
+	// 2. Load the OptionRecord for strike price and underlying.
+	opt, err := s.marketRepo.GetOptionByListingID(holding.AssetID)
+	if err != nil || opt == nil {
+		return fmt.Errorf("option contract data not found for asset %d", holding.AssetID)
+	}
+
+	// 3. Validate settlement date.
+	if time.Now().After(opt.SettlementDate) {
+		return fmt.Errorf("option has expired (settlement: %s)", opt.SettlementDate.Format("2006-01-02"))
+	}
+
+	// 4. Load the underlying stock listing for the current market price.
+	underlying, err := s.marketRepo.GetListingRecordByID(opt.StockListingID)
+	if err != nil || underlying == nil {
+		return fmt.Errorf("underlying stock listing not found")
+	}
+
+	marketPrice := underlying.Price
+	strikePrice := opt.StrikePrice
+
+	// 5. Validate in-the-money and determine direction.
+	var direction string
+	var intrinsicValue float64 // per share
+
+	switch opt.OptionType {
+	case "call":
+		if marketPrice <= strikePrice {
+			return fmt.Errorf("CALL option is not in-the-money (market: %.2f, strike: %.2f)", marketPrice, strikePrice)
+		}
+		direction = "buy"
+		intrinsicValue = marketPrice - strikePrice
+	case "put":
+		if marketPrice >= strikePrice {
+			return fmt.Errorf("PUT option is not in-the-money (market: %.2f, strike: %.2f)", marketPrice, strikePrice)
+		}
+		direction = "sell"
+		intrinsicValue = strikePrice - marketPrice
+	default:
+		return fmt.Errorf("unknown option type: %s", opt.OptionType)
+	}
+
+	// Each option contract covers optionContractSize shares.
+	totalShares := int64(holding.Quantity) * optionContractSize
+	exerciseProfit := roundPnL(intrinsicValue * float64(totalShares))
+
+	// 6. Create a synthetic exercise order for the underlying stock.
+	now := time.Now().UTC()
+	exerciseOrder := &models.OrderRecord{
+		UserID:            holding.UserID,
+		UserType:          holding.UserType,
+		AssetID:           underlying.ID,
+		OrderType:         "market",
+		Direction:         direction,
+		Quantity:          totalShares,
+		ContractSize:      1,
+		PricePerUnit:      strikePrice,
+		Status:            "done",
+		IsDone:            true,
+		RemainingPortions: 0,
+		AccountID:         holding.AccountID,
+		LastModification:  now,
+		CreatedAt:         now,
+	}
+	if err := s.orderRepo.CreateOrder(exerciseOrder); err != nil {
+		return fmt.Errorf("failed to create exercise order: %w", err)
+	}
+
+	// 7. Record the fill transaction.
+	txRecord := &models.OrderTransactionRecord{
+		OrderID:      exerciseOrder.ID,
+		Quantity:     totalShares,
+		PricePerUnit: strikePrice,
+		ExecutedAt:   now,
+	}
+	if err := s.orderRepo.CreateOrderTransaction(txRecord); err != nil {
+		return fmt.Errorf("failed to record exercise transaction: %w", err)
+	}
+
+	// 8. Update the underlying stock portfolio holding.
+	if direction == "buy" {
+		if err := s.portfolioRepo.RecordBuyFill(
+			holding.UserID, holding.UserType, underlying.ID, holding.AccountID,
+			float64(totalShares), strikePrice,
+		); err != nil {
+			return fmt.Errorf("failed to update underlying stock holding: %w", err)
+		}
+	} else {
+		if _, err := s.portfolioRepo.RecordSellFill(
+			holding.UserID, holding.UserType, underlying.ID,
+			float64(totalShares), strikePrice,
+		); err != nil {
+			return fmt.Errorf("failed to update underlying stock holding: %w", err)
+		}
+	}
+
+	// 9. Zero out the option holding and record exercise profit.
+	if err := s.portfolioRepo.ExerciseOptionHolding(holdingID, exerciseProfit); err != nil {
+		return fmt.Errorf("failed to close option holding: %w", err)
+	}
+
+	// 10. Create a TaxRecord for the exercise profit if positive.
+	if exerciseProfit > 0 {
+		tax := roundPnL(exerciseProfit * capitalGainsTaxRate)
+		taxRecord := &models.TaxRecord{
+			UserID:    holding.UserID,
+			UserType:  holding.UserType,
+			AssetID:   holding.AssetID,
+			Period:    now.Format("2006-01"),
+			ProfitRSD: exerciseProfit,
+			TaxRSD:    tax,
+			Status:    "unpaid",
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		_ = s.taxRepo.CreateTaxRecord(taxRecord) // non-fatal
+	}
+
+	return nil
 }
 
 // --- helpers ---


### PR DESCRIPTION
## Summary

- `ExerciseOption`: validates ITM + expiry, exercises at strike price
- CALL → buy underlying at strike; PUT → sell underlying at strike
- 100 shares per option contract; profit = intrinsic value × total shares
- Zeroes option holding, creates synthetic order + transaction, TaxRecord on profit

## Changes

| Task | Issue | Commit |
|------|-------|--------|
| Task 6.3: ExerciseOption | #169 | adf520f |

## Test plan
- [ ] OTM option returns error
- [ ] Expired option returns error
- [ ] CALL exercise buys underlying at strike, records profit
- [ ] PUT exercise sells underlying at strike, records profit
- [ ] TaxRecord created when profit > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)