### PR TITLE
ci: add GitHub Actions CI/CD workflows for all backend services

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,44 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-push:
+    name: Build & Push (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - auth-service
+          - employee-service
+          - client-service
+          - account-service
+          - transfer-service
+          - payment-service
+          - exchange-service
+          - loan-service
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.service }}
+          file: ${{ matrix.service }}/Dockerfile
+          push: true
+          tags: ghcr.io/iplucki/exbanka-3-${{ matrix.service }}:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,90 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - auth-service
+          - employee-service
+          - client-service
+          - account-service
+          - transfer-service
+          - payment-service
+          - exchange-service
+          - loan-service
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: ${{ matrix.service }}/go.mod
+          cache-dependency-path: ${{ matrix.service }}/go.sum
+
+      - name: go mod tidy check
+        working-directory: ${{ matrix.service }}
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
+      - name: gofmt check
+        working-directory: ${{ matrix.service }}
+        run: |
+          output=$(gofmt -l .)
+          if [ -n "$output" ]; then
+            echo "Files not formatted with gofmt:"
+            echo "$output"
+            exit 1
+          fi
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          working-directory: ${{ matrix.service }}
+          version: latest
+
+  build-and-test:
+    name: Build & Test (${{ matrix.service }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - auth-service
+          - employee-service
+          - client-service
+          - account-service
+          - transfer-service
+          - payment-service
+          - exchange-service
+          - loan-service
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: ${{ matrix.service }}/go.mod
+          cache-dependency-path: ${{ matrix.service }}/go.sum
+
+      - name: Build
+        working-directory: ${{ matrix.service }}
+        run: go build ./cmd/server
+
+      - name: Test
+        working-directory: ${{ matrix.service }}
+        run: go test ./...
+
+      - name: Docker build (no push)
+        run: |
+          docker build -f ${{ matrix.service }}/Dockerfile ${{ matrix.service }}/


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` — lint (golangci-lint, gofmt, go mod tidy) + build-and-test (go build, go test, docker build) via matrix strategy for all 8 services
- `.github/workflows/cd.yml` — build and push Docker images to GHCR on push to main

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)