### PR TITLE
feat: monthly tax collection cron (POREZ-BE-2)

### DIFF
--- a/exchange-service/internal/repository/order_repository.go
+++ b/exchange-service/internal/repository/order_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
@@ -178,6 +179,84 @@ func (r *OrderRepository) GetSettlementDate(assetID uint) (*time.Time, error) {
 }
 
 // --- Account helpers (reads from shared DB, account-service tables) ---
+
+// UserRSDAccount holds the ID and available balance of a user's RSD account.
+type UserRSDAccount struct {
+	ID                uint
+	RaspolozivoStanje float64
+}
+
+// GetUserRSDAccounts returns all active RSD-denominated accounts for a user.
+// For clients, matches on client_id; for employees, on zaposleni_id.
+func (r *OrderRepository) GetUserRSDAccounts(userID uint, userType string) ([]UserRSDAccount, error) {
+	q := r.db.Table("accounts").
+		Select("accounts.id, accounts.raspolozivo_stanje").
+		Joins("JOIN currencies ON currencies.id = accounts.currency_id").
+		Where("currencies.kod = 'RSD' AND accounts.status = 'aktivan'")
+
+	if userType == "client" {
+		q = q.Where("accounts.client_id = ?", userID)
+	} else {
+		q = q.Where("accounts.zaposleni_id = ?", userID)
+	}
+
+	rows, err := q.Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var accounts []UserRSDAccount
+	for rows.Next() {
+		var a UserRSDAccount
+		if err := rows.Scan(&a.ID, &a.RaspolozivoStanje); err != nil {
+			return nil, err
+		}
+		accounts = append(accounts, a)
+	}
+	return accounts, nil
+}
+
+// DebitAccount atomically debits amount from an account if sufficient balance exists.
+// Returns an error if the balance is insufficient.
+func (r *OrderRepository) DebitAccount(accountID uint, amount float64) error {
+	result := r.db.Table("accounts").
+		Where("id = ? AND raspolozivo_stanje >= ?", accountID, amount).
+		Updates(map[string]interface{}{
+			"raspolozivo_stanje": gorm.Expr("raspolozivo_stanje - ?", amount),
+			"stanje":             gorm.Expr("stanje - ?", amount),
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("insufficient balance in account %d", accountID)
+	}
+	return nil
+}
+
+// CreditAccount adds amount to an account's balance.
+func (r *OrderRepository) CreditAccount(accountID uint, amount float64) error {
+	return r.db.Table("accounts").
+		Where("id = ?", accountID).
+		Updates(map[string]interface{}{
+			"raspolozivo_stanje": gorm.Expr("raspolozivo_stanje + ?", amount),
+			"stanje":             gorm.Expr("stanje + ?", amount),
+		}).Error
+}
+
+// GetStateTreasuryAccountID returns the ID of the "Republika Srbija" RSD account.
+// Returns 0 if no such account exists.
+func (r *OrderRepository) GetStateTreasuryAccountID() (uint, error) {
+	var id uint
+	err := r.db.Table("accounts").
+		Select("accounts.id").
+		Joins("JOIN currencies ON currencies.id = accounts.currency_id").
+		Where("LOWER(accounts.naziv) LIKE '%republika srbija%' AND currencies.kod = 'RSD' AND accounts.status = 'aktivan'").
+		Limit(1).
+		Scan(&id).Error
+	return id, err
+}
 
 // GetAccountBalance returns the raspolozivo_stanje (available balance) and currency_kod for an account.
 func (r *OrderRepository) GetAccountBalance(accountID uint) (balance float64, currencyKod string, err error) {

--- a/exchange-service/internal/repository/tax_repository.go
+++ b/exchange-service/internal/repository/tax_repository.go
@@ -41,6 +41,35 @@ func (r *TaxRepository) SumUnpaidTaxForUser(userID uint, userType, period string
 	return total, err
 }
 
+// TaxableUser identifies a user who has unpaid tax records.
+type TaxableUser struct {
+	UserID   uint
+	UserType string
+}
+
+// ListDistinctUsersWithUnpaidTax returns all unique users who have unpaid tax
+// records for the given period.
+func (r *TaxRepository) ListDistinctUsersWithUnpaidTax(period string) ([]TaxableUser, error) {
+	rows, err := r.db.Model(&models.TaxRecord{}).
+		Select("DISTINCT user_id, user_type").
+		Where("period = ? AND status = 'unpaid'", period).
+		Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []TaxableUser
+	for rows.Next() {
+		var u TaxableUser
+		if err := rows.Scan(&u.UserID, &u.UserType); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	return users, nil
+}
+
 // MarkTaxRecordsPaid marks all unpaid records for a user+period as paid.
 func (r *TaxRepository) MarkTaxRecordsPaid(userID uint, userType, period string) error {
 	return r.db.Model(&models.TaxRecord{}).

--- a/exchange-service/internal/service/cron_service.go
+++ b/exchange-service/internal/service/cron_service.go
@@ -26,16 +26,33 @@ func StartCronJobs(db *gorm.DB, portfolioSvc *PortfolioService) *cron.Cron {
 	}
 
 	// Order execution engine: attempt to fill active orders every minute.
-	executor := NewOrderExecutor(
-		repository.NewOrderRepository(db),
-		repository.NewMarketRepository(db),
-		portfolioSvc,
-	)
+	orderRepo := repository.NewOrderRepository(db)
+	marketRepo := repository.NewMarketRepository(db)
+	executor := NewOrderExecutor(orderRepo, marketRepo, portfolioSvc)
 	_, err = c.AddFunc("@every 1m", func() {
 		executor.Run()
 	})
 	if err != nil {
 		slog.Error("Failed to add order executor cron job", "error", err)
+	}
+
+	// Monthly tax collection: runs at 02:00 on the 1st of each month.
+	taxRepo := repository.NewTaxRepository(db)
+	taxSvc := NewTaxService(taxRepo, marketRepo)
+	taxCollector := NewTaxCollector(taxSvc, orderRepo, taxRepo)
+	_, err = c.AddFunc("0 2 1 * *", func() {
+		period := PreviousMonthPeriod()
+		slog.Info("Starting monthly tax collection", "period", period)
+		res := taxCollector.CollectForPeriod(period)
+		slog.Info("Monthly tax collection finished",
+			"period", res.Period,
+			"users_processed", res.UsersProcessed,
+			"total_collected_rsd", res.TotalCollected,
+			"debts", len(res.Debts),
+		)
+	})
+	if err != nil {
+		slog.Error("Failed to add tax collection cron job", "error", err)
 	}
 
 	c.Start()

--- a/exchange-service/internal/service/tax_cron.go
+++ b/exchange-service/internal/service/tax_cron.go
@@ -1,0 +1,133 @@
+package service
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// TaxCollector handles monthly tax collection from users' RSD accounts.
+type TaxCollector struct {
+	taxSvc    *TaxService
+	orderRepo *repository.OrderRepository
+	taxRepo   *repository.TaxRepository
+}
+
+// NewTaxCollector creates a new TaxCollector.
+func NewTaxCollector(taxSvc *TaxService, orderRepo *repository.OrderRepository, taxRepo *repository.TaxRepository) *TaxCollector {
+	return &TaxCollector{
+		taxSvc:    taxSvc,
+		orderRepo: orderRepo,
+		taxRepo:   taxRepo,
+	}
+}
+
+// TaxDebt represents a failed collection for a user.
+type TaxDebt struct {
+	UserID   uint
+	UserType string
+	Amount   float64
+	Reason   string
+}
+
+// CollectionResult summarises the outcome of a tax collection run.
+type CollectionResult struct {
+	Period         string
+	UsersProcessed int
+	TotalCollected float64
+	Debts          []TaxDebt
+}
+
+// CollectForPeriod collects all unpaid capital-gains tax for the given period
+// (format "YYYY-MM") by debiting users' RSD accounts and crediting the state
+// treasury account.  Users who cannot pay are recorded as debts.
+func (c *TaxCollector) CollectForPeriod(period string) CollectionResult {
+	result := CollectionResult{Period: period}
+
+	users, err := c.taxRepo.ListDistinctUsersWithUnpaidTax(period)
+	if err != nil {
+		slog.Error("tax_cron: failed to list users with unpaid tax", "period", period, "error", err)
+		return result
+	}
+
+	treasuryID, err := c.orderRepo.GetStateTreasuryAccountID()
+	if err != nil {
+		slog.Error("tax_cron: failed to get state treasury account", "error", err)
+		return result
+	}
+	if treasuryID == 0 {
+		slog.Warn("tax_cron: state treasury account not found, skipping collection", "period", period)
+		return result
+	}
+
+	for _, u := range users {
+		totalOwed, err := c.taxRepo.SumUnpaidTaxForUser(u.UserID, u.UserType, period)
+		if err != nil || totalOwed <= 0 {
+			continue
+		}
+
+		accounts, err := c.orderRepo.GetUserRSDAccounts(u.UserID, u.UserType)
+		if err != nil {
+			slog.Warn("tax_cron: cannot get RSD accounts for user", "userID", u.UserID, "error", err)
+			result.Debts = append(result.Debts, TaxDebt{
+				UserID:   u.UserID,
+				UserType: u.UserType,
+				Amount:   totalOwed,
+				Reason:   fmt.Sprintf("failed to retrieve RSD accounts: %v", err),
+			})
+			continue
+		}
+
+		// Attempt to debit the full tax amount from the first account with
+		// sufficient balance.
+		collected := false
+		for _, acc := range accounts {
+			if acc.RaspolozivoStanje < totalOwed {
+				continue
+			}
+			if err := c.orderRepo.DebitAccount(acc.ID, totalOwed); err != nil {
+				continue
+			}
+			// Credit the state treasury.
+			if err := c.orderRepo.CreditAccount(treasuryID, totalOwed); err != nil {
+				// Best-effort: log but don't roll back the debit (treasury credit
+				// failure is an operational issue, not a user-facing one).
+				slog.Error("tax_cron: failed to credit treasury", "userID", u.UserID, "amount", totalOwed, "error", err)
+			}
+			if err := c.taxRepo.MarkTaxRecordsPaid(u.UserID, u.UserType, period); err != nil {
+				slog.Error("tax_cron: failed to mark records paid", "userID", u.UserID, "error", err)
+			}
+			result.TotalCollected += totalOwed
+			collected = true
+			break
+		}
+
+		if !collected {
+			result.Debts = append(result.Debts, TaxDebt{
+				UserID:   u.UserID,
+				UserType: u.UserType,
+				Amount:   totalOwed,
+				Reason:   "insufficient balance in all RSD accounts",
+			})
+		}
+
+		result.UsersProcessed++
+	}
+
+	slog.Info("tax_cron: collection complete",
+		"period", period,
+		"users_processed", result.UsersProcessed,
+		"total_collected_rsd", result.TotalCollected,
+		"debts", len(result.Debts),
+	)
+	return result
+}
+
+// PreviousMonthPeriod returns the "YYYY-MM" string for the calendar month
+// preceding the current month.
+func PreviousMonthPeriod() string {
+	t := time.Now().UTC().AddDate(0, -1, 0)
+	return fmt.Sprintf("%d-%02d", t.Year(), t.Month())
+}


### PR DESCRIPTION
## Summary
- Adds `TaxCollector` with `CollectForPeriod` that processes all unpaid capital-gains tax each month
- Wires monthly cron job at 02:00 on the 1st of each month into `StartCronJobs`
- Adds `GetUserRSDAccounts`, `DebitAccount`, `CreditAccount`, `GetStateTreasuryAccountID` to `OrderRepository`
- Adds `ListDistinctUsersWithUnpaidTax` to `TaxRepository`

Closes #175

## Test plan
- [ ] Build passes (`go build ./...`)
- [ ] `CollectForPeriod` debits user accounts and credits state treasury
- [ ] Users with insufficient balance appear in `Debts` list, records remain unpaid
- [ ] Cron entry appears at startup (`Exchange-service cron jobs started jobs=3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)