### PR TITLE
POREZ-BE-1: TaxService with RSD conversion for capital gains

### DIFF
--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -42,9 +42,11 @@ func main() {
 	// Build shared repos and services before starting cron so they're reusable.
 	marketRepo := repository.NewMarketRepository(db)
 	orderRepo := repository.NewOrderRepository(db)
+	taxRepo := repository.NewTaxRepository(db)
+	taxSvc := service.NewTaxService(taxRepo, marketRepo)
 	portfolioSvc := service.NewPortfolioService(
 		repository.NewPortfolioRepository(db),
-		repository.NewTaxRepository(db),
+		taxSvc,
 		marketRepo,
 		orderRepo,
 	)

--- a/exchange-service/internal/repository/market_repository.go
+++ b/exchange-service/internal/repository/market_repository.go
@@ -166,6 +166,33 @@ func (r *MarketRepository) GetOptionByListingID(listingID uint) (*models.OptionR
 	return &record, nil
 }
 
+// GetForexRate returns the current exchange rate from baseCurrency to quoteCurrency
+// by looking up the corresponding forex pair listing price.
+// Returns 0, nil when no matching pair exists in the database.
+func (r *MarketRepository) GetForexRate(baseCurrency, quoteCurrency string) (float64, error) {
+	// Direct pair: base→quote
+	row := r.db.Table("forex_pairs").
+		Select("market_listings.price").
+		Joins("JOIN market_listings ON market_listings.id = forex_pairs.listing_id").
+		Where("forex_pairs.base_currency = ? AND forex_pairs.quote_currency = ?", baseCurrency, quoteCurrency).
+		Limit(1).Row()
+	var price float64
+	if err := row.Scan(&price); err == nil && price > 0 {
+		return price, nil
+	}
+	// Inverse pair: quote→base (1/price)
+	row2 := r.db.Table("forex_pairs").
+		Select("market_listings.price").
+		Joins("JOIN market_listings ON market_listings.id = forex_pairs.listing_id").
+		Where("forex_pairs.base_currency = ? AND forex_pairs.quote_currency = ?", quoteCurrency, baseCurrency).
+		Limit(1).Row()
+	var invPrice float64
+	if err := row2.Scan(&invPrice); err == nil && invPrice > 0 {
+		return 1.0 / invPrice, nil
+	}
+	return 0, nil // no pair found
+}
+
 func (r *MarketRepository) GetListingRecordByTicker(ticker string) (*models.MarketListingRecord, error) {
 	var record models.MarketListingRecord
 	if err := r.db.Preload("Exchange").Where("ticker = ?", ticker).First(&record).Error; err != nil {

--- a/exchange-service/internal/service/cron_service.go
+++ b/exchange-service/internal/service/cron_service.go
@@ -26,9 +26,11 @@ func StartCronJobs(db *gorm.DB, portfolioSvc *PortfolioService) *cron.Cron {
 	}
 
 	// Order execution engine: attempt to fill active orders every minute.
-	orderRepo := repository.NewOrderRepository(db)
-	marketRepo := repository.NewMarketRepository(db)
-	executor := NewOrderExecutor(orderRepo, marketRepo, portfolioSvc)
+	executor := NewOrderExecutor(
+		repository.NewOrderRepository(db),
+		repository.NewMarketRepository(db),
+		portfolioSvc,
+	)
 	_, err = c.AddFunc("@every 1m", func() {
 		executor.Run()
 	})

--- a/exchange-service/internal/service/portfolio_service.go
+++ b/exchange-service/internal/service/portfolio_service.go
@@ -12,26 +12,24 @@ import (
 // optionContractSize is the number of underlying shares per option contract.
 const optionContractSize = 100
 
-const capitalGainsTaxRate = 0.15
-
 // PortfolioService maintains PortfolioHoldingRecords in response to order fills
 // and exposes P&L views over the live holdings.
 type PortfolioService struct {
 	portfolioRepo *repository.PortfolioRepository
-	taxRepo       *repository.TaxRepository
+	taxSvc        *TaxService
 	marketRepo    *repository.MarketRepository
 	orderRepo     *repository.OrderRepository
 }
 
 func NewPortfolioService(
 	portfolioRepo *repository.PortfolioRepository,
-	taxRepo *repository.TaxRepository,
+	taxSvc *TaxService,
 	marketRepo *repository.MarketRepository,
 	orderRepo *repository.OrderRepository,
 ) *PortfolioService {
 	return &PortfolioService{
 		portfolioRepo: portfolioRepo,
-		taxRepo:       taxRepo,
+		taxSvc:        taxSvc,
 		marketRepo:    marketRepo,
 		orderRepo:     orderRepo,
 	}
@@ -75,29 +73,16 @@ func (s *PortfolioService) RecordFill(order *models.OrderRecord, fillQty int64, 
 		return fmt.Errorf("portfolio: failed to record sell fill for order %d: %w", order.ID, err)
 	}
 
-	// Create a TaxRecord for any capital gain.
-	// profit_rsd and tax_rsd store the profit in the asset's native currency;
-	// Phase 7 (TaxService) applies the RSD conversion before collection.
-	if realizedProfit > 0 {
-		tax := realizedProfit * capitalGainsTaxRate
-		now := time.Now().UTC()
-		record := &models.TaxRecord{
-			UserID:    order.UserID,
-			UserType:  order.UserType,
-			AssetID:   order.AssetID,
-			Period:    now.Format("2006-01"),
-			ProfitRSD: roundPnL(realizedProfit),
-			TaxRSD:    roundPnL(tax),
-			Status:    "unpaid",
-			CreatedAt: now,
-			UpdatedAt: now,
-		}
-		if err := s.taxRepo.CreateTaxRecord(record); err != nil {
-			// Non-fatal: tax record failure should not block the fill.
-			// Phase 7 cron can reconcile from realized_profit on the holding.
-			_ = err
-		}
-	}
+	// Delegate tax recording to TaxService which handles RSD conversion.
+	// Non-fatal: tax failure does not block the fill.
+	_ = s.taxSvc.RecordCapitalGainTax(
+		order.UserID,
+		order.UserType,
+		order.AssetID,
+		realizedProfit,
+		order.Asset.Type,
+		order.Asset.Exchange.Currency,
+	)
 
 	return nil
 }
@@ -277,22 +262,15 @@ func (s *PortfolioService) ExerciseOption(holdingID, actuaryID uint) error {
 		return fmt.Errorf("failed to close option holding: %w", err)
 	}
 
-	// 10. Create a TaxRecord for the exercise profit if positive.
-	if exerciseProfit > 0 {
-		tax := roundPnL(exerciseProfit * capitalGainsTaxRate)
-		taxRecord := &models.TaxRecord{
-			UserID:    holding.UserID,
-			UserType:  holding.UserType,
-			AssetID:   holding.AssetID,
-			Period:    now.Format("2006-01"),
-			ProfitRSD: exerciseProfit,
-			TaxRSD:    tax,
-			Status:    "unpaid",
-			CreatedAt: now,
-			UpdatedAt: now,
-		}
-		_ = s.taxRepo.CreateTaxRecord(taxRecord) // non-fatal
-	}
+	// 10. Create a TaxRecord for the exercise profit via TaxService (handles RSD conversion).
+	_ = s.taxSvc.RecordCapitalGainTax(
+		holding.UserID,
+		holding.UserType,
+		holding.AssetID,
+		exerciseProfit,
+		"option",
+		underlying.Exchange.Currency,
+	)
 
 	return nil
 }

--- a/exchange-service/internal/service/tax_service.go
+++ b/exchange-service/internal/service/tax_service.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+const (
+	taxRate        = 0.15  // 15% capital gains tax
+	rsdCurrency    = "RSD"
+	fallbackRSDRate = 1.0  // used when no forex pair is found (profit treated as RSD)
+)
+
+// TaxService records capital gains tax for sell transactions.
+type TaxService struct {
+	taxRepo    *repository.TaxRepository
+	marketRepo *repository.MarketRepository
+}
+
+func NewTaxService(taxRepo *repository.TaxRepository, marketRepo *repository.MarketRepository) *TaxService {
+	return &TaxService{taxRepo: taxRepo, marketRepo: marketRepo}
+}
+
+// RecordCapitalGainTax converts the realised profit to RSD and persists a
+// TaxRecord if the profit is positive.
+//
+// Only applies to stock and option assets (not forex or futures).
+//
+// Parameters:
+//   - realizedProfit: already-computed profit in the asset's native currency
+//   - assetType: "stock", "option", "forex", "futures"
+//   - currency: the exchange currency the asset trades in (e.g. "USD", "EUR")
+func (s *TaxService) RecordCapitalGainTax(
+	userID uint,
+	userType string,
+	assetID uint,
+	realizedProfit float64,
+	assetType, currency string,
+) error {
+	// Capital gains tax applies to stocks and options only.
+	if assetType != "stock" && assetType != "option" {
+		return nil
+	}
+
+	if realizedProfit <= 0 {
+		return nil // no taxable gain
+	}
+
+	profit := realizedProfit
+
+	// Convert profit to RSD.
+	profitRSD := s.toRSD(profit, currency)
+	taxRSD := roundPnL(profitRSD * taxRate)
+
+	now := time.Now().UTC()
+	record := &models.TaxRecord{
+		UserID:    userID,
+		UserType:  userType,
+		AssetID:   assetID,
+		Period:    now.Format("2006-01"),
+		ProfitRSD: roundPnL(profitRSD),
+		TaxRSD:    taxRSD,
+		Status:    "unpaid",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := s.taxRepo.CreateTaxRecord(record); err != nil {
+		slog.Error("tax service: failed to create tax record",
+			"userID", userID, "assetID", assetID, "error", err)
+		return err
+	}
+
+	slog.Info("tax service: recorded capital gain",
+		"userID", userID, "assetID", assetID,
+		"profitRSD", profitRSD, "taxRSD", taxRSD, "period", record.Period)
+	return nil
+}
+
+// ListTaxRecords returns all tax records for a user, optionally filtered by period.
+func (s *TaxService) ListTaxRecords(userID uint, userType, period string) ([]models.TaxRecord, error) {
+	return s.taxRepo.ListTaxRecordsForUser(userID, userType, period)
+}
+
+// SumUnpaidTax returns the total unpaid tax for a user in a given period.
+func (s *TaxService) SumUnpaidTax(userID uint, userType, period string) (float64, error) {
+	return s.taxRepo.SumUnpaidTaxForUser(userID, userType, period)
+}
+
+// toRSD converts an amount from the given currency to RSD.
+// Falls back to the original amount when no forex pair is found.
+func (s *TaxService) toRSD(amount float64, currency string) float64 {
+	if currency == rsdCurrency || currency == "" {
+		return amount
+	}
+	rate, err := s.marketRepo.GetForexRate(currency, rsdCurrency)
+	if err != nil || rate == 0 {
+		slog.Warn("tax service: no forex rate found, using 1:1 fallback",
+			"from", currency, "to", rsdCurrency)
+		return amount * fallbackRSDRate
+	}
+	return amount * rate
+}


### PR DESCRIPTION
## Summary

- `TaxService.RecordCapitalGainTax`: applies to stock/option sells, converts to RSD via live forex rate, creates TaxRecord at 15%
- `GetForexRate` in MarketRepository: direct + inverse forex pair lookup
- Replaces inline tax creation in `PortfolioService` — both sell fills and option exercises now go through TaxService

## Changes

| Task | Issue | Commit |
|------|-------|--------|
| Task 7.1: TaxService | #173 | e51811d |

## Test plan
- [ ] Profitable stock sell creates TaxRecord with correct RSD amount
- [ ] Loss sell creates no TaxRecord
- [ ] Forex/futures sells create no TaxRecord
- [ ] USD→RSD rate applied when USD/RSD pair exists in DB
- [ ] Falls back to 1:1 when no forex pair found

🤖 Generated with [Claude Code](https://claude.com/claude-code)