### PR TITLE
feat: tax HTTP handler — collect + records + summary (POREZ-BE-3)

### DIFF
--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -70,6 +70,9 @@ func main() {
 	orderH := handler.NewOrderHTTPHandler(cfg, orderSvc)
 	portfolioH := handler.NewPortfolioHTTPHandler(cfg, portfolioSvc)
 
+	taxCollector := service.NewTaxCollector(taxSvc, orderRepo, taxRepo)
+	taxH := handler.NewTaxHTTPHandler(cfg, taxSvc, taxCollector)
+
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
 			middleware.LoggingInterceptor(),
@@ -114,6 +117,7 @@ func main() {
 	httpMux.Handle("/api/v1/portfolio/", middleware.CORS(http.HandlerFunc(portfolioH.PortfolioRoutes)))
 	httpMux.Handle("/api/v1/orders", middleware.CORS(http.HandlerFunc(orderH.OrdersCollection)))
 	httpMux.Handle("/api/v1/orders/", middleware.CORS(http.HandlerFunc(orderH.OrderRoutes)))
+	httpMux.Handle("/api/v1/tax/", middleware.CORS(http.HandlerFunc(taxH.TaxRoutes)))
 	httpMux.Handle("/", middleware.CORS(gwMux))
 
 	httpServer := &http.Server{

--- a/exchange-service/internal/handler/tax_http_handler.go
+++ b/exchange-service/internal/handler/tax_http_handler.go
@@ -1,0 +1,196 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/util"
+)
+
+// TaxHTTPHandler exposes manual tax-collection trigger and record query endpoints.
+type TaxHTTPHandler struct {
+	cfg       *config.Config
+	taxSvc    *service.TaxService
+	collector *service.TaxCollector
+}
+
+func NewTaxHTTPHandler(cfg *config.Config, taxSvc *service.TaxService, collector *service.TaxCollector) *TaxHTTPHandler {
+	return &TaxHTTPHandler{cfg: cfg, taxSvc: taxSvc, collector: collector}
+}
+
+// TaxRoutes handles paths under /api/v1/tax/.
+//
+//	POST /api/v1/tax/collect              — supervisor: trigger collection for a given period
+//	GET  /api/v1/tax/records              — supervisor: list all records, filterable
+//	GET  /api/v1/tax/summary/{userId}     — supervisor or the user themselves
+func (h *TaxHTTPHandler) TaxRoutes(w http.ResponseWriter, r *http.Request) {
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/tax"), "/")
+
+	switch {
+	case path == "collect" && r.Method == http.MethodPost:
+		h.triggerCollection(w, r)
+	case path == "records" && r.Method == http.MethodGet:
+		h.listRecords(w, r)
+	case strings.HasPrefix(path, "summary/"):
+		h.getUserSummary(w, r, strings.TrimPrefix(path, "summary/"))
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// POST /api/v1/tax/collect
+// Body (optional JSON): { "period": "YYYY-MM" }  — defaults to previous month.
+func (h *TaxHTTPHandler) triggerCollection(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireSupervisorHTTP(w, claims) {
+		return
+	}
+
+	period := service.PreviousMonthPeriod()
+	var body struct {
+		Period string `json:"period"`
+	}
+	// Ignore decode errors — body is optional.
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	r.Body.Close()
+	if body.Period != "" {
+		period = body.Period
+	}
+
+	result := h.collector.CollectForPeriod(period)
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"period":          result.Period,
+		"users_processed": result.UsersProcessed,
+		"total_collected": result.TotalCollected,
+		"debts":           result.Debts,
+	})
+}
+
+// GET /api/v1/tax/records
+// Query params: userId (optional), userType (optional), period (optional)
+func (h *TaxHTTPHandler) listRecords(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireSupervisorHTTP(w, claims) {
+		return
+	}
+
+	q := r.URL.Query()
+	period := q.Get("period")
+
+	var recs []models.TaxRecord
+	var err error
+
+	if uidStr := q.Get("userId"); uidStr != "" {
+		uid, parseErr := strconv.ParseUint(uidStr, 10, 64)
+		if parseErr != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid userId"})
+			return
+		}
+		recs, err = h.taxSvc.ListTaxRecords(uint(uid), q.Get("userType"), period)
+	} else {
+		recs, err = h.taxSvc.ListAllTaxRecords(period)
+	}
+
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to list records"})
+		return
+	}
+
+	h.writeRecordsJSON(w, recs)
+}
+
+// GET /api/v1/tax/summary/{userId}
+// Query params: userType (employee|client), period
+func (h *TaxHTTPHandler) getUserSummary(w http.ResponseWriter, r *http.Request, userIDStr string) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+
+	uid, err := strconv.ParseUint(userIDStr, 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid userId"})
+		return
+	}
+	targetUserID := uint(uid)
+	userType := r.URL.Query().Get("userType")
+	if userType == "" {
+		userType = "client"
+	}
+
+	if !isSupervisor(claims) && !isCallerSelf(claims, targetUserID, userType) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "access denied"})
+		return
+	}
+
+	period := r.URL.Query().Get("period")
+
+	totalUnpaid, err := h.taxSvc.SumUnpaidTax(targetUserID, userType, period)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to compute tax summary"})
+		return
+	}
+
+	records, err := h.taxSvc.ListTaxRecords(targetUserID, userType, period)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to list tax records"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"user_id":      targetUserID,
+		"user_type":    userType,
+		"period":       period,
+		"total_unpaid": totalUnpaid,
+		"record_count": len(records),
+	})
+}
+
+// --- helpers ---
+
+func isCallerSelf(claims *util.Claims, targetUserID uint, targetUserType string) bool {
+	uid, utype := callerIdentity(claims)
+	return uid == targetUserID && utype == targetUserType
+}
+
+type taxRecordResponse struct {
+	ID        uint      `json:"id"`
+	UserID    uint      `json:"user_id"`
+	UserType  string    `json:"user_type"`
+	AssetID   uint      `json:"asset_id"`
+	ProfitRSD float64   `json:"profit_rsd"`
+	TaxRSD    float64   `json:"tax_rsd"`
+	Period    string    `json:"period"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+func (h *TaxHTTPHandler) writeRecordsJSON(w http.ResponseWriter, recs []models.TaxRecord) {
+	out := make([]taxRecordResponse, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, taxRecordResponse{
+			ID:        rec.ID,
+			UserID:    rec.UserID,
+			UserType:  rec.UserType,
+			AssetID:   rec.AssetID,
+			ProfitRSD: rec.ProfitRSD,
+			TaxRSD:    rec.TaxRSD,
+			Period:    rec.Period,
+			Status:    rec.Status,
+			CreatedAt: rec.CreatedAt,
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}

--- a/exchange-service/internal/repository/tax_repository.go
+++ b/exchange-service/internal/repository/tax_repository.go
@@ -41,6 +41,20 @@ func (r *TaxRepository) SumUnpaidTaxForUser(userID uint, userType, period string
 	return total, err
 }
 
+// ListAllTaxRecords returns all tax records, optionally filtered by period.
+// Intended for supervisor use only.
+func (r *TaxRepository) ListAllTaxRecords(period string) ([]models.TaxRecord, error) {
+	q := r.db.Model(&models.TaxRecord{})
+	if period != "" {
+		q = q.Where("period = ?", period)
+	}
+	var records []models.TaxRecord
+	if err := q.Order("period DESC, user_id ASC").Find(&records).Error; err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
 // TaxableUser identifies a user who has unpaid tax records.
 type TaxableUser struct {
 	UserID   uint

--- a/exchange-service/internal/service/tax_service.go
+++ b/exchange-service/internal/service/tax_service.go
@@ -85,6 +85,12 @@ func (s *TaxService) ListTaxRecords(userID uint, userType, period string) ([]mod
 	return s.taxRepo.ListTaxRecordsForUser(userID, userType, period)
 }
 
+// ListAllTaxRecords returns all tax records for all users (supervisor view), optionally
+// filtered by period.
+func (s *TaxService) ListAllTaxRecords(period string) ([]models.TaxRecord, error) {
+	return s.taxRepo.ListAllTaxRecords(period)
+}
+
 // SumUnpaidTax returns the total unpaid tax for a user in a given period.
 func (s *TaxService) SumUnpaidTax(userID uint, userType, period string) (float64, error) {
 	return s.taxRepo.SumUnpaidTaxForUser(userID, userType, period)


### PR DESCRIPTION
## Summary
- `POST /api/v1/tax/collect` — supervisor triggers `CollectForPeriod`; period defaults to previous month or is passed in body
- `GET /api/v1/tax/records` — supervisor lists all tax records, filterable by userId/userType/period
- `GET /api/v1/tax/summary/{userId}` — supervisor or user themselves: total unpaid RSD + record count
- `ListAllTaxRecords` added to `TaxService` and `TaxRepository` for all-users supervisor view

Closes #177

## Test plan
- [ ] Build passes (`go build ./...`)
- [ ] `POST /api/v1/tax/collect` with supervisor JWT triggers collection and returns summary
- [ ] `GET /api/v1/tax/records` without userId returns all records; with userId filters correctly
- [ ] `GET /api/v1/tax/summary/{userId}` forbidden for different user, allowed for supervisor or self

🤖 Generated with [Claude Code](https://claude.com/claude-code)