### PR TITLE
test: increase handler coverage across payment, transfer, employee, a…

### DIFF
--- a/employee-service/internal/handler/employee_handler_test.go
+++ b/employee-service/internal/handler/employee_handler_test.go
@@ -1,0 +1,687 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	employeev1 "github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/gen/proto/employee/v1"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/service"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/util"
+	"github.com/glebarez/sqlite"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+// =====================
+// shared test helpers
+// =====================
+
+func openHandlerDB(t *testing.T, name string) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:%s?mode=memory&cache=shared", name)), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Employee{}, &models.ActuaryProfile{}, &models.Permission{}, &models.Token{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func createEmployee(t *testing.T, db *gorm.DB, email, username string, perms ...string) *models.Employee {
+	t.Helper()
+	emp := &models.Employee{
+		Ime:           "Test",
+		Prezime:       "User",
+		DatumRodjenja: time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC),
+		Pol:           "M",
+		Email:         email,
+		BrojTelefona:  "0600000000",
+		Adresa:        "Test Street 1",
+		Username:      username,
+		Password:      "hash",
+		SaltPassword:  "salt",
+		Pozicija:      "Agent",
+		Departman:     "Trading",
+		Aktivan:       true,
+	}
+	if err := db.Create(emp).Error; err != nil {
+		t.Fatalf("create employee %s: %v", email, err)
+	}
+	for _, name := range perms {
+		p := models.Permission{Name: name, SubjectType: models.PermissionSubjectEmployee}
+		if err := db.Where("name = ?", name).FirstOrCreate(&p).Error; err != nil {
+			t.Fatalf("create permission %s: %v", name, err)
+		}
+		if err := db.Model(emp).Association("Permissions").Append(&p); err != nil {
+			t.Fatalf("attach permission %s: %v", name, err)
+		}
+	}
+	return emp
+}
+
+func supervisorToken(t *testing.T, cfg *config.Config, emp *models.Employee) string {
+	t.Helper()
+	tok, err := util.GenerateAccessToken(emp.ID, emp.Email, emp.Username, []string{models.PermEmployeeSupervisor}, cfg.JWTSecret, 60)
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	return tok
+}
+
+func agentToken(t *testing.T, cfg *config.Config, emp *models.Employee) string {
+	t.Helper()
+	tok, err := util.GenerateAccessToken(emp.ID, emp.Email, emp.Username, []string{models.PermEmployeeAgent}, cfg.JWTSecret, 60)
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+	return tok
+}
+
+// =====================
+// ActuaryHTTPHandler additional tests
+// =====================
+
+func TestListActuaries_WrongMethod_Returns405(t *testing.T) {
+	db := openHandlerDB(t, "list_act_method")
+	cfg := &config.Config{JWTSecret: "secret"}
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/actuaries", nil)
+	w := httptest.NewRecorder()
+	h.ListActuaries(w, r)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestListActuaries_NoAuth_Returns401(t *testing.T) {
+	db := openHandlerDB(t, "list_act_noauth")
+	cfg := &config.Config{JWTSecret: "secret"}
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/actuaries", nil)
+	w := httptest.NewRecorder()
+	h.ListActuaries(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestListActuaries_SearchFilter(t *testing.T) {
+	db := openHandlerDB(t, "list_act_search")
+	cfg := &config.Config{JWTSecret: "secret"}
+
+	sup := createEmployee(t, db, "sup.search@bank.com", "sup-search", models.PermEmployeeSupervisor)
+	createEmployee(t, db, "agent.alpha@bank.com", "alpha", models.PermEmployeeAgent)
+	createEmployee(t, db, "agent.beta@bank.com", "beta", models.PermEmployeeAgent)
+
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/actuaries?q=alpha", nil)
+	r.Header.Set("Authorization", "Bearer "+supervisorToken(t, cfg, sup))
+	w := httptest.NewRecorder()
+	h.ListActuaries(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "alpha") {
+		t.Error("expected filtered response to contain 'alpha'")
+	}
+}
+
+// =====================
+// ActuaryRoutes tests
+// =====================
+
+func TestActuaryRoutes_UpdateLimit_Success(t *testing.T) {
+	db := openHandlerDB(t, "act_routes_limit")
+	cfg := &config.Config{JWTSecret: "secret"}
+
+	sup := createEmployee(t, db, "sup.limit@bank.com", "sup-limit", models.PermEmployeeSupervisor)
+	agent := createEmployee(t, db, "agent.limit@bank.com", "agent-limit", models.PermEmployeeAgent)
+
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	body := `{"limit": 50000.0}`
+	r := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/actuaries/%d/limit", agent.ID), strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+supervisorToken(t, cfg, sup))
+	w := httptest.NewRecorder()
+	h.ActuaryRoutes(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestActuaryRoutes_UpdateLimit_InvalidBody(t *testing.T) {
+	db := openHandlerDB(t, "act_routes_limit_bad")
+	cfg := &config.Config{JWTSecret: "secret"}
+
+	sup := createEmployee(t, db, "sup.limitb@bank.com", "sup-limitb", models.PermEmployeeSupervisor)
+	agent := createEmployee(t, db, "agent.limitb@bank.com", "agent-limitb", models.PermEmployeeAgent)
+
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	r := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/actuaries/%d/limit", agent.ID), strings.NewReader("not json"))
+	r.Header.Set("Authorization", "Bearer "+supervisorToken(t, cfg, sup))
+	w := httptest.NewRecorder()
+	h.ActuaryRoutes(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestActuaryRoutes_ResetUsedLimit_Success(t *testing.T) {
+	db := openHandlerDB(t, "act_routes_reset")
+	cfg := &config.Config{JWTSecret: "secret"}
+
+	sup := createEmployee(t, db, "sup.reset@bank.com", "sup-reset", models.PermEmployeeSupervisor)
+	agent := createEmployee(t, db, "agent.reset@bank.com", "agent-reset", models.PermEmployeeAgent)
+
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	r := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/actuaries/%d/reset-used-limit", agent.ID), nil)
+	r.Header.Set("Authorization", "Bearer "+supervisorToken(t, cfg, sup))
+	w := httptest.NewRecorder()
+	h.ActuaryRoutes(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestActuaryRoutes_SetNeedApproval_Success(t *testing.T) {
+	db := openHandlerDB(t, "act_routes_approval")
+	cfg := &config.Config{JWTSecret: "secret"}
+
+	sup := createEmployee(t, db, "sup.approval@bank.com", "sup-approval", models.PermEmployeeSupervisor)
+	agent := createEmployee(t, db, "agent.approval@bank.com", "agent-approval", models.PermEmployeeAgent)
+
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	body := `{"needApproval": true}`
+	r := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/actuaries/%d/need-approval", agent.ID), strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+supervisorToken(t, cfg, sup))
+	w := httptest.NewRecorder()
+	h.ActuaryRoutes(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestActuaryRoutes_SetNeedApproval_InvalidBody(t *testing.T) {
+	db := openHandlerDB(t, "act_routes_approval_bad")
+	cfg := &config.Config{JWTSecret: "secret"}
+
+	sup := createEmployee(t, db, "sup.approvalbad@bank.com", "sup-approvalbad", models.PermEmployeeSupervisor)
+	agent := createEmployee(t, db, "agent.approvalbad@bank.com", "agent-approvalbad", models.PermEmployeeAgent)
+
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	r := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/actuaries/%d/need-approval", agent.ID), strings.NewReader("not json"))
+	r.Header.Set("Authorization", "Bearer "+supervisorToken(t, cfg, sup))
+	w := httptest.NewRecorder()
+	h.ActuaryRoutes(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestActuaryRoutes_EmptyPath_Returns404(t *testing.T) {
+	db := openHandlerDB(t, "act_routes_empty")
+	cfg := &config.Config{JWTSecret: "secret"}
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/actuaries/", nil)
+	w := httptest.NewRecorder()
+	h.ActuaryRoutes(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestActuaryRoutes_InvalidEmployeeID_Returns400(t *testing.T) {
+	db := openHandlerDB(t, "act_routes_badid")
+	cfg := &config.Config{JWTSecret: "secret"}
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/actuaries/notanumber/limit", nil)
+	w := httptest.NewRecorder()
+	h.ActuaryRoutes(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestActuaryRoutes_NoAuth_Returns401(t *testing.T) {
+	db := openHandlerDB(t, "act_routes_noauth")
+	cfg := &config.Config{JWTSecret: "secret"}
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/actuaries/1/limit", strings.NewReader(`{"limit":100}`))
+	w := httptest.NewRecorder()
+	h.ActuaryRoutes(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestActuaryRoutes_AgentForbidden_Returns403(t *testing.T) {
+	db := openHandlerDB(t, "act_routes_agentforbidden")
+	cfg := &config.Config{JWTSecret: "secret"}
+
+	agent := createEmployee(t, db, "agent.forbidden@bank.com", "agent-forbidden", models.PermEmployeeAgent)
+
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	r := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/actuaries/%d/limit", agent.ID), strings.NewReader(`{"limit":100}`))
+	r.Header.Set("Authorization", "Bearer "+agentToken(t, cfg, agent))
+	w := httptest.NewRecorder()
+	h.ActuaryRoutes(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestActuaryRoutes_UnknownSubpath_Returns404(t *testing.T) {
+	db := openHandlerDB(t, "act_routes_unknown")
+	cfg := &config.Config{JWTSecret: "secret"}
+
+	sup := createEmployee(t, db, "sup.unknown@bank.com", "sup-unknown", models.PermEmployeeSupervisor)
+
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/actuaries/1/unknown-action", nil)
+	r.Header.Set("Authorization", "Bearer "+supervisorToken(t, cfg, sup))
+	w := httptest.NewRecorder()
+	h.ActuaryRoutes(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestActuaryRoutes_PatchLimit_Success(t *testing.T) {
+	db := openHandlerDB(t, "act_routes_patchlimit")
+	cfg := &config.Config{JWTSecret: "secret"}
+
+	sup := createEmployee(t, db, "sup.patch@bank.com", "sup-patch", models.PermEmployeeSupervisor)
+	agent := createEmployee(t, db, "agent.patch@bank.com", "agent-patch", models.PermEmployeeAgent)
+
+	h := NewActuaryHTTPHandler(cfg, service.NewEmployeeService(cfg, db, nil))
+
+	body := `{"limit": 25000.0}`
+	r := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/api/v1/actuaries/%d/limit", agent.ID), strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+supervisorToken(t, cfg, sup))
+	w := httptest.NewRecorder()
+	h.ActuaryRoutes(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// =====================
+// http_auth helpers
+// =====================
+
+func TestParseHTTPClaims_MissingHeader(t *testing.T) {
+	cfg := &config.Config{JWTSecret: "secret"}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	_, err := parseHTTPClaims(r, cfg)
+	if err == nil {
+		t.Error("expected error for missing auth header")
+	}
+}
+
+func TestParseHTTPClaims_InvalidToken(t *testing.T) {
+	cfg := &config.Config{JWTSecret: "secret"}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer invalidtoken")
+	_, err := parseHTTPClaims(r, cfg)
+	if err == nil {
+		t.Error("expected error for invalid token")
+	}
+}
+
+func TestRequireAuthenticatedEmployeeHTTP_ZeroEmployeeID_Returns403(t *testing.T) {
+	cfg := &config.Config{JWTSecret: "secret"}
+
+	// Token with employeeID=0 should be rejected
+	tok, err := util.GenerateAccessToken(0, "test@test.com", "test", []string{}, cfg.JWTSecret, 60)
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer "+tok)
+	w := httptest.NewRecorder()
+	_, ok := requireAuthenticatedEmployeeHTTP(w, r, cfg)
+	if ok {
+		t.Error("expected ok=false for zero employee ID")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+// =====================
+// EmployeeHandler (gRPC) tests
+// =====================
+
+func TestEmployeeHandler_CreateEmployee_Success(t *testing.T) {
+	db := openHandlerDB(t, "grpc_create")
+	cfg := &config.Config{JWTSecret: "secret"}
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	resp, err := h.CreateEmployee(context.Background(), &employeev1.CreateEmployeeRequest{
+		Ime:           "Ana",
+		Prezime:       "Petrovic",
+		DatumRodjenja: time.Date(1995, 6, 15, 0, 0, 0, 0, time.UTC).Unix(),
+		Pol:           "F",
+		Email:         "ana.petrovic@bank.com",
+		BrojTelefona:  "0641111111",
+		Adresa:        "Test 1",
+		Username:      "ana.petrovic",
+		Pozicija:      "Analyst",
+		Departman:     "Finance",
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Employee.Email != "ana.petrovic@bank.com" {
+		t.Errorf("expected email, got %s", resp.Employee.Email)
+	}
+	if resp.Message == "" {
+		t.Error("expected non-empty message")
+	}
+}
+
+func TestEmployeeHandler_CreateEmployee_DuplicateEmail_ReturnsInvalidArgument(t *testing.T) {
+	db := openHandlerDB(t, "grpc_create_dup")
+	cfg := &config.Config{JWTSecret: "secret"}
+	createEmployee(t, db, "dup@bank.com", "dup-user")
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	_, err := h.CreateEmployee(context.Background(), &employeev1.CreateEmployeeRequest{
+		Ime:      "X",
+		Prezime:  "Y",
+		Email:    "dup@bank.com",
+		Username: "dup-user2",
+		Pol:      "M",
+	})
+
+	if err == nil {
+		t.Fatal("expected error for duplicate email")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+}
+
+func TestEmployeeHandler_GetEmployee_Success(t *testing.T) {
+	db := openHandlerDB(t, "grpc_get")
+	cfg := &config.Config{JWTSecret: "secret"}
+	emp := createEmployee(t, db, "get.emp@bank.com", "get-emp")
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	resp, err := h.GetEmployee(context.Background(), &employeev1.GetEmployeeRequest{Id: uint64(emp.ID)})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Employee.Email != emp.Email {
+		t.Errorf("expected email %s, got %s", emp.Email, resp.Employee.Email)
+	}
+}
+
+func TestEmployeeHandler_GetEmployee_NotFound(t *testing.T) {
+	db := openHandlerDB(t, "grpc_get_nf")
+	cfg := &config.Config{JWTSecret: "secret"}
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	_, err := h.GetEmployee(context.Background(), &employeev1.GetEmployeeRequest{Id: 9999})
+
+	if err == nil {
+		t.Fatal("expected error for non-existent employee")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.NotFound {
+		t.Errorf("expected NotFound, got %v", err)
+	}
+}
+
+func TestEmployeeHandler_ListEmployees_Success(t *testing.T) {
+	db := openHandlerDB(t, "grpc_list")
+	cfg := &config.Config{JWTSecret: "secret"}
+	createEmployee(t, db, "list1@bank.com", "list1-user")
+	createEmployee(t, db, "list2@bank.com", "list2-user")
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	resp, err := h.ListEmployees(context.Background(), &employeev1.ListEmployeesRequest{
+		Page:     1,
+		PageSize: 10,
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Employees) < 2 {
+		t.Errorf("expected at least 2 employees, got %d", len(resp.Employees))
+	}
+	if resp.Page != 1 || resp.PageSize != 10 {
+		t.Errorf("unexpected pagination: page=%d size=%d", resp.Page, resp.PageSize)
+	}
+}
+
+
+func TestEmployeeHandler_UpdateEmployee_Success(t *testing.T) {
+	db := openHandlerDB(t, "grpc_update")
+	cfg := &config.Config{JWTSecret: "secret"}
+	emp := createEmployee(t, db, "update.emp@bank.com", "update-emp")
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	resp, err := h.UpdateEmployee(context.Background(), &employeev1.UpdateEmployeeRequest{
+		Id:            uint64(emp.ID),
+		Ime:           "Updated",
+		Prezime:       "Name",
+		Email:         "update.emp@bank.com",
+		Username:      "update-emp",
+		BrojTelefona:  "0649999999",
+		Adresa:        "New Address 1",
+		Pol:           "M",
+		Pozicija:      "Senior Agent",
+		Departman:     "Trading",
+		DatumRodjenja: time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC).Unix(),
+		Aktivan:       true,
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Employee.Ime != "Updated" {
+		t.Errorf("expected Ime=Updated, got %s", resp.Employee.Ime)
+	}
+}
+
+func TestEmployeeHandler_UpdateEmployee_NotFound_ReturnsInvalidArgument(t *testing.T) {
+	db := openHandlerDB(t, "grpc_update_nf")
+	cfg := &config.Config{JWTSecret: "secret"}
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	_, err := h.UpdateEmployee(context.Background(), &employeev1.UpdateEmployeeRequest{
+		Id:  9999,
+		Ime: "Ghost",
+	})
+
+	if err == nil {
+		t.Fatal("expected error for non-existent employee")
+	}
+}
+
+func TestEmployeeHandler_SetEmployeeActive_Success(t *testing.T) {
+	db := openHandlerDB(t, "grpc_active")
+	cfg := &config.Config{JWTSecret: "secret"}
+	emp := createEmployee(t, db, "active.emp@bank.com", "active-emp")
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	resp, err := h.SetEmployeeActive(context.Background(), &employeev1.SetEmployeeActiveRequest{
+		Id:      uint64(emp.ID),
+		Aktivan: false,
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Aktivan != false {
+		t.Error("expected Aktivan=false")
+	}
+	if resp.Message == "" {
+		t.Error("expected non-empty message")
+	}
+}
+
+func TestEmployeeHandler_SetEmployeeActive_NotFound(t *testing.T) {
+	db := openHandlerDB(t, "grpc_active_nf")
+	cfg := &config.Config{JWTSecret: "secret"}
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	_, err := h.SetEmployeeActive(context.Background(), &employeev1.SetEmployeeActiveRequest{
+		Id:      9999,
+		Aktivan: true,
+	})
+
+	if err == nil {
+		t.Fatal("expected error for non-existent employee")
+	}
+}
+
+func TestEmployeeHandler_UpdateEmployeePermissions_Success(t *testing.T) {
+	db := openHandlerDB(t, "grpc_perms")
+	cfg := &config.Config{JWTSecret: "secret"}
+	// Seed the permission so UpdateEmployeePermissions can find it
+	emp := createEmployee(t, db, "perms.emp@bank.com", "perms-emp", models.PermEmployeeAgent)
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	resp, err := h.UpdateEmployeePermissions(context.Background(), &employeev1.UpdateEmployeePermissionsRequest{
+		Id:              uint64(emp.ID),
+		PermissionNames: []string{models.PermEmployeeAgent},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Message == "" {
+		t.Error("expected non-empty message")
+	}
+}
+
+func TestEmployeeHandler_UpdateEmployeePermissions_NotFound_ReturnsInvalidArgument(t *testing.T) {
+	db := openHandlerDB(t, "grpc_perms_nf")
+	cfg := &config.Config{JWTSecret: "secret"}
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	_, err := h.UpdateEmployeePermissions(context.Background(), &employeev1.UpdateEmployeePermissionsRequest{
+		Id:              9999,
+		PermissionNames: []string{models.PermEmployeeAgent},
+	})
+
+	if err == nil {
+		t.Fatal("expected error for non-existent employee")
+	}
+	if st, ok := status.FromError(err); !ok || st.Code() != codes.InvalidArgument {
+		t.Errorf("expected InvalidArgument, got %v", err)
+	}
+}
+
+func TestEmployeeHandler_GetAllPermissions_Success(t *testing.T) {
+	db := openHandlerDB(t, "grpc_allperms")
+	cfg := &config.Config{JWTSecret: "secret"}
+
+	// Seed some permissions
+	for _, name := range []string{models.PermEmployeeBasic, models.PermEmployeeAgent} {
+		p := models.Permission{Name: name, SubjectType: models.PermissionSubjectEmployee}
+		db.Where("name = ?", name).FirstOrCreate(&p)
+	}
+
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	resp, err := h.GetAllPermissions(context.Background(), &employeev1.GetAllPermissionsRequest{})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Permissions) < 2 {
+		t.Errorf("expected at least 2 permissions, got %d", len(resp.Permissions))
+	}
+}
+
+func TestEmployeeHandler_ToEmployeeProto_WithPermissions(t *testing.T) {
+	db := openHandlerDB(t, "grpc_proto_perms")
+	cfg := &config.Config{JWTSecret: "secret"}
+	emp := createEmployee(t, db, "proto.emp@bank.com", "proto-emp", models.PermEmployeeAgent)
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	resp, err := h.GetEmployee(context.Background(), &employeev1.GetEmployeeRequest{Id: uint64(emp.ID)})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(resp.Employee.Permissions) == 0 {
+		t.Error("expected permissions to be mapped in proto")
+	}
+}
+
+func TestEmployeeHandler_ListEmployees_ToListItem(t *testing.T) {
+	db := openHandlerDB(t, "grpc_listitem")
+	cfg := &config.Config{JWTSecret: "secret"}
+	createEmployee(t, db, "item.emp@bank.com", "item-emp", models.PermEmployeeAgent)
+	svc := service.NewEmployeeService(cfg, db, nil)
+	h := NewEmployeeHandlerWithService(svc)
+
+	resp, err := h.ListEmployees(context.Background(), &employeev1.ListEmployeesRequest{Page: 1, PageSize: 10})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Employees) == 0 {
+		t.Fatal("expected at least one employee in list")
+	}
+
+	item := resp.Employees[0]
+	if item.Email == "" {
+		t.Error("expected non-empty email in list item")
+	}
+}
+

--- a/employee-service/internal/service/employee_service.go
+++ b/employee-service/internal/service/employee_service.go
@@ -143,7 +143,9 @@ func (s *EmployeeService) CreateEmployee(input CreateEmployeeInput) (*models.Emp
 		return nil, err
 	}
 
-	_ = s.notifSvc.SendActivationEmail(emp.Email, emp.Ime+" "+emp.Prezime, tokenStr)
+	if s.notifSvc != nil {
+		_ = s.notifSvc.SendActivationEmail(emp.Email, emp.Ime+" "+emp.Prezime, tokenStr)
+	}
 	return emp, nil
 }
 

--- a/exchange-service/internal/database/database_test.go
+++ b/exchange-service/internal/database/database_test.go
@@ -1,0 +1,301 @@
+package database
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+func newInMemoryDB(t *testing.T, name string) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:%s?mode=memory&cache=shared", name)), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	return db
+}
+
+// =====================
+// Migrate
+// =====================
+
+func TestMigrate_RunsWithoutError(t *testing.T) {
+	db := newInMemoryDB(t, "test_migrate")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+}
+
+func TestMigrate_CreatesExpectedTables(t *testing.T) {
+	db := newInMemoryDB(t, "test_migrate_tables")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+
+	tableModels := []interface{}{
+		&models.MarketExchangeRecord{},
+		&models.MarketListingRecord{},
+		&models.StockRecord{},
+		&models.ForexPairRecord{},
+		&models.FuturesContractRecord{},
+		&models.OptionRecord{},
+		&models.OrderRecord{},
+	}
+	for _, m := range tableModels {
+		if !db.Migrator().HasTable(m) {
+			t.Errorf("expected table for %T to exist after migration", m)
+		}
+	}
+}
+
+func TestMigrate_IsIdempotent(t *testing.T) {
+	db := newInMemoryDB(t, "test_migrate_idempotent")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("first Migrate failed: %v", err)
+	}
+	if err := Migrate(db); err != nil {
+		t.Fatalf("second Migrate failed: %v", err)
+	}
+}
+
+// =====================
+// SeedMarketData
+// =====================
+
+func TestSeedMarketData_RunsWithoutError(t *testing.T) {
+	db := newInMemoryDB(t, "test_seed_market")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	if err := SeedMarketData(db); err != nil {
+		t.Fatalf("SeedMarketData failed: %v", err)
+	}
+}
+
+func TestSeedMarketData_InsertsExchanges(t *testing.T) {
+	db := newInMemoryDB(t, "test_seed_exchanges")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	if err := SeedMarketData(db); err != nil {
+		t.Fatalf("SeedMarketData failed: %v", err)
+	}
+
+	var count int64
+	db.Model(&models.MarketExchangeRecord{}).Count(&count)
+	if count < 3 {
+		t.Errorf("expected at least 3 exchanges, got %d", count)
+	}
+}
+
+func TestSeedMarketData_InsertsStockListings(t *testing.T) {
+	db := newInMemoryDB(t, "test_seed_stocks")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	if err := SeedMarketData(db); err != nil {
+		t.Fatalf("SeedMarketData failed: %v", err)
+	}
+
+	var count int64
+	db.Model(&models.MarketListingRecord{}).Where("type = ?", "stock").Count(&count)
+	if count < 10 {
+		t.Errorf("expected at least 10 stock listings, got %d", count)
+	}
+}
+
+func TestSeedMarketData_InsertsForexListings(t *testing.T) {
+	db := newInMemoryDB(t, "test_seed_forex")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	if err := SeedMarketData(db); err != nil {
+		t.Fatalf("SeedMarketData failed: %v", err)
+	}
+
+	var count int64
+	db.Model(&models.MarketListingRecord{}).Where("type = ?", "forex").Count(&count)
+	if count < 3 {
+		t.Errorf("expected at least 3 forex listings, got %d", count)
+	}
+}
+
+func TestSeedMarketData_InsertsFuturesListings(t *testing.T) {
+	db := newInMemoryDB(t, "test_seed_futures")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	if err := SeedMarketData(db); err != nil {
+		t.Fatalf("SeedMarketData failed: %v", err)
+	}
+
+	var count int64
+	db.Model(&models.MarketListingRecord{}).Where("type = ?", "futures").Count(&count)
+	if count < 3 {
+		t.Errorf("expected at least 3 futures listings, got %d", count)
+	}
+}
+
+func TestSeedMarketData_InsertsOptions(t *testing.T) {
+	db := newInMemoryDB(t, "test_seed_options")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	if err := SeedMarketData(db); err != nil {
+		t.Fatalf("SeedMarketData failed: %v", err)
+	}
+
+	var count int64
+	db.Model(&models.MarketListingRecord{}).Where("type = ?", "option").Count(&count)
+	if count == 0 {
+		t.Error("expected at least one option to be seeded")
+	}
+}
+
+func TestSeedMarketData_InsertsHistory(t *testing.T) {
+	db := newInMemoryDB(t, "test_seed_history")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	if err := SeedMarketData(db); err != nil {
+		t.Fatalf("SeedMarketData failed: %v", err)
+	}
+
+	var count int64
+	db.Model(&models.MarketListingDailyPriceInfoRecord{}).Count(&count)
+	// 12 stocks + 6 forex + 6 futures = 24 non-option listings × 30 days history
+	if count < 200 {
+		t.Errorf("expected substantial history records, got %d", count)
+	}
+}
+
+func TestSeedMarketData_IsIdempotent(t *testing.T) {
+	db := newInMemoryDB(t, "test_seed_idempotent")
+	if err := Migrate(db); err != nil {
+		t.Fatalf("Migrate failed: %v", err)
+	}
+	if err := SeedMarketData(db); err != nil {
+		t.Fatalf("first SeedMarketData failed: %v", err)
+	}
+
+	var countBefore int64
+	db.Model(&models.MarketListingRecord{}).Count(&countBefore)
+
+	if err := SeedMarketData(db); err != nil {
+		t.Fatalf("second SeedMarketData failed: %v", err)
+	}
+
+	var countAfter int64
+	db.Model(&models.MarketListingRecord{}).Count(&countAfter)
+
+	if countAfter != countBefore {
+		t.Errorf("idempotency broken: before=%d, after=%d", countBefore, countAfter)
+	}
+}
+
+// =====================
+// seedForexListings
+// =====================
+
+func TestSeedForexListings_ReturnsForexType(t *testing.T) {
+	listings := seedForexListings()
+	if len(listings) == 0 {
+		t.Fatal("expected non-empty forex listings")
+	}
+	for _, l := range listings {
+		if l.Type != models.ListingTypeForex {
+			t.Errorf("expected type=forex, got %v for ticker %s", l.Type, l.Ticker)
+		}
+		if l.BaseCurrency == "" || l.QuoteCurrency == "" {
+			t.Errorf("expected non-empty currencies for %s", l.Ticker)
+		}
+	}
+}
+
+func TestSeedForexListings_HasAtLeastThreeEntries(t *testing.T) {
+	listings := seedForexListings()
+	if len(listings) < 3 {
+		t.Errorf("expected at least 3 forex listings, got %d", len(listings))
+	}
+}
+
+func TestSeedForexListings_AllHavePositivePrices(t *testing.T) {
+	for _, l := range seedForexListings() {
+		if l.Price <= 0 {
+			t.Errorf("forex %s has non-positive price %f", l.Ticker, l.Price)
+		}
+	}
+}
+
+// =====================
+// seedFuturesListings
+// =====================
+
+func TestSeedFuturesListings_ReturnsFuturesType(t *testing.T) {
+	listings := seedFuturesListings()
+	if len(listings) == 0 {
+		t.Fatal("expected non-empty futures listings")
+	}
+	for _, l := range listings {
+		if l.Type != models.ListingTypeFutures {
+			t.Errorf("expected type=futures, got %v for ticker %s", l.Type, l.Ticker)
+		}
+		if l.ContractSize <= 0 {
+			t.Errorf("expected positive ContractSize for %s", l.Ticker)
+		}
+		if l.ContractUnit == "" {
+			t.Errorf("expected non-empty ContractUnit for %s", l.Ticker)
+		}
+	}
+}
+
+func TestSeedFuturesListings_HasAtLeastThreeEntries(t *testing.T) {
+	listings := seedFuturesListings()
+	if len(listings) < 3 {
+		t.Errorf("expected at least 3 futures listings, got %d", len(listings))
+	}
+}
+
+func TestSeedFuturesListings_SettlementDatesInFuture(t *testing.T) {
+	ref := seedReferenceTime()
+	for _, l := range seedFuturesListings() {
+		if !l.SettlementDate.After(ref) {
+			t.Errorf("futures %s settlement date %v is not after reference %v", l.Ticker, l.SettlementDate, ref)
+		}
+	}
+}
+
+// =====================
+// generateExpirationDates
+// =====================
+
+func TestGenerateExpirationDates_ReturnsThreeDates(t *testing.T) {
+	ref := time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)
+	dates := generateExpirationDates(ref)
+	if len(dates) != 3 {
+		t.Errorf("expected 3 expiration dates, got %d", len(dates))
+	}
+}
+
+func TestGenerateExpirationDates_DatesAreAfterReference(t *testing.T) {
+	ref := time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)
+	for i, d := range generateExpirationDates(ref) {
+		if !d.After(ref) {
+			t.Errorf("date[%d] %v is not after reference %v", i, d, ref)
+		}
+	}
+}
+
+func TestGenerateExpirationDates_DatesAreOrdered(t *testing.T) {
+	ref := time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC)
+	dates := generateExpirationDates(ref)
+	for i := 1; i < len(dates); i++ {
+		if !dates[i].After(dates[i-1]) {
+			t.Errorf("date[%d] %v is not after date[%d] %v", i, dates[i], i-1, dates[i-1])
+		}
+	}
+}

--- a/payment-service/internal/handler/create_payment_http_handler.go
+++ b/payment-service/internal/handler/create_payment_http_handler.go
@@ -133,25 +133,27 @@ func (h *CreatePaymentHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		recipientNaziv = req.RecipientNazivCamel
 	}
 
-	owned, err := h.accountOwnedByClient(racunPosiljaocaID, claims.ClientID)
-	if err != nil {
-		writeAuthError(w, http.StatusInternalServerError, "failed to verify account ownership")
-		return
-	}
-	if !owned {
-		writeAuthError(w, http.StatusForbidden, "access denied")
-		return
-	}
-
-	if recipientID != 0 {
-		ownedRecipient, err := h.recipientOwnedByClient(recipientID, claims.ClientID)
+	if claims != nil {
+		owned, err := h.accountOwnedByClient(racunPosiljaocaID, claims.ClientID)
 		if err != nil {
-			writeAuthError(w, http.StatusInternalServerError, "failed to verify recipient ownership")
+			writeAuthError(w, http.StatusInternalServerError, "failed to verify account ownership")
 			return
 		}
-		if !ownedRecipient {
+		if !owned {
 			writeAuthError(w, http.StatusForbidden, "access denied")
 			return
+		}
+
+		if recipientID != 0 {
+			ownedRecipient, err := h.recipientOwnedByClient(recipientID, claims.ClientID)
+			if err != nil {
+				writeAuthError(w, http.StatusInternalServerError, "failed to verify recipient ownership")
+				return
+			}
+			if !ownedRecipient {
+				writeAuthError(w, http.StatusForbidden, "access denied")
+				return
+			}
 		}
 	}
 
@@ -170,7 +172,7 @@ func (h *CreatePaymentHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		input.RecipientID = &id
 	}
 
-	if h.db != nil {
+	if h.db != nil && claims != nil {
 		var client models.Client
 		if err := h.db.First(&client, claims.ClientID).Error; err == nil {
 			input.ClientEmail = client.Email

--- a/payment-service/internal/handler/mobile_verification_handler.go
+++ b/payment-service/internal/handler/mobile_verification_handler.go
@@ -50,7 +50,7 @@ func (h *PaymentMobileVerificationHandler) Approve(w http.ResponseWriter, r *htt
 	if !ok {
 		return
 	}
-	if !requireClientBasicHTTP(w, claims, claims.ClientID) {
+	if claims != nil && !requireClientBasicHTTP(w, claims, claims.ClientID) {
 		return
 	}
 
@@ -95,7 +95,7 @@ func (h *PaymentMobileVerificationHandler) Reject(w http.ResponseWriter, r *http
 	if !ok {
 		return
 	}
-	if !requireClientBasicHTTP(w, claims, claims.ClientID) {
+	if claims != nil && !requireClientBasicHTTP(w, claims, claims.ClientID) {
 		return
 	}
 
@@ -125,14 +125,16 @@ func (h *PaymentMobileVerificationHandler) authorize(w http.ResponseWriter, r *h
 		writeAuthError(w, http.StatusBadRequest, err.Error())
 		return 0, nil, false
 	}
-	owned, err := h.paymentOwnedByClient(paymentID, claims.ClientID)
-	if err != nil {
-		writeAuthError(w, http.StatusInternalServerError, "failed to verify payment ownership")
-		return 0, nil, false
-	}
-	if !owned {
-		writeAuthError(w, http.StatusForbidden, "access denied")
-		return 0, nil, false
+	if claims != nil {
+		owned, err := h.paymentOwnedByClient(paymentID, claims.ClientID)
+		if err != nil {
+			writeAuthError(w, http.StatusInternalServerError, "failed to verify payment ownership")
+			return 0, nil, false
+		}
+		if !owned {
+			writeAuthError(w, http.StatusForbidden, "access denied")
+			return 0, nil, false
+		}
 	}
 
 	return paymentID, claims, true

--- a/payment-service/internal/handler/payment_handler.go
+++ b/payment-service/internal/handler/payment_handler.go
@@ -133,11 +133,13 @@ func (h *PaymentHandler) CreatePayment(ctx context.Context, req *paymentv1.Creat
 		input.RecipientID = &id
 	}
 	// Get client email from JWT claims for verification email
-	if claims, ok := middleware.GetClaimsFromContext(ctx); ok && claims.ClientID != 0 {
-		var client models.Client
-		if err := h.db.First(&client, claims.ClientID).Error; err == nil {
-			input.ClientEmail = client.Email
-			input.ClientName = client.Ime + " " + client.Prezime
+	if h.db != nil {
+		if claims, ok := middleware.GetClaimsFromContext(ctx); ok && claims.ClientID != 0 {
+			var client models.Client
+			if err := h.db.First(&client, claims.ClientID).Error; err == nil {
+				input.ClientEmail = client.Email
+				input.ClientName = client.Ime + " " + client.Prezime
+			}
 		}
 	}
 

--- a/payment-service/internal/handler/payment_internal_test.go
+++ b/payment-service/internal/handler/payment_internal_test.go
@@ -1,0 +1,1613 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	paymentv1 "github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/gen/proto/payment/v1"
+	prv1 "github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/gen/proto/payment_recipient/v1"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/internal/middleware"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/internal/service"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/internal/util"
+)
+
+// =====================
+// mock services
+// =====================
+
+type mockCreateSvc struct {
+	result *models.Payment
+	err    error
+}
+
+func (m *mockCreateSvc) CreatePayment(_ service.CreatePaymentInput) (*models.Payment, error) {
+	return m.result, m.err
+}
+
+type mockMobileSvc struct {
+	approveResult  *models.Payment
+	approveCode    string
+	approveExpiry  *time.Time
+	approveErr     error
+	rejectResult   *models.Payment
+	rejectErr      error
+}
+
+func (m *mockMobileSvc) ApprovePaymentMobile(_ uint, _ string) (*models.Payment, string, *time.Time, error) {
+	return m.approveResult, m.approveCode, m.approveExpiry, m.approveErr
+}
+
+func (m *mockMobileSvc) RejectPayment(_ uint) (*models.Payment, error) {
+	return m.rejectResult, m.rejectErr
+}
+
+type mockPrenosSvc struct {
+	createResult *models.Payment
+	createErr    error
+	verifyResult *models.Payment
+	verifyErr    error
+}
+
+func (m *mockPrenosSvc) CreatePrenos(_ service.CreatePrenosInput) (*models.Payment, error) {
+	return m.createResult, m.createErr
+}
+
+func (m *mockPrenosSvc) VerifyPrenos(_ uint, _ string) (*models.Payment, error) {
+	return m.verifyResult, m.verifyErr
+}
+
+// =====================
+// helpers
+// =====================
+
+func makePaymentModel(id uint) *models.Payment {
+	return &models.Payment{
+		ID:                id,
+		RacunPosiljaocaID: 1,
+		RacunPrimaocaBroj: "000000000000000001",
+		Iznos:             500,
+		Status:            "u_obradi",
+	}
+}
+
+func newCreateHandler(svc paymentCreateService) *CreatePaymentHTTPHandler {
+	return &CreatePaymentHTTPHandler{svc: svc}
+}
+
+func newMobileHandler(svc paymentMobileVerificationService) *PaymentMobileVerificationHandler {
+	return &PaymentMobileVerificationHandler{svc: svc}
+}
+
+func newPrenosHandler(svc prenosService) *PrenosHTTPHandler {
+	return &PrenosHTTPHandler{svc: svc}
+}
+
+// =====================
+// http_auth helpers
+// =====================
+
+func TestWriteAuthError_SetsStatusAndBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeAuthError(w, http.StatusForbidden, "access denied")
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "access denied") {
+		t.Errorf("body missing message: %s", w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected application/json, got %s", ct)
+	}
+}
+
+func TestParseHTTPClaims_NilConfig_ReturnsNilTrue(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	claims, ok := parseHTTPClaims(w, r, nil)
+	if !ok {
+		t.Error("expected ok=true for nil config")
+	}
+	if claims != nil {
+		t.Error("expected nil claims for nil config")
+	}
+}
+
+func TestParseHTTPClaims_MissingHeader_Returns401(t *testing.T) {
+	cfg := &config.Config{JWTSecret: "secret"}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	_, ok := parseHTTPClaims(w, r, cfg)
+	if ok {
+		t.Error("expected ok=false for missing header")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestParseHTTPClaims_InvalidBearerPrefix_Returns401(t *testing.T) {
+	cfg := &config.Config{JWTSecret: "secret"}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Basic abc")
+	w := httptest.NewRecorder()
+	_, ok := parseHTTPClaims(w, r, cfg)
+	if ok {
+		t.Error("expected ok=false for non-bearer scheme")
+	}
+}
+
+func TestParseHTTPClaims_EmptyTokenAfterBearer_Returns401(t *testing.T) {
+	cfg := &config.Config{JWTSecret: "secret"}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer   ")
+	w := httptest.NewRecorder()
+	_, ok := parseHTTPClaims(w, r, cfg)
+	if ok {
+		t.Error("expected ok=false for empty token")
+	}
+}
+
+func TestParseHTTPClaims_InvalidToken_Returns401(t *testing.T) {
+	cfg := &config.Config{JWTSecret: "secret"}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer notavalidtoken")
+	w := httptest.NewRecorder()
+	_, ok := parseHTTPClaims(w, r, cfg)
+	if ok {
+		t.Error("expected ok=false for invalid token")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestRequireClientPermissionHTTP_NilClaims_ReturnsTrue(t *testing.T) {
+	w := httptest.NewRecorder()
+	if !requireClientPermissionHTTP(w, nil, models.PermClientBasic) {
+		t.Error("expected true for nil claims")
+	}
+}
+
+func TestRequireClientPermissionHTTP_NonClientSource_ReturnsFalse(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{TokenSource: "employee", ClientID: 1}
+	if requireClientPermissionHTTP(w, claims, models.PermClientBasic) {
+		t.Error("expected false for non-client source")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestRequireClientPermissionHTTP_ZeroClientID_ReturnsFalse(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{TokenSource: "client", ClientID: 0}
+	if requireClientPermissionHTTP(w, claims, models.PermClientBasic) {
+		t.Error("expected false for zero client ID")
+	}
+}
+
+func TestRequireClientPermissionHTTP_MissingPerm_ReturnsFalse(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{TokenSource: "client", ClientID: 1, Permissions: []string{}}
+	if requireClientPermissionHTTP(w, claims, models.PermClientBasic) {
+		t.Error("expected false when permission missing")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestRequireClientPermissionHTTP_HasPerm_ReturnsTrue(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{TokenSource: "client", ClientID: 1, Permissions: []string{models.PermClientBasic}}
+	if !requireClientPermissionHTTP(w, claims, models.PermClientBasic) {
+		t.Error("expected true when client has permission")
+	}
+}
+
+func TestRequireClientOwnershipHTTP_NilClaims_ReturnsTrue(t *testing.T) {
+	w := httptest.NewRecorder()
+	if !requireClientOwnershipHTTP(w, nil, 5) {
+		t.Error("expected true for nil claims")
+	}
+}
+
+func TestRequireClientOwnershipHTTP_MatchingID_ReturnsTrue(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{ClientID: 5}
+	if !requireClientOwnershipHTTP(w, claims, 5) {
+		t.Error("expected true for matching client ID")
+	}
+}
+
+func TestRequireClientOwnershipHTTP_MismatchID_ReturnsFalse(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{ClientID: 5}
+	if requireClientOwnershipHTTP(w, claims, 99) {
+		t.Error("expected false for mismatched client ID")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestRequireClientBasicHTTP_NilClaims_ReturnsTrue(t *testing.T) {
+	w := httptest.NewRecorder()
+	if !requireClientBasicHTTP(w, nil, 5) {
+		t.Error("expected true for nil claims")
+	}
+}
+
+func TestRequireClientBasicHTTP_ValidClient_ReturnsTrue(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{TokenSource: "client", ClientID: 5, Permissions: []string{models.PermClientBasic}}
+	if !requireClientBasicHTTP(w, claims, 5) {
+		t.Error("expected true for valid client")
+	}
+}
+
+func TestRequireClientBasicHTTP_WrongClient_ReturnsFalse(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{TokenSource: "client", ClientID: 5, Permissions: []string{models.PermClientBasic}}
+	if requireClientBasicHTTP(w, claims, 99) {
+		t.Error("expected false for wrong client ID")
+	}
+}
+
+
+// =====================
+// writeJSON
+// =====================
+
+func TestWriteJSON_SetsStatusAndBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeJSON(w, http.StatusCreated, map[string]interface{}{"key": "value"})
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected application/json, got %s", ct)
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["key"] != "value" {
+		t.Errorf("expected key=value, got %v", body["key"])
+	}
+}
+
+// =====================
+// toPaymentHTTPJSON
+// =====================
+
+func TestToPaymentHTTPJSON_WithRecipient(t *testing.T) {
+	rid := uint(7)
+	p := makePaymentModel(3)
+	p.RecipientID = &rid
+	j := toPaymentHTTPJSON(p)
+	if j.ID != "3" {
+		t.Errorf("expected ID=3, got %s", j.ID)
+	}
+	if j.RecipientID != "7" {
+		t.Errorf("expected RecipientID=7, got %s", j.RecipientID)
+	}
+}
+
+func TestToPaymentHTTPJSON_WithoutRecipient(t *testing.T) {
+	p := makePaymentModel(5)
+	j := toPaymentHTTPJSON(p)
+	if j.RecipientID != "0" {
+		t.Errorf("expected RecipientID=0, got %s", j.RecipientID)
+	}
+}
+
+// =====================
+// defaultString
+// =====================
+
+func TestDefaultString_ReturnsValue_WhenNonEmpty(t *testing.T) {
+	if got := defaultString("hello", "fallback"); got != "hello" {
+		t.Errorf("expected 'hello', got '%s'", got)
+	}
+}
+
+func TestDefaultString_ReturnsFallback_WhenEmpty(t *testing.T) {
+	if got := defaultString("", "fallback"); got != "fallback" {
+		t.Errorf("expected 'fallback', got '%s'", got)
+	}
+}
+
+func TestDefaultString_ReturnsFallback_WhenWhitespace(t *testing.T) {
+	if got := defaultString("   ", "fallback"); got != "fallback" {
+		t.Errorf("expected 'fallback', got '%s'", got)
+	}
+}
+
+// =====================
+// extractPaymentID
+// =====================
+
+func TestExtractPaymentID_ValidPath(t *testing.T) {
+	id, err := extractPaymentID("/api/v1/payment/42/approve")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 42 {
+		t.Errorf("expected 42, got %d", id)
+	}
+}
+
+func TestExtractPaymentID_ShortPath_ReturnsError(t *testing.T) {
+	if _, err := extractPaymentID("/api/v1"); err == nil {
+		t.Error("expected error for short path")
+	}
+}
+
+func TestExtractPaymentID_NonNumericID_ReturnsError(t *testing.T) {
+	if _, err := extractPaymentID("/api/v1/payment/notanumber/approve"); err == nil {
+		t.Error("expected error for non-numeric ID")
+	}
+}
+
+// =====================
+// extractPrenosID
+// =====================
+
+func TestExtractPrenosID_ValidPath(t *testing.T) {
+	id, err := extractPrenosID("/api/v1/prenos/99/verify")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 99 {
+		t.Errorf("expected 99, got %d", id)
+	}
+}
+
+func TestExtractPrenosID_ShortPath_ReturnsError(t *testing.T) {
+	if _, err := extractPrenosID("/short"); err == nil {
+		t.Error("expected error for short path")
+	}
+}
+
+func TestExtractPrenosID_NonNumericID_ReturnsError(t *testing.T) {
+	if _, err := extractPrenosID("/api/v1/prenos/abc/verify"); err == nil {
+		t.Error("expected error for non-numeric ID")
+	}
+}
+
+// =====================
+// CreatePaymentHTTPHandler
+// =====================
+
+func TestCreateHTTPHandler_WrongMethod_Returns405(t *testing.T) {
+	h := newCreateHandler(&mockCreateSvc{})
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/payments", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestCreateHTTPHandler_InvalidJSON_Returns400(t *testing.T) {
+	h := newCreateHandler(&mockCreateSvc{})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payments", strings.NewReader("not json"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateHTTPHandler_ServiceError_Returns400(t *testing.T) {
+	h := newCreateHandler(&mockCreateSvc{err: errors.New("insufficient funds")})
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_broj":"000001","iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payments", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateHTTPHandler_Success_Returns200(t *testing.T) {
+	h := newCreateHandler(&mockCreateSvc{result: makePaymentModel(1)})
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_broj":"000001","iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payments", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateHTTPHandler_CamelCaseFields_Accepted(t *testing.T) {
+	h := newCreateHandler(&mockCreateSvc{result: makePaymentModel(2)})
+	body := `{"racunPosiljaocaId":1,"racunPrimaocaBroj":"000001","iznos":200,"sifraPlacanja":"289","pozivNaBroj":"99-001","addRecipient":true,"recipientNaziv":"Test"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payments", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// =====================
+// PaymentMobileVerificationHandler
+// =====================
+
+func TestMobileHandler_Approve_WrongMethod_Returns405(t *testing.T) {
+	h := newMobileHandler(&mockMobileSvc{})
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/payment/1/approve", nil)
+	w := httptest.NewRecorder()
+	h.Approve(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestMobileHandler_Approve_BadPath_Returns400(t *testing.T) {
+	h := newMobileHandler(&mockMobileSvc{})
+	r := httptest.NewRequest(http.MethodPost, "/bad", nil)
+	w := httptest.NewRecorder()
+	h.Approve(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestMobileHandler_Approve_Success_Returns200(t *testing.T) {
+	svc := &mockMobileSvc{approveResult: makePaymentModel(5)}
+	h := newMobileHandler(svc)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payment/5/approve", nil)
+	w := httptest.NewRecorder()
+	h.Approve(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestMobileHandler_Approve_WithVerificationCode_Returns200(t *testing.T) {
+	expiry := time.Now().Add(10 * time.Minute)
+	svc := &mockMobileSvc{approveResult: makePaymentModel(5), approveCode: "ABC123", approveExpiry: &expiry}
+	h := newMobileHandler(svc)
+	body := `{"mode":"code"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payment/5/approve", strings.NewReader(body))
+	r.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+	h.Approve(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "ABC123") {
+		t.Error("expected verificationCode in response")
+	}
+}
+
+func TestMobileHandler_Approve_ServiceError_Returns400(t *testing.T) {
+	svc := &mockMobileSvc{approveErr: errors.New("payment not found")}
+	h := newMobileHandler(svc)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payment/5/approve", nil)
+	w := httptest.NewRecorder()
+	h.Approve(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestMobileHandler_Approve_InvalidBody_Returns400(t *testing.T) {
+	h := newMobileHandler(&mockMobileSvc{approveResult: makePaymentModel(1)})
+	body := "not json"
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payment/1/approve", strings.NewReader(body))
+	r.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+	h.Approve(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestMobileHandler_Reject_WrongMethod_Returns405(t *testing.T) {
+	h := newMobileHandler(&mockMobileSvc{})
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/payment/1/reject", nil)
+	w := httptest.NewRecorder()
+	h.Reject(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestMobileHandler_Reject_BadPath_Returns400(t *testing.T) {
+	h := newMobileHandler(&mockMobileSvc{})
+	r := httptest.NewRequest(http.MethodPost, "/bad", nil)
+	w := httptest.NewRecorder()
+	h.Reject(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestMobileHandler_Reject_Success_Returns200(t *testing.T) {
+	svc := &mockMobileSvc{rejectResult: makePaymentModel(3)}
+	h := newMobileHandler(svc)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payment/3/reject", nil)
+	w := httptest.NewRecorder()
+	h.Reject(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestMobileHandler_Reject_ServiceError_Returns400(t *testing.T) {
+	svc := &mockMobileSvc{rejectErr: errors.New("already settled")}
+	h := newMobileHandler(svc)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payment/3/reject", nil)
+	w := httptest.NewRecorder()
+	h.Reject(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestMobileHandler_WriteVerificationError_PaymentNotPending_Returns409(t *testing.T) {
+	h := newMobileHandler(&mockMobileSvc{})
+	w := httptest.NewRecorder()
+	verErr := &service.PaymentVerificationError{
+		Code:    "payment_not_pending",
+		Message: "not pending",
+		Status:  "uspesno",
+	}
+	h.writeVerificationError(w, verErr)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+	var body map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&body)
+	if body["code"] != "payment_not_pending" {
+		t.Errorf("expected code=payment_not_pending, got %v", body["code"])
+	}
+}
+
+func TestMobileHandler_WriteVerificationError_WithAttemptsRemaining(t *testing.T) {
+	h := newMobileHandler(&mockMobileSvc{})
+	w := httptest.NewRecorder()
+	verErr := &service.PaymentVerificationError{
+		Code:              "insufficient_balance",
+		Message:           "not enough",
+		AttemptsRemaining: 2,
+	}
+	h.writeVerificationError(w, verErr)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+	var body map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&body)
+	if _, ok := body["attemptsRemaining"]; !ok {
+		t.Error("expected attemptsRemaining in response")
+	}
+}
+
+func TestMobileHandler_WriteVerificationError_UnsupportedMode(t *testing.T) {
+	h := newMobileHandler(&mockMobileSvc{})
+	w := httptest.NewRecorder()
+	h.writeVerificationError(w, errors.New("unsupported approval mode"))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	var body map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&body)
+	if body["code"] != "unsupported_approval_mode" {
+		t.Errorf("expected unsupported_approval_mode, got %v", body["code"])
+	}
+}
+
+func TestMobileHandler_WriteVerificationError_GenericError(t *testing.T) {
+	h := newMobileHandler(&mockMobileSvc{})
+	w := httptest.NewRecorder()
+	h.writeVerificationError(w, errors.New("something went wrong"))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// =====================
+// CombinedPaymentHandler
+// =====================
+
+func TestCombinedHandler_RoutesToCreate(t *testing.T) {
+	createH := newCreateHandler(&mockCreateSvc{result: makePaymentModel(1)})
+	mobileH := newMobileHandler(&mockMobileSvc{})
+	combined := NewCombinedPaymentHandler(createH, mobileH, http.NotFoundHandler())
+
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_broj":"001","iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payments", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	combined.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestCombinedHandler_RoutesToApprove(t *testing.T) {
+	mobileH := newMobileHandler(&mockMobileSvc{approveResult: makePaymentModel(1)})
+	combined := NewCombinedPaymentHandler(newCreateHandler(&mockCreateSvc{}), mobileH, http.NotFoundHandler())
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payment/1/approve", nil)
+	w := httptest.NewRecorder()
+	combined.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestCombinedHandler_RoutesToReject(t *testing.T) {
+	mobileH := newMobileHandler(&mockMobileSvc{rejectResult: makePaymentModel(1)})
+	combined := NewCombinedPaymentHandler(newCreateHandler(&mockCreateSvc{}), mobileH, http.NotFoundHandler())
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payment/1/reject", nil)
+	w := httptest.NewRecorder()
+	combined.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestCombinedHandler_UnknownRoute_UsesFallback(t *testing.T) {
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	combined := NewCombinedPaymentHandler(newCreateHandler(&mockCreateSvc{}), newMobileHandler(&mockMobileSvc{}), fallback)
+
+	r := httptest.NewRequest(http.MethodGet, "/unknown", nil)
+	w := httptest.NewRecorder()
+	combined.ServeHTTP(w, r)
+	if w.Code != http.StatusTeapot {
+		t.Errorf("expected 418, got %d", w.Code)
+	}
+}
+
+// =====================
+// PrenosHTTPHandler
+// =====================
+
+func TestPrenosHandler_ServeHTTP_CreateRoute(t *testing.T) {
+	h := newPrenosHandler(&mockPrenosSvc{createResult: makePaymentModel(1)})
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_broj":"001","iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/prenos", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPrenosHandler_ServeHTTP_VerifyRoute(t *testing.T) {
+	h := newPrenosHandler(&mockPrenosSvc{verifyResult: makePaymentModel(1)})
+	body := `{"verification_code":"ABC123"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/prenos/1/verify", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPrenosHandler_ServeHTTP_UnknownRoute_Returns404(t *testing.T) {
+	h := newPrenosHandler(&mockPrenosSvc{})
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/unknown", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestPrenosHandler_Create_InvalidJSON_Returns400(t *testing.T) {
+	h := newPrenosHandler(&mockPrenosSvc{})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/prenos", strings.NewReader("not json"))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestPrenosHandler_Create_ServiceError_Returns400(t *testing.T) {
+	h := newPrenosHandler(&mockPrenosSvc{createErr: errors.New("insufficient funds")})
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_broj":"001","iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/prenos", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestPrenosHandler_Create_CamelCase_Accepted(t *testing.T) {
+	h := newPrenosHandler(&mockPrenosSvc{createResult: makePaymentModel(2)})
+	body := `{"racunPosiljaocaId":2,"racunPrimaocaBroj":"002","iznos":200}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/prenos", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPrenosHandler_Verify_BadPath_Returns400(t *testing.T) {
+	h := newPrenosHandler(&mockPrenosSvc{})
+	body := `{"verification_code":"ABC"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/prenos/bad/verify", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestPrenosHandler_Verify_MissingCode_Returns400(t *testing.T) {
+	h := newPrenosHandler(&mockPrenosSvc{})
+	body := `{"verification_code":""}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/prenos/1/verify", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestPrenosHandler_Verify_ServiceError_Returns400(t *testing.T) {
+	h := newPrenosHandler(&mockPrenosSvc{verifyErr: errors.New("invalid code")})
+	body := `{"verification_code":"WRONG"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/prenos/1/verify", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestPrenosHandler_Verify_ServiceVerificationError_Returns409(t *testing.T) {
+	verErr := &service.PaymentVerificationError{
+		Code:              "payment_not_pending",
+		Message:           "payment is not pending",
+		AttemptsRemaining: 2,
+	}
+	h := newPrenosHandler(&mockPrenosSvc{verifyErr: verErr})
+	body := `{"verification_code":"WRONG"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/prenos/1/verify", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// =====================
+// gRPC PaymentHandler mocks
+// =====================
+
+type mockPaymentGRPCSvc struct {
+	createResult        *models.Payment
+	createErr           error
+	verifyResult        *models.Payment
+	verifyErr           error
+	getResult           *models.Payment
+	getErr              error
+	listByAccountResult []models.Payment
+	listByAccountErr    error
+	listByClientResult  []models.Payment
+	listByClientErr     error
+}
+
+func (m *mockPaymentGRPCSvc) CreatePayment(_ service.CreatePaymentInput) (*models.Payment, error) {
+	return m.createResult, m.createErr
+}
+func (m *mockPaymentGRPCSvc) VerifyPayment(_ uint, _ string) (*models.Payment, error) {
+	return m.verifyResult, m.verifyErr
+}
+func (m *mockPaymentGRPCSvc) GetPayment(_ uint) (*models.Payment, error) {
+	return m.getResult, m.getErr
+}
+func (m *mockPaymentGRPCSvc) ListPaymentsByAccount(_ uint, _ models.PaymentFilter) ([]models.Payment, int64, error) {
+	return m.listByAccountResult, int64(len(m.listByAccountResult)), m.listByAccountErr
+}
+func (m *mockPaymentGRPCSvc) ListPaymentsByClient(_ uint, _ models.PaymentFilter) ([]models.Payment, int64, error) {
+	return m.listByClientResult, int64(len(m.listByClientResult)), m.listByClientErr
+}
+
+func newPaymentGRPCHandler(svc PaymentServiceInterface) *PaymentHandler {
+	return NewPaymentHandlerWithService(svc)
+}
+
+func ctxWithClaims(claims *util.Claims) context.Context {
+	return context.WithValue(context.Background(), middleware.ClaimsKey, claims)
+}
+
+func clientClaims(clientID uint) *util.Claims {
+	return &util.Claims{
+		ClientID:    clientID,
+		TokenSource: "client",
+		Permissions: []string{models.PermClientBasic},
+	}
+}
+
+// =====================
+// PaymentHandler.CreatePayment (gRPC)
+// =====================
+
+func TestPaymentHandler_CreatePayment_MissingPosiljaocaID_ReturnsError(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{})
+	_, err := h.CreatePayment(context.Background(), &paymentv1.CreatePaymentRequest{RacunPrimaocaBroj: "001"})
+	if err == nil {
+		t.Error("expected error for missing racun_posiljaoca_id")
+	}
+}
+
+func TestPaymentHandler_CreatePayment_MissingPrimaocaBroj_ReturnsError(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{})
+	_, err := h.CreatePayment(context.Background(), &paymentv1.CreatePaymentRequest{RacunPosiljaocaId: 1})
+	if err == nil {
+		t.Error("expected error for missing racun_primaoca_broj")
+	}
+}
+
+func TestPaymentHandler_CreatePayment_Success(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{createResult: makePaymentModel(10)})
+	resp, err := h.CreatePayment(context.Background(), &paymentv1.CreatePaymentRequest{
+		RacunPosiljaocaId: 1,
+		RacunPrimaocaBroj: "000111000111000111",
+		Iznos:             100,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Payment.Id != 10 {
+		t.Errorf("expected payment ID=10, got %d", resp.Payment.Id)
+	}
+}
+
+func TestPaymentHandler_CreatePayment_ServiceError_ReturnsInvalidArgument(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{createErr: errors.New("insufficient funds")})
+	_, err := h.CreatePayment(context.Background(), &paymentv1.CreatePaymentRequest{
+		RacunPosiljaocaId: 1,
+		RacunPrimaocaBroj: "001",
+	})
+	if err == nil {
+		t.Error("expected error from service")
+	}
+}
+
+func TestPaymentHandler_CreatePayment_WithClaims_ZeroClientID_ReturnsDenied(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{})
+	ctx := ctxWithClaims(&util.Claims{ClientID: 0})
+	_, err := h.CreatePayment(ctx, &paymentv1.CreatePaymentRequest{
+		RacunPosiljaocaId: 1,
+		RacunPrimaocaBroj: "001",
+	})
+	if err == nil {
+		t.Error("expected error for zero client ID")
+	}
+}
+
+func TestPaymentHandler_CreatePayment_WithClaims_NilDB_Success(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{createResult: makePaymentModel(11)})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.CreatePayment(ctx, &paymentv1.CreatePaymentRequest{
+		RacunPosiljaocaId: 1,
+		RacunPrimaocaBroj: "001",
+		Iznos:             50,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPaymentHandler_CreatePayment_WithClaims_WithRecipientID(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{createResult: makePaymentModel(12)})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.CreatePayment(ctx, &paymentv1.CreatePaymentRequest{
+		RacunPosiljaocaId: 1,
+		RacunPrimaocaBroj: "001",
+		Iznos:             50,
+		RecipientId:       3,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// =====================
+// PaymentHandler.VerifyPayment (gRPC)
+// =====================
+
+func TestPaymentHandler_VerifyPayment_Success(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{verifyResult: makePaymentModel(5)})
+	resp, err := h.VerifyPayment(context.Background(), &paymentv1.VerifyPaymentRequest{
+		Id:               5,
+		VerificationCode: "ABC123",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Payment.Id != 5 {
+		t.Errorf("expected ID=5, got %d", resp.Payment.Id)
+	}
+}
+
+func TestPaymentHandler_VerifyPayment_ServiceError_ReturnsInvalidArgument(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{verifyErr: errors.New("bad code")})
+	_, err := h.VerifyPayment(context.Background(), &paymentv1.VerifyPaymentRequest{Id: 1, VerificationCode: "X"})
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestPaymentHandler_VerifyPayment_VerificationError_NotPending(t *testing.T) {
+	verErr := &service.PaymentVerificationError{Code: "payment_not_pending", Message: "not pending"}
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{verifyErr: verErr})
+	_, err := h.VerifyPayment(context.Background(), &paymentv1.VerifyPaymentRequest{Id: 1, VerificationCode: "X"})
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestPaymentHandler_VerifyPayment_VerificationError_Default(t *testing.T) {
+	verErr := &service.PaymentVerificationError{Code: "invalid_code", Message: "invalid"}
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{verifyErr: verErr})
+	_, err := h.VerifyPayment(context.Background(), &paymentv1.VerifyPaymentRequest{Id: 1, VerificationCode: "X"})
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestPaymentHandler_VerifyPayment_WithClaims_ZeroClientID_ReturnsDenied(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{})
+	ctx := ctxWithClaims(&util.Claims{ClientID: 0})
+	_, err := h.VerifyPayment(ctx, &paymentv1.VerifyPaymentRequest{Id: 1, VerificationCode: "X"})
+	if err == nil {
+		t.Error("expected error for zero client ID")
+	}
+}
+
+func TestPaymentHandler_VerifyPayment_WithClaims_NilDB_Success(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{verifyResult: makePaymentModel(3)})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.VerifyPayment(ctx, &paymentv1.VerifyPaymentRequest{Id: 3, VerificationCode: "ABC"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// =====================
+// PaymentHandler.GetPayment (gRPC)
+// =====================
+
+func TestPaymentHandler_GetPayment_Success(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{getResult: makePaymentModel(7)})
+	resp, err := h.GetPayment(context.Background(), &paymentv1.GetPaymentRequest{Id: 7})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Payment.Id != 7 {
+		t.Errorf("expected ID=7, got %d", resp.Payment.Id)
+	}
+}
+
+func TestPaymentHandler_GetPayment_ServiceError_ReturnsNotFound(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{getErr: errors.New("not found")})
+	_, err := h.GetPayment(context.Background(), &paymentv1.GetPaymentRequest{Id: 99})
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestPaymentHandler_GetPayment_WithClaims_ZeroClientID_ReturnsDenied(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{})
+	ctx := ctxWithClaims(&util.Claims{ClientID: 0})
+	_, err := h.GetPayment(ctx, &paymentv1.GetPaymentRequest{Id: 1})
+	if err == nil {
+		t.Error("expected error for zero client ID")
+	}
+}
+
+func TestPaymentHandler_GetPayment_WithClaims_NilDB_Success(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{getResult: makePaymentModel(8)})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.GetPayment(ctx, &paymentv1.GetPaymentRequest{Id: 8})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// =====================
+// PaymentHandler.ListPaymentsByAccount (gRPC)
+// =====================
+
+func TestPaymentHandler_ListPaymentsByAccount_Success(t *testing.T) {
+	payments := []models.Payment{*makePaymentModel(1), *makePaymentModel(2)}
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{listByAccountResult: payments})
+	resp, err := h.ListPaymentsByAccount(context.Background(), &paymentv1.ListPaymentsByAccountRequest{AccountId: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Payments) != 2 {
+		t.Errorf("expected 2 payments, got %d", len(resp.Payments))
+	}
+}
+
+func TestPaymentHandler_ListPaymentsByAccount_ServiceError(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{listByAccountErr: errors.New("db error")})
+	_, err := h.ListPaymentsByAccount(context.Background(), &paymentv1.ListPaymentsByAccountRequest{AccountId: 1})
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestPaymentHandler_ListPaymentsByAccount_WithClaims_ZeroClientID_ReturnsDenied(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{})
+	ctx := ctxWithClaims(&util.Claims{ClientID: 0})
+	_, err := h.ListPaymentsByAccount(ctx, &paymentv1.ListPaymentsByAccountRequest{AccountId: 1})
+	if err == nil {
+		t.Error("expected error for zero client ID")
+	}
+}
+
+func TestPaymentHandler_ListPaymentsByAccount_WithClaims_NilDB(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{listByAccountResult: []models.Payment{*makePaymentModel(1)}})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.ListPaymentsByAccount(ctx, &paymentv1.ListPaymentsByAccountRequest{AccountId: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPaymentHandler_ListPaymentsByAccount_WithFilter(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{listByAccountResult: []models.Payment{}})
+	req := &paymentv1.ListPaymentsByAccountRequest{
+		AccountId: 1,
+		Status:    "u_obradi",
+		MinAmount: 10,
+		MaxAmount: 1000,
+		DateFrom:  "2024-01-01T00:00:00Z",
+		DateTo:    "2024-12-31T00:00:00Z",
+		Page:      1,
+		PageSize:  10,
+	}
+	_, err := h.ListPaymentsByAccount(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// =====================
+// PaymentHandler.ListPaymentsByClient (gRPC)
+// =====================
+
+func TestPaymentHandler_ListPaymentsByClient_Success(t *testing.T) {
+	payments := []models.Payment{*makePaymentModel(1)}
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{listByClientResult: payments})
+	resp, err := h.ListPaymentsByClient(context.Background(), &paymentv1.ListPaymentsByClientRequest{ClientId: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Payments) != 1 {
+		t.Errorf("expected 1 payment, got %d", len(resp.Payments))
+	}
+}
+
+func TestPaymentHandler_ListPaymentsByClient_ServiceError(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{listByClientErr: errors.New("db error")})
+	_, err := h.ListPaymentsByClient(context.Background(), &paymentv1.ListPaymentsByClientRequest{ClientId: 5})
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestPaymentHandler_ListPaymentsByClient_WithClaims_ZeroClientID_ReturnsDenied(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{})
+	ctx := ctxWithClaims(&util.Claims{ClientID: 0})
+	_, err := h.ListPaymentsByClient(ctx, &paymentv1.ListPaymentsByClientRequest{ClientId: 5})
+	if err == nil {
+		t.Error("expected error for zero client ID")
+	}
+}
+
+func TestPaymentHandler_ListPaymentsByClient_WithClaims_MismatchClientID_ReturnsDenied(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.ListPaymentsByClient(ctx, &paymentv1.ListPaymentsByClientRequest{ClientId: 99})
+	if err == nil {
+		t.Error("expected error for mismatched client ID")
+	}
+}
+
+func TestPaymentHandler_ListPaymentsByClient_WithClaims_Match(t *testing.T) {
+	h := newPaymentGRPCHandler(&mockPaymentGRPCSvc{listByClientResult: []models.Payment{}})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.ListPaymentsByClient(ctx, &paymentv1.ListPaymentsByClientRequest{ClientId: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// =====================
+// parsePaymentFilter
+// =====================
+
+func TestParsePaymentFilter_WithAmounts(t *testing.T) {
+	f := parsePaymentFilter("", "", "", 10.0, 500.0, 1, 20)
+	if f.MinAmount == nil || *f.MinAmount != 10.0 {
+		t.Errorf("expected MinAmount=10, got %v", f.MinAmount)
+	}
+	if f.MaxAmount == nil || *f.MaxAmount != 500.0 {
+		t.Errorf("expected MaxAmount=500, got %v", f.MaxAmount)
+	}
+}
+
+func TestParsePaymentFilter_WithValidDates(t *testing.T) {
+	f := parsePaymentFilter("", "2024-01-01T00:00:00Z", "2024-12-31T00:00:00Z", 0, 0, 0, 0)
+	if f.DateFrom == nil {
+		t.Error("expected DateFrom to be set")
+	}
+	if f.DateTo == nil {
+		t.Error("expected DateTo to be set")
+	}
+}
+
+func TestParsePaymentFilter_WithInvalidDates_IgnoresThem(t *testing.T) {
+	f := parsePaymentFilter("", "not-a-date", "also-not-a-date", 0, 0, 0, 0)
+	if f.DateFrom != nil {
+		t.Error("expected DateFrom to be nil for invalid input")
+	}
+	if f.DateTo != nil {
+		t.Error("expected DateTo to be nil for invalid input")
+	}
+}
+
+func TestToPaymentProto_WithRecipientID(t *testing.T) {
+	rid := uint(42)
+	p := makePaymentModel(9)
+	p.RecipientID = &rid
+	proto := toPaymentProto(p)
+	if proto.RecipientId != 42 {
+		t.Errorf("expected RecipientId=42, got %d", proto.RecipientId)
+	}
+}
+
+// =====================
+// gRPC PaymentRecipientHandler mocks
+// =====================
+
+type mockRecipientGRPCSvc struct {
+	createResult *models.PaymentRecipient
+	createErr    error
+	listResult   []models.PaymentRecipient
+	listErr      error
+	updateResult *models.PaymentRecipient
+	updateErr    error
+	deleteErr    error
+}
+
+func (m *mockRecipientGRPCSvc) CreateRecipient(_ service.CreateRecipientInput) (*models.PaymentRecipient, error) {
+	return m.createResult, m.createErr
+}
+func (m *mockRecipientGRPCSvc) ListRecipientsByClient(_ uint) ([]models.PaymentRecipient, error) {
+	return m.listResult, m.listErr
+}
+func (m *mockRecipientGRPCSvc) UpdateRecipient(_ uint, _ uint, _ service.UpdateRecipientInput) (*models.PaymentRecipient, error) {
+	return m.updateResult, m.updateErr
+}
+func (m *mockRecipientGRPCSvc) DeleteRecipient(_ uint, _ uint) error {
+	return m.deleteErr
+}
+
+func newRecipientGRPCHandler(svc PaymentRecipientServiceInterface) *PaymentRecipientHandler {
+	return NewPaymentRecipientHandlerWithService(svc)
+}
+
+func makeRecipient(id uint) *models.PaymentRecipient {
+	return &models.PaymentRecipient{
+		ID:         id,
+		ClientID:   5,
+		Naziv:      "Test",
+		BrojRacuna: "000111000111000111",
+	}
+}
+
+// =====================
+// PaymentRecipientHandler.CreateRecipient (gRPC)
+// =====================
+
+func TestRecipientHandler_CreateRecipient_Success_NoContext(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{createResult: makeRecipient(1)})
+	resp, err := h.CreateRecipient(context.Background(), &prv1.CreateRecipientRequest{
+		ClientId:   5,
+		Naziv:      "Test",
+		BrojRacuna: "000111000111000111",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Recipient.Id != 1 {
+		t.Errorf("expected ID=1, got %d", resp.Recipient.Id)
+	}
+}
+
+func TestRecipientHandler_CreateRecipient_ZeroClientID_NoContext_ReturnsError(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{})
+	_, err := h.CreateRecipient(context.Background(), &prv1.CreateRecipientRequest{ClientId: 0})
+	if err == nil {
+		t.Error("expected error for zero client_id")
+	}
+}
+
+func TestRecipientHandler_CreateRecipient_ServiceError(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{createErr: errors.New("duplicate")})
+	_, err := h.CreateRecipient(context.Background(), &prv1.CreateRecipientRequest{ClientId: 5, Naziv: "X"})
+	if err == nil {
+		t.Error("expected error from service")
+	}
+}
+
+func TestRecipientHandler_CreateRecipient_WithClaims_ZeroClientID_ReturnsDenied(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{})
+	ctx := ctxWithClaims(&util.Claims{ClientID: 0})
+	_, err := h.CreateRecipient(ctx, &prv1.CreateRecipientRequest{ClientId: 5})
+	if err == nil {
+		t.Error("expected error for zero clientID in claims")
+	}
+}
+
+func TestRecipientHandler_CreateRecipient_WithClaims_MismatchClientID_ReturnsDenied(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.CreateRecipient(ctx, &prv1.CreateRecipientRequest{ClientId: 99})
+	if err == nil {
+		t.Error("expected error for mismatched client ID")
+	}
+}
+
+func TestRecipientHandler_CreateRecipient_WithClaims_Match_Success(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{createResult: makeRecipient(2)})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.CreateRecipient(ctx, &prv1.CreateRecipientRequest{
+		ClientId:   5,
+		Naziv:      "Test",
+		BrojRacuna: "000111000111000111",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// =====================
+// PaymentRecipientHandler.ListRecipients (gRPC)
+// =====================
+
+func TestRecipientHandler_ListRecipients_Success(t *testing.T) {
+	list := []models.PaymentRecipient{*makeRecipient(1), *makeRecipient(2)}
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{listResult: list})
+	resp, err := h.ListRecipients(context.Background(), &prv1.ListRecipientsRequest{ClientId: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Recipients) != 2 {
+		t.Errorf("expected 2 recipients, got %d", len(resp.Recipients))
+	}
+}
+
+func TestRecipientHandler_ListRecipients_ServiceError(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{listErr: errors.New("db error")})
+	_, err := h.ListRecipients(context.Background(), &prv1.ListRecipientsRequest{ClientId: 5})
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestRecipientHandler_ListRecipients_WithClaims_ZeroClientID_ReturnsDenied(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{})
+	ctx := ctxWithClaims(&util.Claims{ClientID: 0})
+	_, err := h.ListRecipients(ctx, &prv1.ListRecipientsRequest{ClientId: 5})
+	if err == nil {
+		t.Error("expected error for zero clientID in claims")
+	}
+}
+
+func TestRecipientHandler_ListRecipients_WithClaims_MismatchClientID_ReturnsDenied(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.ListRecipients(ctx, &prv1.ListRecipientsRequest{ClientId: 99})
+	if err == nil {
+		t.Error("expected error for mismatched client ID")
+	}
+}
+
+func TestRecipientHandler_ListRecipients_WithClaims_Match(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{listResult: []models.PaymentRecipient{*makeRecipient(1)}})
+	ctx := ctxWithClaims(clientClaims(5))
+	resp, err := h.ListRecipients(ctx, &prv1.ListRecipientsRequest{ClientId: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Recipients) != 1 {
+		t.Errorf("expected 1 recipient, got %d", len(resp.Recipients))
+	}
+}
+
+// =====================
+// PaymentRecipientHandler.UpdateRecipient (gRPC)
+// =====================
+
+func TestRecipientHandler_UpdateRecipient_Success(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{updateResult: makeRecipient(1)})
+	resp, err := h.UpdateRecipient(context.Background(), &prv1.UpdateRecipientRequest{
+		Id:       1,
+		ClientId: 5,
+		Naziv:    "Updated",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Recipient.Id != 1 {
+		t.Errorf("expected ID=1, got %d", resp.Recipient.Id)
+	}
+}
+
+func TestRecipientHandler_UpdateRecipient_ServiceError(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{updateErr: errors.New("not found")})
+	_, err := h.UpdateRecipient(context.Background(), &prv1.UpdateRecipientRequest{Id: 99, ClientId: 5})
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestRecipientHandler_UpdateRecipient_WithClaims_ZeroClientID_ReturnsDenied(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{})
+	ctx := ctxWithClaims(&util.Claims{ClientID: 0})
+	_, err := h.UpdateRecipient(ctx, &prv1.UpdateRecipientRequest{Id: 1, ClientId: 5})
+	if err == nil {
+		t.Error("expected error for zero clientID in claims")
+	}
+}
+
+func TestRecipientHandler_UpdateRecipient_WithClaims_MismatchClientID_ReturnsDenied(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.UpdateRecipient(ctx, &prv1.UpdateRecipientRequest{Id: 1, ClientId: 99})
+	if err == nil {
+		t.Error("expected error for mismatched client ID")
+	}
+}
+
+func TestRecipientHandler_UpdateRecipient_WithClaims_Match_Success(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{updateResult: makeRecipient(1)})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.UpdateRecipient(ctx, &prv1.UpdateRecipientRequest{Id: 1, ClientId: 5, Naziv: "Updated"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// =====================
+// PaymentRecipientHandler.DeleteRecipient (gRPC)
+// =====================
+
+func TestRecipientHandler_DeleteRecipient_Success(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{})
+	resp, err := h.DeleteRecipient(context.Background(), &prv1.DeleteRecipientRequest{Id: 1, ClientId: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Message == "" {
+		t.Error("expected non-empty message")
+	}
+}
+
+func TestRecipientHandler_DeleteRecipient_ServiceError(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{deleteErr: errors.New("not found")})
+	_, err := h.DeleteRecipient(context.Background(), &prv1.DeleteRecipientRequest{Id: 99, ClientId: 5})
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestRecipientHandler_DeleteRecipient_WithClaims_ZeroClientID_ReturnsDenied(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{})
+	ctx := ctxWithClaims(&util.Claims{ClientID: 0})
+	_, err := h.DeleteRecipient(ctx, &prv1.DeleteRecipientRequest{Id: 1, ClientId: 5})
+	if err == nil {
+		t.Error("expected error for zero clientID in claims")
+	}
+}
+
+func TestRecipientHandler_DeleteRecipient_WithClaims_MismatchClientID_ReturnsDenied(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.DeleteRecipient(ctx, &prv1.DeleteRecipientRequest{Id: 1, ClientId: 99})
+	if err == nil {
+		t.Error("expected error for mismatched client ID")
+	}
+}
+
+func TestRecipientHandler_DeleteRecipient_WithClaims_Match_Success(t *testing.T) {
+	h := newRecipientGRPCHandler(&mockRecipientGRPCSvc{})
+	ctx := ctxWithClaims(clientClaims(5))
+	_, err := h.DeleteRecipient(ctx, &prv1.DeleteRecipientRequest{Id: 1, ClientId: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// =====================
+// JWT-authenticated HTTP handler tests
+// =====================
+
+const testJWTSecret = "test-secret-key"
+
+func makeTestJWT(claims *util.Claims) string {
+	claims.RegisteredClaims = jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, _ := token.SignedString([]byte(testJWTSecret))
+	return signed
+}
+
+func testCfg() *config.Config {
+	return &config.Config{JWTSecret: testJWTSecret}
+}
+
+func makeClientJWT(clientID uint) string {
+	return makeTestJWT(&util.Claims{
+		ClientID:    clientID,
+		TokenSource: "client",
+		TokenType:   "access",
+		Permissions: []string{models.PermClientBasic},
+	})
+}
+
+// =====================
+// CreatePaymentHTTPHandler with auth
+// =====================
+
+func TestCreateHTTPHandler_WithAuth_AccountOwnershipCheck(t *testing.T) {
+	h := &CreatePaymentHTTPHandler{
+		svc: &mockCreateSvc{result: makePaymentModel(1)},
+		cfg: testCfg(),
+	}
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_broj":"000001","iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payments", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+makeClientJWT(5))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (nil db → ownership allowed), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateHTTPHandler_WithAuth_RecipientOwnershipCheck(t *testing.T) {
+	h := &CreatePaymentHTTPHandler{
+		svc: &mockCreateSvc{result: makePaymentModel(2)},
+		cfg: testCfg(),
+	}
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_broj":"000001","iznos":100,"recipient_id":3}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payments", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+makeClientJWT(5))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (nil db → recipient ownership allowed), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// =====================
+// PrenosHTTPHandler with auth
+// =====================
+
+func TestPrenosHandler_Create_WithAuth_ClaimsNotNil(t *testing.T) {
+	h := &PrenosHTTPHandler{
+		svc: &mockPrenosSvc{createResult: makePaymentModel(1)},
+		cfg: testCfg(),
+	}
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_broj":"000001","iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/prenos", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+makeClientJWT(5))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (nil db → allowed), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPrenosHandler_Create_WithAuth_ServiceError(t *testing.T) {
+	h := &PrenosHTTPHandler{
+		svc: &mockPrenosSvc{createErr: errors.New("limit exceeded")},
+		cfg: testCfg(),
+	}
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_broj":"000001","iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/prenos", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+makeClientJWT(5))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestPrenosHandler_Verify_WithAuth_ClaimsNotNil(t *testing.T) {
+	h := &PrenosHTTPHandler{
+		svc: &mockPrenosSvc{verifyResult: makePaymentModel(1)},
+		cfg: testCfg(),
+	}
+	body := `{"verification_code":"ABC123"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/prenos/1/verify", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+makeClientJWT(5))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (nil db → allowed), got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestPrenosHandler_Verify_WithAuth_VerificationError_UnsupportedAccounts(t *testing.T) {
+	verErr := &service.PaymentVerificationError{
+		Code:    "unsupported_prenos_accounts",
+		Message: "unsupported accounts",
+	}
+	h := &PrenosHTTPHandler{
+		svc: &mockPrenosSvc{verifyErr: verErr},
+		cfg: testCfg(),
+	}
+	body := `{"verification_code":"ABC"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/prenos/1/verify", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+makeClientJWT(5))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409 for unsupported_prenos_accounts, got %d", w.Code)
+	}
+}
+
+// =====================
+// PaymentMobileVerificationHandler with auth
+// =====================
+
+func TestMobileHandler_Approve_WithAuth_ClaimsNotNil_NilDB_Success(t *testing.T) {
+	h := &PaymentMobileVerificationHandler{
+		svc: &mockMobileSvc{approveResult: makePaymentModel(5)},
+		cfg: testCfg(),
+	}
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payment/5/approve", nil)
+	r.Header.Set("Authorization", "Bearer "+makeClientJWT(5))
+	w := httptest.NewRecorder()
+	h.Approve(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestMobileHandler_Reject_WithAuth_ClaimsNotNil_NilDB_Success(t *testing.T) {
+	h := &PaymentMobileVerificationHandler{
+		svc: &mockMobileSvc{rejectResult: makePaymentModel(5)},
+		cfg: testCfg(),
+	}
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/payment/5/reject", nil)
+	r.Header.Set("Authorization", "Bearer "+makeClientJWT(5))
+	w := httptest.NewRecorder()
+	h.Reject(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/payment-service/internal/handler/prenos_http_handler.go
+++ b/payment-service/internal/handler/prenos_http_handler.go
@@ -77,14 +77,16 @@ func (h *PrenosHTTPHandler) create(w http.ResponseWriter, r *http.Request) {
 		racunPrimaocaBroj = strings.TrimSpace(req.RacunPrimaocaBrojCamel)
 	}
 
-	owned, err := h.accountOwnedByClient(racunPosiljaocaID, claims.ClientID)
-	if err != nil {
-		writeAuthError(w, http.StatusInternalServerError, "failed to verify account ownership")
-		return
-	}
-	if !owned {
-		writeAuthError(w, http.StatusForbidden, "access denied")
-		return
+	if claims != nil {
+		owned, err := h.accountOwnedByClient(racunPosiljaocaID, claims.ClientID)
+		if err != nil {
+			writeAuthError(w, http.StatusInternalServerError, "failed to verify account ownership")
+			return
+		}
+		if !owned {
+			writeAuthError(w, http.StatusForbidden, "access denied")
+			return
+		}
 	}
 
 	input := service.CreatePrenosInput{
@@ -94,7 +96,7 @@ func (h *PrenosHTTPHandler) create(w http.ResponseWriter, r *http.Request) {
 		Svrha:             req.Svrha,
 	}
 
-	if h.db != nil {
+	if h.db != nil && claims != nil {
 		var client models.Client
 		if err := h.db.First(&client, claims.ClientID).Error; err == nil {
 			input.ClientEmail = client.Email
@@ -130,14 +132,16 @@ func (h *PrenosHTTPHandler) verify(w http.ResponseWriter, r *http.Request) {
 		writeAuthError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	owned, err := h.paymentOwnedByClient(prenosID, claims.ClientID)
-	if err != nil {
-		writeAuthError(w, http.StatusInternalServerError, "failed to verify prenos ownership")
-		return
-	}
-	if !owned {
-		writeAuthError(w, http.StatusForbidden, "access denied")
-		return
+	if claims != nil {
+		owned, err := h.paymentOwnedByClient(prenosID, claims.ClientID)
+		if err != nil {
+			writeAuthError(w, http.StatusInternalServerError, "failed to verify prenos ownership")
+			return
+		}
+		if !owned {
+			writeAuthError(w, http.StatusForbidden, "access denied")
+			return
+		}
 	}
 
 	var body struct {

--- a/transfer-service/internal/handler/http_handler_internal_test.go
+++ b/transfer-service/internal/handler/http_handler_internal_test.go
@@ -1,0 +1,902 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/transfer-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/transfer-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/transfer-service/internal/service"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/transfer-service/internal/util"
+)
+
+// --- mock HTTP service ---
+
+type mockHTTPSvc struct {
+	createResult    *models.Transfer
+	createErr       error
+	previewResult   *service.TransferPreview
+	previewErr      error
+	byClientResult  []models.Transfer
+	byClientTotal   int64
+	byAccountResult []models.Transfer
+	byAccountTotal  int64
+	listErr         error
+}
+
+func (m *mockHTTPSvc) CreateAndSettleTransfer(_ service.CreateTransferInput) (*models.Transfer, error) {
+	return m.createResult, m.createErr
+}
+
+func (m *mockHTTPSvc) PreviewTransfer(_ service.CreateTransferInput) (*service.TransferPreview, error) {
+	return m.previewResult, m.previewErr
+}
+
+func (m *mockHTTPSvc) ListTransfersByAccount(_ uint, _ models.TransferFilter) ([]models.Transfer, int64, error) {
+	return m.byAccountResult, m.byAccountTotal, m.listErr
+}
+
+func (m *mockHTTPSvc) ListTransfersByClient(_ uint, _ models.TransferFilter) ([]models.Transfer, int64, error) {
+	return m.byClientResult, m.byClientTotal, m.listErr
+}
+
+// --- mock mobile verification service ---
+
+type mockMobileSvc struct {
+	approveTransfer *models.Transfer
+	approveErr      error
+	rejectTransfer  *models.Transfer
+	rejectErr       error
+}
+
+func (m *mockMobileSvc) ApproveTransferMobile(_ uint, _ string) (*models.Transfer, string, *time.Time, error) {
+	return m.approveTransfer, "", nil, m.approveErr
+}
+
+func (m *mockMobileSvc) RejectTransfer(_ uint) (*models.Transfer, error) {
+	return m.rejectTransfer, m.rejectErr
+}
+
+// --- helpers ---
+
+func makeTestTransfer(id uint) *models.Transfer {
+	return &models.Transfer{
+		ID:                id,
+		RacunPosiljaocaID: 1,
+		RacunPrimaocaID:   2,
+		Iznos:             100,
+		ValutaIznosa:      "RSD",
+		KonvertovaniIznos: 100,
+		Kurs:              1.0,
+		Status:            "uspesno",
+	}
+}
+
+func newTestHTTPHandler(svc transferHTTPService) *TransferHTTPHandler {
+	return &TransferHTTPHandler{svc: svc}
+}
+
+func newTestMobileHandler(svc transferMobileVerificationService) *TransferMobileVerificationHandler {
+	return &TransferMobileVerificationHandler{svc: svc}
+}
+
+// =====================
+// writeAuthError
+// =====================
+
+func TestWriteAuthError_SetsStatusAndBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeAuthError(w, http.StatusUnauthorized, "missing token")
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected application/json, got %s", ct)
+	}
+	if !strings.Contains(w.Body.String(), "missing token") {
+		t.Errorf("body missing message: %s", w.Body.String())
+	}
+}
+
+// =====================
+// parseHTTPClaims
+// =====================
+
+func TestParseHTTPClaims_NilConfig_ReturnsNilTrue(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	claims, ok := parseHTTPClaims(w, r, nil)
+	if !ok {
+		t.Error("expected ok=true with nil config")
+	}
+	if claims != nil {
+		t.Error("expected nil claims with nil config")
+	}
+}
+
+func TestParseHTTPClaims_MissingAuthHeader_Returns401(t *testing.T) {
+	cfg := &config.Config{JWTSecret: "secret"}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	_, ok := parseHTTPClaims(w, r, cfg)
+	if ok {
+		t.Error("expected ok=false for missing auth header")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestParseHTTPClaims_InvalidBearerPrefix_Returns401(t *testing.T) {
+	cfg := &config.Config{JWTSecret: "secret"}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Basic abc123")
+	w := httptest.NewRecorder()
+	_, ok := parseHTTPClaims(w, r, cfg)
+	if ok {
+		t.Error("expected ok=false for non-bearer scheme")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestParseHTTPClaims_InvalidToken_Returns401(t *testing.T) {
+	cfg := &config.Config{JWTSecret: "secret"}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer notavalidtoken")
+	w := httptest.NewRecorder()
+	_, ok := parseHTTPClaims(w, r, cfg)
+	if ok {
+		t.Error("expected ok=false for invalid token")
+	}
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestParseHTTPClaims_EmptyTokenAfterBearer_Returns401(t *testing.T) {
+	cfg := &config.Config{JWTSecret: "secret"}
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("Authorization", "Bearer   ")
+	w := httptest.NewRecorder()
+	_, ok := parseHTTPClaims(w, r, cfg)
+	if ok {
+		t.Error("expected ok=false for empty token")
+	}
+}
+
+// =====================
+// requireClientPermissionHTTP
+// =====================
+
+func TestRequireClientPermissionHTTP_NilClaims_ReturnsTrue(t *testing.T) {
+	w := httptest.NewRecorder()
+	if !requireClientPermissionHTTP(w, nil, models.PermClientBasic) {
+		t.Error("expected true for nil claims")
+	}
+}
+
+func TestRequireClientPermissionHTTP_NonClientSource_ReturnsFalse(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{TokenSource: "employee", ClientID: 1}
+	if requireClientPermissionHTTP(w, claims, models.PermClientBasic) {
+		t.Error("expected false for employee token source")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestRequireClientPermissionHTTP_ZeroClientID_ReturnsFalse(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{TokenSource: "client", ClientID: 0}
+	if requireClientPermissionHTTP(w, claims, models.PermClientBasic) {
+		t.Error("expected false for zero client ID")
+	}
+}
+
+func TestRequireClientPermissionHTTP_HasPermission_ReturnsTrue(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{TokenSource: "client", ClientID: 1, Permissions: []string{models.PermClientBasic}}
+	if !requireClientPermissionHTTP(w, claims, models.PermClientBasic) {
+		t.Error("expected true when client has permission")
+	}
+}
+
+func TestRequireClientPermissionHTTP_MissingPermission_ReturnsFalse(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{TokenSource: "client", ClientID: 1, Permissions: []string{}}
+	if requireClientPermissionHTTP(w, claims, models.PermClientBasic) {
+		t.Error("expected false when permission is missing")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+// =====================
+// requireClientBasicHTTP
+// =====================
+
+func TestRequireClientBasicHTTP_MatchingClientID_ReturnsTrue(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{TokenSource: "client", ClientID: 5, Permissions: []string{models.PermClientBasic}}
+	if !requireClientBasicHTTP(w, claims, 5) {
+		t.Error("expected true for matching client ID")
+	}
+}
+
+func TestRequireClientBasicHTTP_MismatchedClientID_ReturnsFalse(t *testing.T) {
+	w := httptest.NewRecorder()
+	claims := &util.Claims{TokenSource: "client", ClientID: 5, Permissions: []string{models.PermClientBasic}}
+	if requireClientBasicHTTP(w, claims, 99) {
+		t.Error("expected false for mismatched client ID")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestRequireClientBasicHTTP_NilClaims_ReturnsTrue(t *testing.T) {
+	w := httptest.NewRecorder()
+	if !requireClientBasicHTTP(w, nil, 5) {
+		t.Error("expected true for nil claims")
+	}
+}
+
+// =====================
+// parsePositiveInt
+// =====================
+
+func TestParsePositiveInt(t *testing.T) {
+	cases := []struct {
+		input    string
+		fallback int
+		want     int
+	}{
+		{"5", 1, 5},
+		{"0", 1, 1},
+		{"-1", 1, 1},
+		{"abc", 1, 1},
+		{"", 20, 20},
+		{"100", 20, 100},
+		{" 10 ", 1, 10},
+	}
+	for _, c := range cases {
+		got := parsePositiveInt(c.input, c.fallback)
+		if got != c.want {
+			t.Errorf("parsePositiveInt(%q, %d) = %d, want %d", c.input, c.fallback, got, c.want)
+		}
+	}
+}
+
+// =====================
+// extractPathUint
+// =====================
+
+func TestExtractPathUint_ValidPath(t *testing.T) {
+	got, err := extractPathUint("/api/v1/transfers/client/42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 42 {
+		t.Errorf("expected 42, got %d", got)
+	}
+}
+
+func TestExtractPathUint_TooShortPath_ReturnsError(t *testing.T) {
+	if _, err := extractPathUint("/api/v1/short"); err == nil {
+		t.Error("expected error for short path")
+	}
+}
+
+func TestExtractPathUint_NonNumericID_ReturnsError(t *testing.T) {
+	if _, err := extractPathUint("/api/v1/transfers/client/notanumber"); err == nil {
+		t.Error("expected error for non-numeric id")
+	}
+}
+
+// =====================
+// uintToString
+// =====================
+
+func TestUintToString(t *testing.T) {
+	if got := uintToString(123); got != "123" {
+		t.Errorf("expected '123', got '%s'", got)
+	}
+	if got := uintToString(0); got != "0" {
+		t.Errorf("expected '0', got '%s'", got)
+	}
+}
+
+// =====================
+// decodeTransferInput
+// =====================
+
+func TestDecodeTransferInput_SnakeCase(t *testing.T) {
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_id":2,"iznos":500,"svrha":"test"}`
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	input, err := decodeTransferInput(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if input.RacunPosiljaocaID != 1 || input.RacunPrimaocaID != 2 || input.Iznos != 500 || input.Svrha != "test" {
+		t.Errorf("unexpected input: %+v", input)
+	}
+}
+
+func TestDecodeTransferInput_CamelCase(t *testing.T) {
+	body := `{"racunPosiljaocaId":3,"racunPrimaocaId":4,"iznos":200}`
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	input, err := decodeTransferInput(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if input.RacunPosiljaocaID != 3 || input.RacunPrimaocaID != 4 {
+		t.Errorf("unexpected input: %+v", input)
+	}
+}
+
+func TestDecodeTransferInput_InvalidJSON_ReturnsError(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("not json"))
+	if _, err := decodeTransferInput(r); err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+// =====================
+// toTransferHTTPJSON
+// =====================
+
+func TestToTransferHTTPJSON(t *testing.T) {
+	tr := makeTestTransfer(7)
+	j := toTransferHTTPJSON(tr)
+	if j.ID != "7" {
+		t.Errorf("expected ID='7', got '%s'", j.ID)
+	}
+	if j.Iznos != tr.Iznos {
+		t.Errorf("expected Iznos=%f, got %f", tr.Iznos, j.Iznos)
+	}
+	if j.Status != tr.Status {
+		t.Errorf("expected Status=%s, got %s", tr.Status, j.Status)
+	}
+	if j.RacunPosiljaocaID != "1" || j.RacunPrimaocaID != "2" {
+		t.Errorf("unexpected account IDs: %s, %s", j.RacunPosiljaocaID, j.RacunPrimaocaID)
+	}
+}
+
+// =====================
+// parseHTTPTransferFilter
+// =====================
+
+func TestParseHTTPTransferFilter_Defaults(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/transfers", nil)
+	f := parseHTTPTransferFilter(r)
+	if f.Page != 1 {
+		t.Errorf("expected page=1, got %d", f.Page)
+	}
+	if f.PageSize != 20 {
+		t.Errorf("expected pageSize=20, got %d", f.PageSize)
+	}
+	if f.MinAmount != nil || f.MaxAmount != nil || f.DateFrom != nil || f.DateTo != nil {
+		t.Error("expected nil optional filters")
+	}
+}
+
+func TestParseHTTPTransferFilter_WithParams(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/transfers?page=3&page_size=10&status=uspesno&min_amount=100&max_amount=500", nil)
+	f := parseHTTPTransferFilter(r)
+	if f.Page != 3 {
+		t.Errorf("expected page=3, got %d", f.Page)
+	}
+	if f.PageSize != 10 {
+		t.Errorf("expected pageSize=10, got %d", f.PageSize)
+	}
+	if f.Status != "uspesno" {
+		t.Errorf("expected status=uspesno, got %s", f.Status)
+	}
+	if f.MinAmount == nil || *f.MinAmount != 100 {
+		t.Error("expected minAmount=100")
+	}
+	if f.MaxAmount == nil || *f.MaxAmount != 500 {
+		t.Error("expected maxAmount=500")
+	}
+}
+
+func TestParseHTTPTransferFilter_WithDates(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/transfers?date_from=2025-01-01T00:00:00Z&date_to=2025-12-31T23:59:59Z", nil)
+	f := parseHTTPTransferFilter(r)
+	if f.DateFrom == nil {
+		t.Error("expected DateFrom to be set")
+	}
+	if f.DateTo == nil {
+		t.Error("expected DateTo to be set")
+	}
+}
+
+func TestParseHTTPTransferFilter_InvalidAmounts_IgnoredGracefully(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/transfers?min_amount=notanumber&max_amount=alsonotanumber", nil)
+	f := parseHTTPTransferFilter(r)
+	if f.MinAmount != nil {
+		t.Error("expected MinAmount nil for invalid value")
+	}
+	if f.MaxAmount != nil {
+		t.Error("expected MaxAmount nil for invalid value")
+	}
+}
+
+// =====================
+// writeJSON
+// =====================
+
+func TestWriteJSON_SetsStatusAndBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeJSON(w, http.StatusOK, map[string]interface{}{"key": "value"})
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected application/json, got %s", ct)
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["key"] != "value" {
+		t.Errorf("expected key=value, got %v", body["key"])
+	}
+}
+
+// =====================
+// writeTransferJSON
+// =====================
+
+func TestWriteTransferJSON_SetsStatusAndContentType(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeTransferJSON(w, http.StatusCreated, map[string]interface{}{"message": "ok"})
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected application/json, got %s", ct)
+	}
+}
+
+// =====================
+// extractTransferID
+// =====================
+
+func TestExtractTransferID_ValidPath(t *testing.T) {
+	id, err := extractTransferID("/api/v1/transfer/99/approve")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 99 {
+		t.Errorf("expected 99, got %d", id)
+	}
+}
+
+func TestExtractTransferID_TooShortPath_ReturnsError(t *testing.T) {
+	if _, err := extractTransferID("/api/v1"); err == nil {
+		t.Error("expected error for short path")
+	}
+}
+
+func TestExtractTransferID_NonNumericID_ReturnsError(t *testing.T) {
+	if _, err := extractTransferID("/api/v1/transfer/notanumber/approve"); err == nil {
+		t.Error("expected error for non-numeric ID")
+	}
+}
+
+// =====================
+// TransferHTTPHandler.Create
+// =====================
+
+func TestHTTPCreate_MissingAccountIDs_Returns400(t *testing.T) {
+	h := newTestHTTPHandler(&mockHTTPSvc{})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfers", strings.NewReader(`{"iznos":100}`))
+	w := httptest.NewRecorder()
+	h.Create(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHTTPCreate_InvalidJSON_Returns400(t *testing.T) {
+	h := newTestHTTPHandler(&mockHTTPSvc{})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfers", strings.NewReader("not json"))
+	w := httptest.NewRecorder()
+	h.Create(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHTTPCreate_ServiceError_Returns400(t *testing.T) {
+	svc := &mockHTTPSvc{createErr: errors.New("insufficient funds")}
+	h := newTestHTTPHandler(svc)
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_id":2,"iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfers", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.Create(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHTTPCreate_Success_Returns200(t *testing.T) {
+	svc := &mockHTTPSvc{createResult: makeTestTransfer(1)}
+	h := newTestHTTPHandler(svc)
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_id":2,"iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfers", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.Create(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+// =====================
+// TransferHTTPHandler.Preview
+// =====================
+
+func TestHTTPPreview_MissingAccountIDs_Returns400(t *testing.T) {
+	h := newTestHTTPHandler(&mockHTTPSvc{})
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfers/preview", strings.NewReader(`{"iznos":100}`))
+	w := httptest.NewRecorder()
+	h.Preview(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHTTPPreview_ServiceError_Returns400(t *testing.T) {
+	svc := &mockHTTPSvc{previewErr: errors.New("exchange service unavailable")}
+	h := newTestHTTPHandler(svc)
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_id":2,"iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfers/preview", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.Preview(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHTTPPreview_Success_Returns200(t *testing.T) {
+	svc := &mockHTTPSvc{previewResult: &service.TransferPreview{Iznos: 100, ValutaIznosa: "RSD"}}
+	h := newTestHTTPHandler(svc)
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_id":2,"iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfers/preview", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.Preview(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+// =====================
+// TransferHTTPHandler.ListByClient
+// =====================
+
+func TestHTTPListByClient_BadPath_Returns400(t *testing.T) {
+	h := newTestHTTPHandler(&mockHTTPSvc{})
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/short", nil)
+	w := httptest.NewRecorder()
+	h.ListByClient(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHTTPListByClient_ServiceError_Returns500(t *testing.T) {
+	svc := &mockHTTPSvc{listErr: errors.New("db error")}
+	h := newTestHTTPHandler(svc)
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/transfers/client/5", nil)
+	w := httptest.NewRecorder()
+	h.ListByClient(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHTTPListByClient_Success_Returns200(t *testing.T) {
+	svc := &mockHTTPSvc{byClientResult: []models.Transfer{*makeTestTransfer(1)}, byClientTotal: 1}
+	h := newTestHTTPHandler(svc)
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/transfers/client/5", nil)
+	w := httptest.NewRecorder()
+	h.ListByClient(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+// =====================
+// TransferHTTPHandler.ListByAccount
+// =====================
+
+func TestHTTPListByAccount_BadPath_Returns400(t *testing.T) {
+	h := newTestHTTPHandler(&mockHTTPSvc{})
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/short", nil)
+	w := httptest.NewRecorder()
+	h.ListByAccount(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHTTPListByAccount_ServiceError_Returns500(t *testing.T) {
+	svc := &mockHTTPSvc{listErr: errors.New("db error")}
+	h := newTestHTTPHandler(svc)
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/transfers/account/5", nil)
+	w := httptest.NewRecorder()
+	h.ListByAccount(w, r)
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHTTPListByAccount_Success_Returns200(t *testing.T) {
+	svc := &mockHTTPSvc{byAccountResult: []models.Transfer{*makeTestTransfer(2)}, byAccountTotal: 1}
+	h := newTestHTTPHandler(svc)
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/transfers/account/5", nil)
+	w := httptest.NewRecorder()
+	h.ListByAccount(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+// =====================
+// TransferMobileVerificationHandler.Approve
+// =====================
+
+func TestMobileApprove_WrongMethod_Returns405(t *testing.T) {
+	h := newTestMobileHandler(&mockMobileSvc{})
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/transfer/1/approve", nil)
+	w := httptest.NewRecorder()
+	h.Approve(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestMobileApprove_BadPath_Returns400(t *testing.T) {
+	h := newTestMobileHandler(&mockMobileSvc{})
+	r := httptest.NewRequest(http.MethodPost, "/bad", nil)
+	w := httptest.NewRecorder()
+	h.Approve(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestMobileApprove_Success_Returns200(t *testing.T) {
+	svc := &mockMobileSvc{approveTransfer: makeTestTransfer(5)}
+	h := newTestMobileHandler(svc)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfer/5/approve", nil)
+	w := httptest.NewRecorder()
+	h.Approve(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestMobileApprove_WithModeBody_Success(t *testing.T) {
+	svc := &mockMobileSvc{approveTransfer: makeTestTransfer(5)}
+	h := newTestMobileHandler(svc)
+	body := `{"mode":"2fa"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfer/5/approve", strings.NewReader(body))
+	r.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+	h.Approve(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestMobileApprove_ServiceError_Returns400(t *testing.T) {
+	svc := &mockMobileSvc{approveErr: errors.New("transfer not found")}
+	h := newTestMobileHandler(svc)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfer/5/approve", nil)
+	w := httptest.NewRecorder()
+	h.Approve(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// =====================
+// TransferMobileVerificationHandler.Reject
+// =====================
+
+func TestMobileReject_WrongMethod_Returns405(t *testing.T) {
+	h := newTestMobileHandler(&mockMobileSvc{})
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/transfer/1/reject", nil)
+	w := httptest.NewRecorder()
+	h.Reject(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestMobileReject_Success_Returns200(t *testing.T) {
+	svc := &mockMobileSvc{rejectTransfer: makeTestTransfer(3)}
+	h := newTestMobileHandler(svc)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfer/3/reject", nil)
+	w := httptest.NewRecorder()
+	h.Reject(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestMobileReject_ServiceError_Returns400(t *testing.T) {
+	svc := &mockMobileSvc{rejectErr: errors.New("transfer already settled")}
+	h := newTestMobileHandler(svc)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfer/3/reject", nil)
+	w := httptest.NewRecorder()
+	h.Reject(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// =====================
+// writeVerificationError
+// =====================
+
+func TestWriteVerificationError_TransferNotPending_Returns409(t *testing.T) {
+	h := newTestMobileHandler(&mockMobileSvc{})
+	w := httptest.NewRecorder()
+	verErr := &service.TransferVerificationError{
+		Code:    "transfer_not_pending",
+		Message: "transfer is not pending",
+		Status:  "uspesno",
+	}
+	h.writeVerificationError(w, verErr)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode body: %v", err)
+	}
+	if body["code"] != "transfer_not_pending" {
+		t.Errorf("expected code=transfer_not_pending, got %v", body["code"])
+	}
+}
+
+func TestWriteVerificationError_WithAttemptsRemaining_IncludesField(t *testing.T) {
+	h := newTestMobileHandler(&mockMobileSvc{})
+	w := httptest.NewRecorder()
+	verErr := &service.TransferVerificationError{
+		Code:              "insufficient_balance",
+		Message:           "not enough balance",
+		AttemptsRemaining: 2,
+	}
+	h.writeVerificationError(w, verErr)
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409, got %d", w.Code)
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode body: %v", err)
+	}
+	if _, ok := body["attemptsRemaining"]; !ok {
+		t.Error("expected attemptsRemaining in response")
+	}
+}
+
+func TestWriteVerificationError_UnsupportedMode_SetsCode(t *testing.T) {
+	h := newTestMobileHandler(&mockMobileSvc{})
+	w := httptest.NewRecorder()
+	h.writeVerificationError(w, errors.New("unsupported approval mode"))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode body: %v", err)
+	}
+	if body["code"] != "unsupported_approval_mode" {
+		t.Errorf("expected unsupported_approval_mode, got %v", body["code"])
+	}
+}
+
+func TestWriteVerificationError_GenericError_Returns400(t *testing.T) {
+	h := newTestMobileHandler(&mockMobileSvc{})
+	w := httptest.NewRecorder()
+	h.writeVerificationError(w, errors.New("something went wrong"))
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// =====================
+// CombinedTransferHandler routing
+// =====================
+
+func TestCombinedHandler_RoutesToCreate(t *testing.T) {
+	httpSvc := &mockHTTPSvc{createResult: makeTestTransfer(1)}
+	combined := NewCombinedTransferHandler(newTestHTTPHandler(httpSvc), newTestMobileHandler(&mockMobileSvc{}), http.NotFoundHandler())
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_id":2,"iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfers", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	combined.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestCombinedHandler_RoutesToPreview(t *testing.T) {
+	httpSvc := &mockHTTPSvc{previewResult: &service.TransferPreview{Iznos: 100}}
+	combined := NewCombinedTransferHandler(newTestHTTPHandler(httpSvc), newTestMobileHandler(&mockMobileSvc{}), http.NotFoundHandler())
+	body := `{"racun_posiljaoca_id":1,"racun_primaoca_id":2,"iznos":100}`
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfers/preview", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	combined.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestCombinedHandler_RoutesToListByClient(t *testing.T) {
+	combined := NewCombinedTransferHandler(newTestHTTPHandler(&mockHTTPSvc{}), newTestMobileHandler(&mockMobileSvc{}), http.NotFoundHandler())
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/transfers/client/5", nil)
+	w := httptest.NewRecorder()
+	combined.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestCombinedHandler_RoutesToListByAccount(t *testing.T) {
+	combined := NewCombinedTransferHandler(newTestHTTPHandler(&mockHTTPSvc{}), newTestMobileHandler(&mockMobileSvc{}), http.NotFoundHandler())
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/transfers/account/5", nil)
+	w := httptest.NewRecorder()
+	combined.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestCombinedHandler_RoutesToApprove(t *testing.T) {
+	mobileSvc := &mockMobileSvc{approveTransfer: makeTestTransfer(1)}
+	combined := NewCombinedTransferHandler(newTestHTTPHandler(&mockHTTPSvc{}), newTestMobileHandler(mobileSvc), http.NotFoundHandler())
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfer/1/approve", nil)
+	w := httptest.NewRecorder()
+	combined.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestCombinedHandler_RoutesToReject(t *testing.T) {
+	mobileSvc := &mockMobileSvc{rejectTransfer: makeTestTransfer(1)}
+	combined := NewCombinedTransferHandler(newTestHTTPHandler(&mockHTTPSvc{}), newTestMobileHandler(mobileSvc), http.NotFoundHandler())
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/transfer/1/reject", nil)
+	w := httptest.NewRecorder()
+	combined.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestCombinedHandler_UnknownRoute_UsesBackend(t *testing.T) {
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	combined := NewCombinedTransferHandler(newTestHTTPHandler(&mockHTTPSvc{}), newTestMobileHandler(&mockMobileSvc{}), fallback)
+	r := httptest.NewRequest(http.MethodGet, "/unknown", nil)
+	w := httptest.NewRecorder()
+	combined.ServeHTTP(w, r)
+	if w.Code != http.StatusTeapot {
+		t.Errorf("expected 418, got %d", w.Code)
+	}
+}

--- a/transfer-service/internal/handler/transfer_http_handler.go
+++ b/transfer-service/internal/handler/transfer_http_handler.go
@@ -90,8 +90,10 @@ func (h *TransferHTTPHandler) Create(w http.ResponseWriter, r *http.Request) {
 		writeAuthError(w, http.StatusBadRequest, "sender and receiver account IDs are required")
 		return
 	}
-	if ok := h.ensureAccountsOwnedByClient(w, claims.ClientID, input.RacunPosiljaocaID, input.RacunPrimaocaID); !ok {
-		return
+	if claims != nil {
+		if ok := h.ensureAccountsOwnedByClient(w, claims.ClientID, input.RacunPosiljaocaID, input.RacunPrimaocaID); !ok {
+			return
+		}
 	}
 
 	transfer, err := h.svc.CreateAndSettleTransfer(input)
@@ -126,8 +128,10 @@ func (h *TransferHTTPHandler) Preview(w http.ResponseWriter, r *http.Request) {
 		writeAuthError(w, http.StatusBadRequest, "sender and receiver account IDs are required")
 		return
 	}
-	if ok := h.ensureAccountsOwnedByClient(w, claims.ClientID, input.RacunPosiljaocaID, input.RacunPrimaocaID); !ok {
-		return
+	if claims != nil {
+		if ok := h.ensureAccountsOwnedByClient(w, claims.ClientID, input.RacunPosiljaocaID, input.RacunPrimaocaID); !ok {
+			return
+		}
 	}
 
 	preview, err := h.svc.PreviewTransfer(input)
@@ -203,14 +207,16 @@ func (h *TransferHTTPHandler) ListByAccount(w http.ResponseWriter, r *http.Reque
 		writeAuthError(w, http.StatusBadRequest, "invalid account id")
 		return
 	}
-	owned, err := h.accountOwnedByClient(accountID, claims.ClientID)
-	if err != nil {
-		writeAuthError(w, http.StatusInternalServerError, "failed to verify account ownership")
-		return
-	}
-	if !owned {
-		writeAuthError(w, http.StatusForbidden, "access denied")
-		return
+	if claims != nil {
+		owned, err := h.accountOwnedByClient(accountID, claims.ClientID)
+		if err != nil {
+			writeAuthError(w, http.StatusInternalServerError, "failed to verify account ownership")
+			return
+		}
+		if !owned {
+			writeAuthError(w, http.StatusForbidden, "access denied")
+			return
+		}
 	}
 
 	filter := parseHTTPTransferFilter(r)


### PR DESCRIPTION
…nd exchange services

- payment-service/internal/handler: add internal tests covering HTTP and gRPC handlers (CreatePayment, VerifyPayment, GetPayment, ListPayments, Prenos, mobile approval/rejection, recipients); fix nil-claims and nil-db dereferences in create_payment, prenos, and mobile_verification handlers; fix nil-db guard in payment_handler.go
- transfer-service/internal/handler: add internal tests for HTTP and mobile verification handlers; fix nil-claims dereferences in transfer_http_handler.go
- employee-service/internal/handler: add gRPC and HTTP tests covering CRUD, permissions, and actuaries; fix nil-notifSvc dereference in employee_service.go
- exchange-service/internal/database: add tests for Migrate and SeedMarketData reaching >80% coverage