### PR TITLE
fix(order): sell commission, stop-limit trigger, order type auto-dete…

### DIFF
--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	exchangev1 "github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/gen/proto/exchange/v1"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
@@ -39,11 +40,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Shared rate provider: same static rates used by the exchange rates page, with caching.
+	staticRates := provider.NewStaticRateProvider()
+	rateProvider := provider.NewCachedProvider(staticRates, staticRates, 24*time.Hour)
+
 	// Build shared repos and services before starting cron so they're reusable.
 	marketRepo := repository.NewMarketRepository(db)
 	orderRepo := repository.NewOrderRepository(db)
 	taxRepo := repository.NewTaxRepository(db)
-	taxSvc := service.NewTaxService(taxRepo, marketRepo)
+	taxSvc := service.NewTaxService(taxRepo, marketRepo, rateProvider)
 	portfolioSvc := service.NewPortfolioService(
 		repository.NewPortfolioRepository(db),
 		taxSvc,
@@ -51,7 +56,7 @@ func main() {
 		orderRepo,
 	)
 
-	cronScheduler := service.StartCronJobs(db, portfolioSvc)
+	cronScheduler := service.StartCronJobs(db, portfolioSvc, rateProvider)
 
 	go func() {
 		slog.Info("Running market data seed in background...")
@@ -66,7 +71,7 @@ func main() {
 	marketSvc := service.NewMarketService(marketProvider)
 	marketH := handler.NewMarketHTTPHandler(cfg, marketSvc, marketRepo)
 
-	orderSvc := service.NewOrderService(orderRepo, marketRepo)
+	orderSvc := service.NewOrderService(orderRepo, marketRepo, rateProvider)
 	orderH := handler.NewOrderHTTPHandler(cfg, orderSvc)
 	portfolioH := handler.NewPortfolioHTTPHandler(cfg, portfolioSvc)
 

--- a/exchange-service/internal/handler/market_http_handler.go
+++ b/exchange-service/internal/handler/market_http_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -12,6 +13,48 @@ import (
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
 )
+
+const bsRiskFreeRate = 0.05 // 5% annual risk-free rate used in Black-Scholes
+
+// blackScholesTheta computes the daily theta (time decay) for an option using Black-Scholes.
+// Returns the change in option value per day (always negative for long positions).
+// Returns 0 if the option has already expired or inputs are invalid.
+func blackScholesTheta(stockPrice, strikePrice, impliedVolatility float64, settlementDate time.Time, optionType string) float64 {
+	T := time.Until(settlementDate).Hours() / (365.0 * 24.0) // time to expiry in years
+	if T <= 0 || stockPrice <= 0 || strikePrice <= 0 || impliedVolatility <= 0 {
+		return 0
+	}
+
+	S := stockPrice
+	K := strikePrice
+	sigma := impliedVolatility
+	r := bsRiskFreeRate
+	sqrtT := math.Sqrt(T)
+
+	d1 := (math.Log(S/K) + (r+sigma*sigma/2)*T) / (sigma * sqrtT)
+	d2 := d1 - sigma*sqrtT
+
+	// Standard normal PDF at d1
+	nPrimeD1 := math.Exp(-d1*d1/2) / math.Sqrt(2*math.Pi)
+
+	firstTerm := -(S * sigma * nPrimeD1) / (2 * sqrtT)
+
+	var annualTheta float64
+	if optionType == "call" {
+		annualTheta = firstTerm - r*K*math.Exp(-r*T)*normalCDF(d2)
+	} else { // put
+		annualTheta = firstTerm + r*K*math.Exp(-r*T)*normalCDF(-d2)
+	}
+
+	// Convert to daily theta and round to 4 decimal places
+	daily := annualTheta / 365.0
+	return math.Round(daily*10000) / 10000
+}
+
+// normalCDF is the standard normal cumulative distribution function.
+func normalCDF(x float64) float64 {
+	return 0.5 * math.Erfc(-x/math.Sqrt2)
+}
 
 type MarketHTTPHandler struct {
 	cfg  *config.Config
@@ -182,6 +225,7 @@ func (h *MarketHTTPHandler) ListingRoutes(w http.ResponseWriter, r *http.Request
 		}
 		optionItems := make([]map[string]interface{}, 0, len(options))
 		for _, opt := range options {
+			theta := blackScholesTheta(record.Price, opt.StrikePrice, opt.ImpliedVolatility, opt.SettlementDate, opt.OptionType)
 			optionItems = append(optionItems, map[string]interface{}{
 				"ticker":            opt.Listing.Ticker,
 				"name":              opt.Listing.Name,
@@ -194,6 +238,7 @@ func (h *MarketHTTPHandler) ListingRoutes(w http.ResponseWriter, r *http.Request
 				"impliedVolatility": opt.ImpliedVolatility,
 				"openInterest":      opt.OpenInterest,
 				"settlementDate":    opt.SettlementDate.Format("2006-01-02"),
+				"theta":             theta,
 			})
 		}
 		writeJSON(w, http.StatusOK, map[string]interface{}{

--- a/exchange-service/internal/handler/order_http_handler.go
+++ b/exchange-service/internal/handler/order_http_handler.go
@@ -95,11 +95,26 @@ func (h *OrderHTTPHandler) createOrder(w http.ResponseWriter, r *http.Request) {
 
 	userID, userType := callerIdentity(claims)
 
+	// Auto-detect order type from provided values when the client sends "market".
+	// Both values → stop_limit; limit only → limit; stop only → stop.
+	orderType := body.OrderType
+	if orderType == "market" {
+		hasLimit := body.LimitValue != nil && *body.LimitValue > 0
+		hasStop := body.StopValue != nil && *body.StopValue > 0
+		if hasLimit && hasStop {
+			orderType = "stop_limit"
+		} else if hasLimit {
+			orderType = "limit"
+		} else if hasStop {
+			orderType = "stop"
+		}
+	}
+
 	input := service.CreateOrderInput{
 		UserID:       userID,
 		UserType:     userType,
 		AssetTicker:  body.AssetTicker,
-		OrderType:    body.OrderType,
+		OrderType:    orderType,
 		Direction:    body.Direction,
 		Quantity:     body.Quantity,
 		ContractSize: body.ContractSize,

--- a/exchange-service/internal/models/market_entities.go
+++ b/exchange-service/internal/models/market_entities.go
@@ -190,6 +190,7 @@ type OrderRecord struct {
 	IsDone            bool                     `gorm:"column:is_done;not null;default:false"`
 	RemainingPortions int64                    `gorm:"column:remaining_portions;not null"`
 	Commission        float64                  `gorm:"column:commission;not null;default:0"`
+	CurrencyRate      float64                  `gorm:"column:currency_rate;not null;default:1"` // rate from asset currency to account currency at order creation
 	AfterHours        bool                     `gorm:"column:after_hours;not null;default:false"`
 	AccountID         uint                     `gorm:"column:account_id;not null"`
 	LastModification  time.Time                `gorm:"column:last_modification;not null"`

--- a/exchange-service/internal/repository/order_repository.go
+++ b/exchange-service/internal/repository/order_repository.go
@@ -272,6 +272,20 @@ func (r *OrderRepository) GetStateTreasuryAccountID() (uint, error) {
 	return id, err
 }
 
+// GetBankAccountByCurrency returns the ID of EXBanka's (non-state firm) account for the given currency.
+// Returns 0 if no such account is found.
+func (r *OrderRepository) GetBankAccountByCurrency(currencyKod string) (uint, error) {
+	var id uint
+	err := r.db.Table("accounts").
+		Select("accounts.id").
+		Joins("JOIN currencies ON currencies.id = accounts.currency_id").
+		Joins("JOIN firmas ON firmas.id = accounts.firma_id").
+		Where("currencies.kod = ? AND firmas.is_state = false AND accounts.status = 'aktivan'", currencyKod).
+		Limit(1).
+		Scan(&id).Error
+	return id, err
+}
+
 // GetAccountBalance returns the raspolozivo_stanje (available balance) and currency_kod for an account.
 func (r *OrderRepository) GetAccountBalance(accountID uint) (balance float64, currencyKod string, err error) {
 	row := r.db.Table("accounts").

--- a/exchange-service/internal/service/cron_service.go
+++ b/exchange-service/internal/service/cron_service.go
@@ -14,7 +14,7 @@ import (
 
 // StartCronJobs sets up and starts the cron scheduler for the exchange service.
 // portfolioSvc is created in main and shared with the portfolio HTTP handler.
-func StartCronJobs(db *gorm.DB, portfolioSvc *PortfolioService) *cron.Cron {
+func StartCronJobs(db *gorm.DB, portfolioSvc *PortfolioService, rateProvider RateProviderInterface) *cron.Cron {
 	c := cron.New()
 
 	// Refresh listing prices every 15 minutes.
@@ -28,7 +28,7 @@ func StartCronJobs(db *gorm.DB, portfolioSvc *PortfolioService) *cron.Cron {
 	// Order execution engine: attempt to fill active orders every minute.
 	orderRepo := repository.NewOrderRepository(db)
 	marketRepo := repository.NewMarketRepository(db)
-	executor := NewOrderExecutor(orderRepo, marketRepo, portfolioSvc)
+	executor := NewOrderExecutor(orderRepo, marketRepo, portfolioSvc, rateProvider)
 	_, err = c.AddFunc("@every 1m", func() {
 		executor.Run()
 	})
@@ -38,7 +38,7 @@ func StartCronJobs(db *gorm.DB, portfolioSvc *PortfolioService) *cron.Cron {
 
 	// Monthly tax collection: runs at 02:00 on the 1st of each month.
 	taxRepo := repository.NewTaxRepository(db)
-	taxSvc := NewTaxService(taxRepo, marketRepo)
+	taxSvc := NewTaxService(taxRepo, marketRepo, rateProvider)
 	taxCollector := NewTaxCollector(taxSvc, orderRepo, taxRepo)
 	_, err = c.AddFunc("0 2 1 * *", func() {
 		period := PreviousMonthPeriod()

--- a/exchange-service/internal/service/order_executor.go
+++ b/exchange-service/internal/service/order_executor.go
@@ -14,13 +14,14 @@ const afterHoursDelay = 30 * time.Minute
 
 // OrderExecutor fills active orders on each cron tick.
 type OrderExecutor struct {
-	orderRepo     *repository.OrderRepository
-	marketRepo    *repository.MarketRepository
-	portfolioSvc  *PortfolioService
+	orderRepo    *repository.OrderRepository
+	marketRepo   *repository.MarketRepository
+	portfolioSvc *PortfolioService
+	rateProvider RateProviderInterface
 }
 
-func NewOrderExecutor(orderRepo *repository.OrderRepository, marketRepo *repository.MarketRepository, portfolioSvc *PortfolioService) *OrderExecutor {
-	return &OrderExecutor{orderRepo: orderRepo, marketRepo: marketRepo, portfolioSvc: portfolioSvc}
+func NewOrderExecutor(orderRepo *repository.OrderRepository, marketRepo *repository.MarketRepository, portfolioSvc *PortfolioService, rateProvider RateProviderInterface) *OrderExecutor {
+	return &OrderExecutor{orderRepo: orderRepo, marketRepo: marketRepo, portfolioSvc: portfolioSvc, rateProvider: rateProvider}
 }
 
 // Run processes all approved, not-done orders and partially or fully fills them
@@ -78,11 +79,64 @@ func (e *OrderExecutor) Run() {
 			// Non-fatal: order fill is committed; portfolio can be reconciled later.
 		}
 
-		// Credit account for sell fills.
+		// Credit account for sell fills, converting to account currency if needed.
+		// Commission is deducted from the proceeds and credited to the bank account.
 		if order.Direction == "sell" {
 			fillAmount := round2(float64(fillQty) * float64(order.ContractSize) * price)
-			if err := e.orderRepo.CreditAccount(order.AccountID, fillAmount); err != nil {
+			assetCurrency := order.Asset.Exchange.Currency
+
+			// Proportional commission for this partial fill (in asset trading currency).
+			fillCommission := round2(order.Commission * float64(fillQty) / float64(order.Quantity))
+
+			// Credit bank account with the commission in the asset's trading currency.
+			if fillCommission > 0 {
+				bankAccountID, err := e.orderRepo.GetBankAccountByCurrency(assetCurrency)
+				if err != nil {
+					slog.Error("order executor: failed to find bank account for sell commission", "orderID", order.ID, "currency", assetCurrency, "error", err)
+				} else if bankAccountID > 0 {
+					if err := e.orderRepo.CreditAccount(bankAccountID, fillCommission); err != nil {
+						slog.Error("order executor: failed to credit bank sell commission", "orderID", order.ID, "currency", assetCurrency, "amount", fillCommission, "error", err)
+					}
+				} else {
+					slog.Warn("order executor: no bank account found for currency, sell commission not credited", "orderID", order.ID, "currency", assetCurrency)
+				}
+			}
+
+			// Net proceeds after commission, converted to account currency if needed.
+			netAmount := round2(fillAmount - fillCommission)
+			_, accountCurrency, err := e.orderRepo.GetAccountBalance(order.AccountID)
+			if err != nil {
+				slog.Error("order executor: failed to get account currency on sell", "orderID", order.ID, "error", err)
+			} else if assetCurrency != accountCurrency {
+				rate, err := e.rateProvider.GetRate(assetCurrency, accountCurrency)
+				if err != nil || rate == 0 {
+					slog.Error("order executor: no forex rate for sell proceeds", "orderID", order.ID, "from", assetCurrency, "to", accountCurrency)
+				} else {
+					netAmount = round2(netAmount * rate)
+				}
+			}
+			if err := e.orderRepo.CreditAccount(order.AccountID, netAmount); err != nil {
 				slog.Error("order executor: failed to credit account on sell", "orderID", order.ID, "error", err)
+			}
+		}
+
+		// Credit the bank's account with the proportional commission for buy fills.
+		// Commission was already deducted from the client's account at order creation.
+		// The commission is in the asset's trading currency (exchange currency), not the user's account currency.
+		if order.Direction == "buy" && order.Commission > 0 {
+			fillCommission := round2(order.Commission * float64(fillQty) / float64(order.Quantity))
+			if fillCommission > 0 {
+				currencyKod := order.Asset.Exchange.Currency
+				bankAccountID, err := e.orderRepo.GetBankAccountByCurrency(currencyKod)
+				if err != nil {
+					slog.Error("order executor: failed to find bank account for commission", "orderID", order.ID, "currency", currencyKod, "error", err)
+				} else if bankAccountID > 0 {
+					if err := e.orderRepo.CreditAccount(bankAccountID, fillCommission); err != nil {
+						slog.Error("order executor: failed to credit bank commission", "orderID", order.ID, "currency", currencyKod, "amount", fillCommission, "error", err)
+					}
+				} else {
+					slog.Warn("order executor: no bank account found for currency, commission not credited", "orderID", order.ID, "currency", currencyKod)
+				}
 			}
 		}
 
@@ -122,8 +176,10 @@ func conditionsMet(order *models.OrderRecord, listing *models.MarketListingRecor
 		return listing.Bid < *order.StopValue
 	case "stop_limit":
 		// Stop triggers activation; limit guards the fill price.
+		// Buy:  Ask reaches or exceeds stop value, AND Ask is still within limit.
+		// Sell: Bid falls below stop value, AND Bid is still within limit.
 		if order.Direction == "buy" {
-			return listing.Ask > *order.StopValue && listing.Ask <= *order.LimitValue
+			return listing.Ask >= *order.StopValue && listing.Ask <= *order.LimitValue
 		}
 		return listing.Bid < *order.StopValue && listing.Bid >= *order.LimitValue
 	}

--- a/exchange-service/internal/service/order_service.go
+++ b/exchange-service/internal/service/order_service.go
@@ -21,14 +21,16 @@ const (
 
 // OrderService handles order creation, approval, and cancellation.
 type OrderService struct {
-	orderRepo  *repository.OrderRepository
-	marketRepo *repository.MarketRepository
+	orderRepo    *repository.OrderRepository
+	marketRepo   *repository.MarketRepository
+	rateProvider RateProviderInterface
 }
 
-func NewOrderService(orderRepo *repository.OrderRepository, marketRepo *repository.MarketRepository) *OrderService {
+func NewOrderService(orderRepo *repository.OrderRepository, marketRepo *repository.MarketRepository, rateProvider RateProviderInterface) *OrderService {
 	return &OrderService{
-		orderRepo:  orderRepo,
-		marketRepo: marketRepo,
+		orderRepo:    orderRepo,
+		marketRepo:   marketRepo,
+		rateProvider: rateProvider,
 	}
 }
 
@@ -85,33 +87,53 @@ func (s *OrderService) CreateOrder(input CreateOrderInput) (*CreateOrderResult, 
 	// Commission depends on order type.
 	commission := calcCommission(input.OrderType, totalPrice)
 
+	// For buy orders, resolve the exchange rate between the asset's trading currency and
+	// the account's currency. The rate is stored on the order so refunds use the same rate.
+	// Sell orders don't debit at creation time — proceeds are converted at fill time.
+	currencyRate := 1.0
+	if input.Direction == "buy" {
+		assetCurrency := listing.Exchange.Currency
+		_, accountCurrency, err := s.orderRepo.GetAccountBalance(input.AccountID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read account currency: %w", err)
+		}
+		if assetCurrency != accountCurrency {
+			rate, err := s.rateProvider.GetRate(assetCurrency, accountCurrency)
+			if err != nil || rate == 0 {
+				return nil, fmt.Errorf("no exchange rate available for %s/%s", assetCurrency, accountCurrency)
+			}
+			currencyRate = rate
+		}
+	}
+
 	// Margin orders: verify the account has enough available balance to cover
-	// the Initial Margin Cost before accepting the order.
-	// MaintenanceMargin = contractSize * pricePerUnit * 10%
-	// InitialMarginCost = MaintenanceMargin * 1.1
+	// the Initial Margin Cost (MaintenanceMargin × 1.1) before accepting the order.
 	if input.IsMargin {
-		if err := s.validateMargin(input.AccountID, contractSize, pricePerUnit); err != nil {
+		if err := s.validateMargin(input.AccountID, listing, input.Quantity, contractSize, pricePerUnit, currencyRate); err != nil {
 			return nil, err
 		}
 	}
 
+	// Convert totalPrice to RSD for agent limit checks (limits are always in RSD).
+	totalPriceRSD := s.toRSD(totalPrice, listing.Exchange.Currency)
+
 	// Determine initial order status.
-	status, needsApproval, err := s.resolveStatus(input, totalPrice)
+	status, needsApproval, err := s.resolveStatus(input, totalPriceRSD)
 	if err != nil {
 		return nil, err
 	}
 
-	// For agent orders that don't need approval, increment their usedLimit.
+	// For agent orders that don't need approval, increment their usedLimit in RSD.
 	if input.UserType == "employee" && !needsApproval {
-		if err := s.orderRepo.IncrementUsedLimit(input.UserID, totalPrice); err != nil {
+		if err := s.orderRepo.IncrementUsedLimit(input.UserID, totalPriceRSD); err != nil {
 			return nil, fmt.Errorf("failed to update actuary used limit: %w", err)
 		}
 	}
 
-	// For buy orders, debit the full order value + commission from the account upfront.
-	// On cancel, RefundToAccount returns the unfilled portion (without commission).
+	// For buy orders, debit the full order value + commission from the account upfront,
+	// converted to the account's currency if it differs from the asset's currency.
 	if input.Direction == "buy" {
-		totalDebit := round2(totalPrice + commission)
+		totalDebit := round2((totalPrice + commission) * currencyRate)
 		if err := s.orderRepo.DebitAccount(input.AccountID, totalDebit); err != nil {
 			return nil, fmt.Errorf("insufficient funds: %w", err)
 		}
@@ -135,6 +157,7 @@ func (s *OrderService) CreateOrder(input CreateOrderInput) (*CreateOrderResult, 
 		IsDone:            false,
 		RemainingPortions: input.Quantity,
 		Commission:        commission,
+		CurrencyRate:      currencyRate,
 		AfterHours:        input.AfterHours,
 		AccountID:         input.AccountID,
 		LastModification:  now,
@@ -175,9 +198,14 @@ func (s *OrderService) resolveStatus(input CreateOrderInput, totalPrice float64)
 		return "approved", false, nil
 	}
 
-	// Agent: check if approval required.
+	// Agent: daily limit already exhausted — hard block, no new orders allowed.
+	if profile.UsedLimit >= *profile.Limit {
+		return "", false, fmt.Errorf("daily trading limit exhausted (used: %.2f RSD, limit: %.2f RSD)", profile.UsedLimit, *profile.Limit)
+	}
+
+	// Agent: order would exceed remaining limit, or agent always requires approval.
 	remaining := *profile.Limit - profile.UsedLimit
-	if profile.NeedApproval || profile.UsedLimit >= *profile.Limit || totalPrice > remaining {
+	if profile.NeedApproval || totalPrice > remaining {
 		return "pending", true, nil
 	}
 
@@ -209,10 +237,11 @@ func (s *OrderService) ApproveOrder(orderID, supervisorID uint) error {
 		return s.orderRepo.UpdateOrderStatus(orderID, "declined", &supervisorID)
 	}
 
-	// Increment the agent's usedLimit now that the order is officially approved.
+	// Increment the agent's usedLimit in RSD now that the order is officially approved.
 	if order.UserType == "employee" {
 		totalPrice := round2(float64(order.ContractSize) * order.PricePerUnit * float64(order.Quantity))
-		if err := s.orderRepo.IncrementUsedLimit(order.UserID, totalPrice); err != nil {
+		totalPriceRSD := s.toRSD(totalPrice, order.Asset.Exchange.Currency)
+		if err := s.orderRepo.IncrementUsedLimit(order.UserID, totalPriceRSD); err != nil {
 			return fmt.Errorf("failed to update actuary used limit: %w", err)
 		}
 	}
@@ -234,10 +263,10 @@ func (s *OrderService) DeclineOrder(orderID, supervisorID uint) error {
 		return fmt.Errorf("order is not pending (status: %s)", order.Status)
 	}
 
-	// Refund the full debit that was taken on creation.
+	// Refund the full debit that was taken on creation, converting back to account currency.
 	if order.Direction == "buy" {
 		totalPrice := round2(float64(order.Quantity) * float64(order.ContractSize) * order.PricePerUnit)
-		refund := round2(totalPrice + order.Commission)
+		refund := round2((totalPrice + order.Commission) * order.CurrencyRate)
 		if err := s.orderRepo.RefundToAccount(order.AccountID, refund); err != nil {
 			return fmt.Errorf("failed to refund account on decline: %w", err)
 		}
@@ -268,7 +297,7 @@ func (s *OrderService) CancelOrder(orderID, requesterID uint, newRemaining int64
 	}
 
 	cancelledQty := order.RemainingPortions - newRemaining
-	refundAmount := round2(float64(cancelledQty) * float64(order.ContractSize) * order.PricePerUnit)
+	refundAmount := round2(float64(cancelledQty) * float64(order.ContractSize) * order.PricePerUnit * order.CurrencyRate)
 
 	if newRemaining == 0 {
 		// Full cancel.
@@ -427,17 +456,57 @@ func orderPricePerUnit(listing *models.MarketListingRecord, input CreateOrderInp
 //
 //	MaintenanceMargin = contractSize * pricePerUnit * 10%
 //	InitialMarginCost = MaintenanceMargin * 1.1
-func (s *OrderService) validateMargin(accountID uint, contractSize int64, pricePerUnit float64) error {
+// validateMargin checks that the account's available balance covers the Initial Margin Cost.
+// Margin rates per asset type:
+//   stock:   50% of total position value  (quantity × contractSize × price × 50%)
+//   option:  100 shares/contract × 50% × underlying stock price  (quantity × contractSize × 100 × stockPrice × 50%)
+//   forex / futures: 10% of nominal value (quantity × contractSize × price × 10%)
+// InitialMarginCost = MaintenanceMargin × 1.1
+func (s *OrderService) validateMargin(accountID uint, listing *models.MarketListingRecord, quantity, contractSize int64, pricePerUnit, currencyRate float64) error {
 	balance, _, err := s.orderRepo.GetAccountBalance(accountID)
 	if err != nil {
 		return fmt.Errorf("failed to read account balance: %w", err)
 	}
-	maintenanceMargin := float64(contractSize) * pricePerUnit * 0.10
-	imc := maintenanceMargin * 1.1
+
+	qty := float64(quantity) * float64(contractSize)
+	var maintenanceMargin float64
+
+	switch listing.Type {
+	case "stock":
+		maintenanceMargin = qty * pricePerUnit * 0.50
+	case "option":
+		opt, err := s.marketRepo.GetOptionByListingID(listing.ID)
+		if err != nil || opt == nil {
+			return fmt.Errorf("option contract data not found for margin calculation")
+		}
+		underlying, err := s.marketRepo.GetListingRecordByID(opt.StockListingID)
+		if err != nil || underlying == nil {
+			return fmt.Errorf("underlying stock not found for option margin calculation")
+		}
+		// Each option contract covers 100 shares; margin = 50% of underlying position value.
+		maintenanceMargin = qty * 100 * underlying.Price * 0.50
+	default: // forex, futures
+		maintenanceMargin = qty * pricePerUnit * 0.10
+	}
+
+	imc := round2(maintenanceMargin * 1.1 * currencyRate)
 	if balance < imc {
 		return fmt.Errorf("insufficient balance for margin order: need %.2f, have %.2f", imc, balance)
 	}
 	return nil
+}
+
+// toRSD converts an amount from the given currency to RSD using the rate provider.
+// Returns the original amount unchanged if already RSD or no rate is found.
+func (s *OrderService) toRSD(amount float64, currency string) float64 {
+	if currency == "RSD" || currency == "" {
+		return amount
+	}
+	rate, err := s.rateProvider.GetRate(currency, "RSD")
+	if err != nil || rate == 0 {
+		return amount
+	}
+	return round2(amount * rate)
 }
 
 // calcCommission computes the commission for an order.

--- a/exchange-service/internal/service/tax_service.go
+++ b/exchange-service/internal/service/tax_service.go
@@ -16,12 +16,13 @@ const (
 
 // TaxService records capital gains tax for sell transactions.
 type TaxService struct {
-	taxRepo    *repository.TaxRepository
-	marketRepo *repository.MarketRepository
+	taxRepo      *repository.TaxRepository
+	marketRepo   *repository.MarketRepository
+	rateProvider RateProviderInterface
 }
 
-func NewTaxService(taxRepo *repository.TaxRepository, marketRepo *repository.MarketRepository) *TaxService {
-	return &TaxService{taxRepo: taxRepo, marketRepo: marketRepo}
+func NewTaxService(taxRepo *repository.TaxRepository, marketRepo *repository.MarketRepository, rateProvider RateProviderInterface) *TaxService {
+	return &TaxService{taxRepo: taxRepo, marketRepo: marketRepo, rateProvider: rateProvider}
 }
 
 // RecordCapitalGainTax converts the realised profit to RSD and persists a
@@ -101,13 +102,12 @@ func (s *TaxService) SumPaidTaxForYear(userID uint, userType, year string) (floa
 	return s.taxRepo.SumPaidTaxForUserYear(userID, userType, year)
 }
 
-// toRSD converts an amount from the given currency to RSD.
-// Falls back to the original amount when no forex pair is found.
+// toRSD converts an amount from the given currency to RSD using the rate provider.
 func (s *TaxService) toRSD(amount float64, currency string) float64 {
 	if currency == rsdCurrency || currency == "" {
 		return amount
 	}
-	rate, err := s.marketRepo.GetForexRate(currency, rsdCurrency)
+	rate, err := s.rateProvider.GetRate(currency, rsdCurrency)
 	if err != nil || rate == 0 {
 		slog.Warn("tax service: no forex rate found, using 1:1 fallback",
 			"from", currency, "to", rsdCurrency)


### PR DESCRIPTION
…ction

- order_executor: deduct commission from sell proceeds and credit bank account (was silently ignored for sells)
- order_executor: fix buy stop-limit trigger to use >= stop value ("reaches or exceeds") instead of strict >
- order_http_handler: auto-detect order type from provided values (limitValue→limit, stopValue→stop, both→stop_limit)