### PR TITLE
feat(tax): expose paid_this_year in tax summary endpoint

### DIFF
--- a/exchange-service/internal/handler/tax_http_handler.go
+++ b/exchange-service/internal/handler/tax_http_handler.go
@@ -136,10 +136,20 @@ func (h *TaxHTTPHandler) getUserSummary(w http.ResponseWriter, r *http.Request, 
 	}
 
 	period := r.URL.Query().Get("period")
+	year := r.URL.Query().Get("year")
+	if year == "" {
+		year = time.Now().UTC().Format("2006")
+	}
 
 	totalUnpaid, err := h.taxSvc.SumUnpaidTax(targetUserID, userType, period)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to compute tax summary"})
+		return
+	}
+
+	paidThisYear, err := h.taxSvc.SumPaidTaxForYear(targetUserID, userType, year)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to compute paid tax"})
 		return
 	}
 
@@ -150,11 +160,12 @@ func (h *TaxHTTPHandler) getUserSummary(w http.ResponseWriter, r *http.Request, 
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"user_id":      targetUserID,
-		"user_type":    userType,
-		"period":       period,
-		"total_unpaid": totalUnpaid,
-		"record_count": len(records),
+		"user_id":        targetUserID,
+		"user_type":      userType,
+		"period":         period,
+		"total_unpaid":   totalUnpaid,
+		"paid_this_year": paidThisYear,
+		"record_count":   len(records),
 	})
 }
 

--- a/exchange-service/internal/repository/tax_repository.go
+++ b/exchange-service/internal/repository/tax_repository.go
@@ -41,6 +41,16 @@ func (r *TaxRepository) SumUnpaidTaxForUser(userID uint, userType, period string
 	return total, err
 }
 
+// SumPaidTaxForUserYear returns the total paid tax amount for a user in a given year (e.g. "2026").
+func (r *TaxRepository) SumPaidTaxForUserYear(userID uint, userType, year string) (float64, error) {
+	var total float64
+	err := r.db.Model(&models.TaxRecord{}).
+		Where("user_id = ? AND user_type = ? AND period LIKE ? AND status = 'paid'", userID, userType, year+"-%").
+		Select("COALESCE(SUM(tax_rsd), 0)").
+		Scan(&total).Error
+	return total, err
+}
+
 // ListAllTaxRecords returns all tax records, optionally filtered by period.
 // Intended for supervisor use only.
 func (r *TaxRepository) ListAllTaxRecords(period string) ([]models.TaxRecord, error) {

--- a/exchange-service/internal/service/tax_service.go
+++ b/exchange-service/internal/service/tax_service.go
@@ -96,6 +96,11 @@ func (s *TaxService) SumUnpaidTax(userID uint, userType, period string) (float64
 	return s.taxRepo.SumUnpaidTaxForUser(userID, userType, period)
 }
 
+// SumPaidTaxForYear returns the total paid tax for a user in a given calendar year (e.g. "2026").
+func (s *TaxService) SumPaidTaxForYear(userID uint, userType, year string) (float64, error) {
+	return s.taxRepo.SumPaidTaxForUserYear(userID, userType, year)
+}
+
 // toRSD converts an amount from the given currency to RSD.
 // Falls back to the original amount when no forex pair is found.
 func (s *TaxService) toRSD(amount float64, currency string) float64 {


### PR DESCRIPTION
## Summary
- Added `SumPaidTaxForUserYear` to `TaxRepository` (LIKE filter on period column)
- Added `SumPaidTaxForYear` to `TaxService`
- Updated `GET /api/v1/tax/summary/{userId}` to return `paid_this_year` alongside `total_unpaid`

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)