### PR TITLE
fix(order): supervisors see all orders and declined buys get refunded

### DIFF
--- a/exchange-service/internal/handler/order_http_handler.go
+++ b/exchange-service/internal/handler/order_http_handler.go
@@ -136,20 +136,28 @@ func (h *OrderHTTPHandler) listOrders(w http.ResponseWriter, r *http.Request) {
 	statusFilter := r.URL.Query().Get("status")
 	userID, userType := callerIdentity(claims)
 
-	// Supervisors can optionally filter by a different user via ?userId=N&userType=employee|client
+	var orders []models.OrderRecord
+	var err error
+
 	if util.HasPermission(claims, models.PermEmployeeSupervisor) {
+		// Supervisors see ALL orders by default.
+		// Optionally narrow to a specific user via ?userId=N&userType=employee|client
 		if uidStr := r.URL.Query().Get("userId"); uidStr != "" {
-			uid, err := strconv.ParseUint(uidStr, 10, 64)
-			if err == nil {
+			uid, parseErr := strconv.ParseUint(uidStr, 10, 64)
+			if parseErr == nil {
 				userID = uint(uid)
 				if ut := r.URL.Query().Get("userType"); ut != "" {
 					userType = ut
 				}
 			}
+			orders, err = h.svc.ListOrdersForUser(userID, userType, statusFilter)
+		} else {
+			orders, err = h.svc.ListAllOrders(statusFilter)
 		}
+	} else {
+		orders, err = h.svc.ListOrdersForUser(userID, userType, statusFilter)
 	}
 
-	orders, err := h.svc.ListOrdersForUser(userID, userType, statusFilter)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to load orders"})
 		return

--- a/exchange-service/internal/repository/order_repository.go
+++ b/exchange-service/internal/repository/order_repository.go
@@ -49,6 +49,20 @@ func (r *OrderRepository) ListOrdersForUser(userID uint, userType, statusFilter 
 	return records, nil
 }
 
+// ListAllOrders returns all orders across all users, optionally filtered by status.
+// Used by supervisors to review orders from all agents.
+func (r *OrderRepository) ListAllOrders(statusFilter string) ([]models.OrderRecord, error) {
+	q := r.db.Preload("Asset").Preload("Asset.Exchange")
+	if statusFilter != "" {
+		q = q.Where("status = ?", statusFilter)
+	}
+	var records []models.OrderRecord
+	if err := q.Order("created_at DESC").Find(&records).Error; err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
 // ListPendingActiveOrders returns all orders that are approved/pending and not done,
 // used by the execution engine cron.
 func (r *OrderRepository) ListPendingActiveOrders() ([]models.OrderRecord, error) {

--- a/exchange-service/internal/service/order_executor.go
+++ b/exchange-service/internal/service/order_executor.go
@@ -78,6 +78,14 @@ func (e *OrderExecutor) Run() {
 			// Non-fatal: order fill is committed; portfolio can be reconciled later.
 		}
 
+		// Credit account for sell fills.
+		if order.Direction == "sell" {
+			fillAmount := round2(float64(fillQty) * float64(order.ContractSize) * price)
+			if err := e.orderRepo.CreditAccount(order.AccountID, fillAmount); err != nil {
+				slog.Error("order executor: failed to credit account on sell", "orderID", order.ID, "error", err)
+			}
+		}
+
 		slog.Info("order executor: filled",
 			"orderID", order.ID,
 			"type", order.OrderType,

--- a/exchange-service/internal/service/order_service.go
+++ b/exchange-service/internal/service/order_service.go
@@ -108,6 +108,15 @@ func (s *OrderService) CreateOrder(input CreateOrderInput) (*CreateOrderResult, 
 		}
 	}
 
+	// For buy orders, debit the full order value + commission from the account upfront.
+	// On cancel, RefundToAccount returns the unfilled portion (without commission).
+	if input.Direction == "buy" {
+		totalDebit := round2(totalPrice + commission)
+		if err := s.orderRepo.DebitAccount(input.AccountID, totalDebit); err != nil {
+			return nil, fmt.Errorf("insufficient funds: %w", err)
+		}
+	}
+
 	now := time.Now().UTC()
 	order := &models.OrderRecord{
 		UserID:            input.UserID,
@@ -212,6 +221,7 @@ func (s *OrderService) ApproveOrder(orderID, supervisorID uint) error {
 }
 
 // DeclineOrder declines a pending order on behalf of a supervisor.
+// For buy orders the full debit (order value + commission) is refunded.
 func (s *OrderService) DeclineOrder(orderID, supervisorID uint) error {
 	order, err := s.orderRepo.GetOrderByID(orderID)
 	if err != nil {
@@ -223,6 +233,16 @@ func (s *OrderService) DeclineOrder(orderID, supervisorID uint) error {
 	if order.Status != "pending" {
 		return fmt.Errorf("order is not pending (status: %s)", order.Status)
 	}
+
+	// Refund the full debit that was taken on creation.
+	if order.Direction == "buy" {
+		totalPrice := round2(float64(order.Quantity) * float64(order.ContractSize) * order.PricePerUnit)
+		refund := round2(totalPrice + order.Commission)
+		if err := s.orderRepo.RefundToAccount(order.AccountID, refund); err != nil {
+			return fmt.Errorf("failed to refund account on decline: %w", err)
+		}
+	}
+
 	return s.orderRepo.UpdateOrderStatus(orderID, "declined", &supervisorID)
 }
 
@@ -298,6 +318,11 @@ func (s *OrderService) GetOrder(id uint) (*models.OrderRecord, error) {
 // ListOrdersForUser returns orders for a user with optional status filter.
 func (s *OrderService) ListOrdersForUser(userID uint, userType, statusFilter string) ([]models.OrderRecord, error) {
 	return s.orderRepo.ListOrdersForUser(userID, userType, statusFilter)
+}
+
+// ListAllOrders returns all orders across all users, used by supervisors.
+func (s *OrderService) ListAllOrders(statusFilter string) ([]models.OrderRecord, error) {
+	return s.orderRepo.ListAllOrders(statusFilter)
 }
 
 // ListTransactionsForOrder returns all fill events for an order.


### PR DESCRIPTION
- listOrders now returns all orders for supervisors (not just their own); passing ?userId=N still narrows to a specific user
- DeclineOrder refunds the full debit (order value + commission) for buy orders so money is not lost when a supervisor rejects a pending order
- ListAllOrders added to repository and service layers