### PR TITLE
Implement Sprint 6 OTC backend foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,12 @@ jobs:
 
       - name: Docker build (no push)
         run: |
-          cd ..
-          docker build -f EXBanka-3-Backend/${{ matrix.service }}/Dockerfile .
+          case "${{ matrix.service }}" in
+            transfer-service|payment-service|exchange-service|loan-service)
+              docker build -f "${{ matrix.service }}/Dockerfile" "${{ matrix.service }}"
+              ;;
+            *)
+              cd ..
+              docker build -f "EXBanka-3-Backend/${{ matrix.service }}/Dockerfile" .
+              ;;
+          esac

--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -47,10 +47,12 @@ func main() {
 	// Build shared repos and services before starting cron so they're reusable.
 	marketRepo := repository.NewMarketRepository(db)
 	orderRepo := repository.NewOrderRepository(db)
+	portfolioRepo := repository.NewPortfolioRepository(db)
+	otcRepo := repository.NewOtcRepository(db)
 	taxRepo := repository.NewTaxRepository(db)
 	taxSvc := service.NewTaxService(taxRepo, marketRepo, rateProvider)
 	portfolioSvc := service.NewPortfolioService(
-		repository.NewPortfolioRepository(db),
+		portfolioRepo,
 		taxSvc,
 		marketRepo,
 		orderRepo,
@@ -74,6 +76,8 @@ func main() {
 	orderSvc := service.NewOrderService(orderRepo, marketRepo, rateProvider)
 	orderH := handler.NewOrderHTTPHandler(cfg, orderSvc)
 	portfolioH := handler.NewPortfolioHTTPHandler(cfg, portfolioSvc)
+	otcSvc := service.NewOtcService(portfolioRepo, otcRepo)
+	otcH := handler.NewOtcHTTPHandler(cfg, otcSvc)
 
 	taxCollector := service.NewTaxCollector(taxSvc, orderRepo, taxRepo)
 	taxH := handler.NewTaxHTTPHandler(cfg, taxSvc, taxCollector)
@@ -120,6 +124,7 @@ func main() {
 	httpMux.Handle("/api/v1/listings/", middleware.CORS(http.HandlerFunc(marketH.ListingRoutes)))
 	httpMux.Handle("/api/v1/portfolio", middleware.CORS(http.HandlerFunc(portfolioH.PortfolioCollection)))
 	httpMux.Handle("/api/v1/portfolio/", middleware.CORS(http.HandlerFunc(portfolioH.PortfolioRoutes)))
+	httpMux.Handle("/api/v1/otc/", middleware.CORS(http.HandlerFunc(otcH.OtcRoutes)))
 	httpMux.Handle("/api/v1/orders", middleware.CORS(http.HandlerFunc(orderH.OrdersCollection)))
 	httpMux.Handle("/api/v1/orders/", middleware.CORS(http.HandlerFunc(orderH.OrderRoutes)))
 	httpMux.Handle("/api/v1/tax/", middleware.CORS(http.HandlerFunc(taxH.TaxRoutes)))

--- a/exchange-service/internal/database/database.go
+++ b/exchange-service/internal/database/database.go
@@ -42,6 +42,8 @@ func Migrate(db *gorm.DB) error {
 		&models.OrderRecord{},
 		&models.OrderTransactionRecord{},
 		&models.PortfolioHoldingRecord{},
+		&models.OtcOfferRecord{},
+		&models.OtcContractRecord{},
 		&models.TaxRecord{},
 	); err != nil {
 		return fmt.Errorf("migration failed: %w", err)

--- a/exchange-service/internal/database/database_test.go
+++ b/exchange-service/internal/database/database_test.go
@@ -44,6 +44,10 @@ func TestMigrate_CreatesExpectedTables(t *testing.T) {
 		&models.FuturesContractRecord{},
 		&models.OptionRecord{},
 		&models.OrderRecord{},
+		&models.PortfolioHoldingRecord{},
+		&models.OtcOfferRecord{},
+		&models.OtcContractRecord{},
+		&models.TaxRecord{},
 	}
 	for _, m := range tableModels {
 		if !db.Migrator().HasTable(m) {

--- a/exchange-service/internal/handler/handler_helpers_test.go
+++ b/exchange-service/internal/handler/handler_helpers_test.go
@@ -256,7 +256,7 @@ func TestHoldingToResponse_PreservesAssetFields(t *testing.T) {
 	h := service.HoldingWithPnL{
 		Holding: &models.PortfolioHoldingRecord{
 			ID: 1, UserID: 0, UserType: "bank", AssetID: 9, Quantity: 5, AvgBuyPrice: 100,
-			RealizedProfit: 12.5, IsPublic: true, AccountID: 7, CreatedAt: time.Now().UTC(),
+			RealizedProfit: 12.5, IsPublic: true, PublicQuantity: 3, ReservedQuantity: 1, AccountID: 7, CreatedAt: time.Now().UTC(),
 			Asset: models.MarketListingRecord{
 				Ticker: "AAPL", Name: "Apple",
 				Type: "stock", Exchange: models.MarketExchangeRecord{Acronym: "NASDAQ", Currency: "USD"},
@@ -274,6 +274,9 @@ func TestHoldingToResponse_PreservesAssetFields(t *testing.T) {
 	if resp.MarketValue != 550 || resp.UnrealizedPnL != 50 {
 		t.Errorf("pnl fields not propagated: %+v", resp)
 	}
+	if resp.PublicQuantity != 3 || resp.ReservedQuantity != 1 || resp.AvailableForOTC != 2 {
+		t.Errorf("OTC fields not propagated: %+v", resp)
+	}
 }
 
 func TestHoldingToResponse_EmptyAssetIsBlank(t *testing.T) {
@@ -289,12 +292,12 @@ func TestHoldingToResponse_EmptyAssetIsBlank(t *testing.T) {
 func TestBuildPortfolioSummary_AggregatesTotals(t *testing.T) {
 	now := time.Now().UTC()
 	h1 := service.HoldingWithPnL{
-		Holding:      &models.PortfolioHoldingRecord{ID: 1, RealizedProfit: 10, CreatedAt: now},
-		MarketValue:  100, UnrealizedPnL: 5,
+		Holding:     &models.PortfolioHoldingRecord{ID: 1, RealizedProfit: 10, CreatedAt: now},
+		MarketValue: 100, UnrealizedPnL: 5,
 	}
 	h2 := service.HoldingWithPnL{
-		Holding:      &models.PortfolioHoldingRecord{ID: 2, RealizedProfit: 20, CreatedAt: now},
-		MarketValue:  200, UnrealizedPnL: 15,
+		Holding:     &models.PortfolioHoldingRecord{ID: 2, RealizedProfit: 20, CreatedAt: now},
+		MarketValue: 200, UnrealizedPnL: 15,
 	}
 	summary := buildPortfolioSummary(0, "bank", []service.HoldingWithPnL{h1, h2})
 	if summary.PositionCount != 2 {

--- a/exchange-service/internal/handler/handler_http_test.go
+++ b/exchange-service/internal/handler/handler_http_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -328,6 +329,67 @@ func TestPortfolioHTTP_Routes_HoldingNotFound(t *testing.T) {
 	h.PortfolioRoutes(rec, req)
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestPortfolioHTTP_Routes_SetPublicQuantity(t *testing.T) {
+	db := newTestDB(t, "h_pf_public_quantity")
+	_, assetID := seedExchangeAndListing(t, db, "PUB")
+	holding := models.PortfolioHoldingRecord{
+		UserID: 0, UserType: "bank", AssetID: assetID, Quantity: 10, AvgBuyPrice: 100, AccountID: 7,
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupPortfolioHandler(t, db)
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/portfolio/holdings/%d/public", holding.ID), strings.NewReader(`{"publicQuantity":4}`))
+	req.Header.Set("Authorization", "Bearer "+bankToken(t))
+	rec := httptest.NewRecorder()
+	h.PortfolioRoutes(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["publicQuantity"].(float64) != 4 || body["availableForOtc"].(float64) != 4 {
+		t.Fatalf("unexpected response: %+v", body)
+	}
+}
+
+func TestPortfolioHTTP_Routes_SetPublicRejectsNonStock(t *testing.T) {
+	db := newTestDB(t, "h_pf_public_non_stock")
+	exch := models.MarketExchangeRecord{
+		Acronym: "FX", Name: "FX Exchange", MICCode: "FX1", Polity: "X", Currency: "USD",
+		Timezone: "UTC", WorkingHours: "09:00-17:00",
+	}
+	if err := db.Create(&exch).Error; err != nil {
+		t.Fatal(err)
+	}
+	listing := models.MarketListingRecord{
+		Ticker: "EUR/USD", Name: "Euro Dollar", Type: "forex",
+		ExchangeID: exch.ID, Price: 1.1, Ask: 1.11, Bid: 1.09, Volume: 1000,
+	}
+	if err := db.Create(&listing).Error; err != nil {
+		t.Fatal(err)
+	}
+	holding := models.PortfolioHoldingRecord{
+		UserID: 0, UserType: "bank", AssetID: listing.ID, Quantity: 10, AvgBuyPrice: 1.1, AccountID: 7,
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupPortfolioHandler(t, db)
+	req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/portfolio/holdings/%d/public", holding.ID), strings.NewReader(`{"publicQuantity":4}`))
+	req.Header.Set("Authorization", "Bearer "+bankToken(t))
+	rec := httptest.NewRecorder()
+	h.PortfolioRoutes(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got status=%d body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/exchange-service/internal/handler/otc_http_handler.go
+++ b/exchange-service/internal/handler/otc_http_handler.go
@@ -1,0 +1,536 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+type OtcHTTPHandler struct {
+	cfg *config.Config
+	svc *service.OtcService
+}
+
+func NewOtcHTTPHandler(cfg *config.Config, svc *service.OtcService) *OtcHTTPHandler {
+	return &OtcHTTPHandler{cfg: cfg, svc: svc}
+}
+
+func (h *OtcHTTPHandler) OtcRoutes(w http.ResponseWriter, r *http.Request) {
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/otc/"), "/")
+	if path == "" {
+		http.NotFound(w, r)
+		return
+	}
+	parts := strings.Split(path, "/")
+
+	switch {
+	case len(parts) == 1 && parts[0] == "public-stocks":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.listPublicStocks(w, r)
+	case len(parts) == 1 && parts[0] == "offers":
+		switch r.Method {
+		case http.MethodGet:
+			h.listOffers(w, r)
+		case http.MethodPost:
+			h.createOffer(w, r)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	case len(parts) == 1 && parts[0] == "contracts":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.listContracts(w, r)
+	case len(parts) == 2 && parts[0] == "offers":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		offerID, err := strconv.ParseUint(parts[1], 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid offer id"})
+			return
+		}
+		h.getOffer(w, r, uint(offerID))
+	case len(parts) == 3 && parts[0] == "offers":
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		offerID, err := strconv.ParseUint(parts[1], 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid offer id"})
+			return
+		}
+		switch parts[2] {
+		case "counter":
+			h.counterOffer(w, r, uint(offerID))
+		case "accept":
+			h.acceptOffer(w, r, uint(offerID))
+		case "decline":
+			h.declineOffer(w, r, uint(offerID))
+		case "cancel":
+			h.cancelOffer(w, r, uint(offerID))
+		default:
+			http.NotFound(w, r)
+		}
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *OtcHTTPHandler) listPublicStocks(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+
+	requesterID, requesterType := callerIdentity(claims)
+	stocks, err := h.svc.ListPublicStocks(requesterID, requesterType)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to load public OTC stocks"})
+		return
+	}
+
+	items := make([]publicOtcStockResponse, 0, len(stocks))
+	for _, stock := range stocks {
+		items = append(items, publicOtcStockToResponse(stock))
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"stocks": items,
+		"count":  len(items),
+	})
+}
+
+func (h *OtcHTTPHandler) createOffer(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+
+	var body struct {
+		SellerHoldingID uint    `json:"sellerHoldingId"`
+		BuyerAccountID  uint    `json:"buyerAccountId"`
+		Amount          float64 `json:"amount"`
+		PricePerStock   float64 `json:"pricePerStock"`
+		SettlementDate  string  `json:"settlementDate"`
+		Premium         float64 `json:"premium"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid request body"})
+		return
+	}
+
+	settlementDate, err := parseSettlementDate(body.SettlementDate)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+
+	buyerID, buyerType := callerIdentity(claims)
+	offer, err := h.svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         buyerID,
+		BuyerType:       buyerType,
+		BuyerAccountID:  body.BuyerAccountID,
+		SellerHoldingID: body.SellerHoldingID,
+		Amount:          body.Amount,
+		PricePerStock:   body.PricePerStock,
+		SettlementDate:  settlementDate,
+		Premium:         body.Premium,
+	})
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]interface{}{"offer": otcOfferToResponse(*offer)})
+}
+
+func (h *OtcHTTPHandler) listOffers(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+
+	userID, userType := callerIdentity(claims)
+	status := strings.TrimSpace(r.URL.Query().Get("status"))
+	offers, err := h.svc.ListOffersForParticipant(userID, userType, status)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+
+	items := make([]otcOfferResponse, 0, len(offers))
+	for _, offer := range offers {
+		items = append(items, otcOfferToResponse(offer))
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"offers": items,
+		"count":  len(items),
+		"status": status,
+	})
+}
+
+func (h *OtcHTTPHandler) listContracts(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+
+	userID, userType := callerIdentity(claims)
+	status := strings.TrimSpace(r.URL.Query().Get("status"))
+	contracts, err := h.svc.ListContractsForParticipant(userID, userType, status)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+
+	items := make([]otcContractResponse, 0, len(contracts))
+	for _, contract := range contracts {
+		items = append(items, otcContractToResponse(contract))
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"contracts": items,
+		"count":     len(items),
+		"status":    status,
+	})
+}
+
+func (h *OtcHTTPHandler) getOffer(w http.ResponseWriter, r *http.Request, offerID uint) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+
+	userID, userType := callerIdentity(claims)
+	offer, err := h.svc.GetOfferForParticipant(offerID, userID, userType)
+	if err != nil {
+		if errors.Is(err, service.ErrOtcOfferNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"message": "offer not found"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to load offer"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"offer": otcOfferToResponse(*offer)})
+}
+
+func (h *OtcHTTPHandler) acceptOffer(w http.ResponseWriter, r *http.Request, offerID uint) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+
+	sellerID, sellerType := callerIdentity(claims)
+	contract, err := h.svc.AcceptOffer(offerID, sellerID, sellerType)
+	if err != nil {
+		if errors.Is(err, service.ErrOtcOfferNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"message": "offer not found"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"contract": otcContractToResponse(*contract)})
+}
+
+func (h *OtcHTTPHandler) declineOffer(w http.ResponseWriter, r *http.Request, offerID uint) {
+	h.updateOfferStatus(w, r, offerID, "decline")
+}
+
+func (h *OtcHTTPHandler) cancelOffer(w http.ResponseWriter, r *http.Request, offerID uint) {
+	h.updateOfferStatus(w, r, offerID, "cancel")
+}
+
+func (h *OtcHTTPHandler) updateOfferStatus(w http.ResponseWriter, r *http.Request, offerID uint, action string) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+
+	userID, userType := callerIdentity(claims)
+	var (
+		offer *models.OtcOfferRecord
+		err   error
+	)
+	switch action {
+	case "decline":
+		offer, err = h.svc.DeclineOffer(offerID, userID, userType)
+	case "cancel":
+		offer, err = h.svc.CancelOffer(offerID, userID, userType)
+	default:
+		http.NotFound(w, r)
+		return
+	}
+	if err != nil {
+		if errors.Is(err, service.ErrOtcOfferNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"message": "offer not found"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"offer": otcOfferToResponse(*offer)})
+}
+
+func (h *OtcHTTPHandler) counterOffer(w http.ResponseWriter, r *http.Request, offerID uint) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+
+	var body struct {
+		Amount         float64 `json:"amount"`
+		PricePerStock  float64 `json:"pricePerStock"`
+		SettlementDate string  `json:"settlementDate"`
+		Premium        float64 `json:"premium"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid request body"})
+		return
+	}
+
+	settlementDate, err := parseSettlementDate(body.SettlementDate)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+
+	modifiedByID, modifiedByType := callerIdentity(claims)
+	offer, err := h.svc.CounterOffer(service.CounterOtcOfferInput{
+		OfferID:        offerID,
+		ModifiedByID:   modifiedByID,
+		ModifiedByType: modifiedByType,
+		Amount:         body.Amount,
+		PricePerStock:  body.PricePerStock,
+		SettlementDate: settlementDate,
+		Premium:        body.Premium,
+	})
+	if err != nil {
+		if errors.Is(err, service.ErrOtcOfferNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"message": "offer not found"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"offer": otcOfferToResponse(*offer)})
+}
+
+type publicOtcStockResponse struct {
+	HoldingID         uint    `json:"holdingId"`
+	SellerID          uint    `json:"sellerId"`
+	SellerType        string  `json:"sellerType"`
+	AssetID           uint    `json:"assetId"`
+	Ticker            string  `json:"ticker"`
+	Name              string  `json:"name"`
+	Exchange          string  `json:"exchange"`
+	Currency          string  `json:"currency"`
+	Price             float64 `json:"price"`
+	Ask               float64 `json:"ask"`
+	Bid               float64 `json:"bid"`
+	PublicQuantity    float64 `json:"publicQuantity"`
+	ReservedQuantity  float64 `json:"reservedQuantity"`
+	AvailableQuantity float64 `json:"availableQuantity"`
+	LastRefresh       string  `json:"lastRefresh"`
+}
+
+func publicOtcStockToResponse(stock service.PublicOtcStock) publicOtcStockResponse {
+	return publicOtcStockResponse{
+		HoldingID:         stock.HoldingID,
+		SellerID:          stock.SellerID,
+		SellerType:        stock.SellerType,
+		AssetID:           stock.AssetID,
+		Ticker:            stock.Ticker,
+		Name:              stock.Name,
+		Exchange:          stock.Exchange,
+		Currency:          stock.Currency,
+		Price:             stock.Price,
+		Ask:               stock.Ask,
+		Bid:               stock.Bid,
+		PublicQuantity:    stock.PublicQuantity,
+		ReservedQuantity:  stock.ReservedQuantity,
+		AvailableQuantity: stock.AvailableQuantity,
+		LastRefresh:       stock.LastRefresh.UTC().Format(time.RFC3339),
+	}
+}
+
+type otcOfferResponse struct {
+	ID              uint                    `json:"id"`
+	StockListingID  uint                    `json:"stockListingId"`
+	SellerHoldingID uint                    `json:"sellerHoldingId"`
+	Ticker          string                  `json:"ticker"`
+	Name            string                  `json:"name"`
+	Exchange        exchangeSummaryResponse `json:"exchange"`
+	Amount          float64                 `json:"amount"`
+	PricePerStock   float64                 `json:"pricePerStock"`
+	CurrentPrice    float64                 `json:"currentPrice"`
+	DeviationPct    float64                 `json:"deviationPct"`
+	SettlementDate  string                  `json:"settlementDate"`
+	Premium         float64                 `json:"premium"`
+	LastModified    string                  `json:"lastModified"`
+	ModifiedByID    uint                    `json:"modifiedById"`
+	ModifiedByType  string                  `json:"modifiedByType"`
+	Status          string                  `json:"status"`
+	BuyerID         uint                    `json:"buyerId"`
+	BuyerType       string                  `json:"buyerType"`
+	BuyerAccountID  uint                    `json:"buyerAccountId"`
+	SellerID        uint                    `json:"sellerId"`
+	SellerType      string                  `json:"sellerType"`
+	SellerAccountID uint                    `json:"sellerAccountId"`
+}
+
+type otcContractResponse struct {
+	ID              uint                    `json:"id"`
+	OfferID         *uint                   `json:"offerId,omitempty"`
+	StockListingID  uint                    `json:"stockListingId"`
+	SellerHoldingID uint                    `json:"sellerHoldingId"`
+	Ticker          string                  `json:"ticker"`
+	Name            string                  `json:"name"`
+	Exchange        exchangeSummaryResponse `json:"exchange"`
+	Amount          float64                 `json:"amount"`
+	StrikePrice     float64                 `json:"strikePrice"`
+	CurrentPrice    float64                 `json:"currentPrice"`
+	Premium         float64                 `json:"premium"`
+	Profit          float64                 `json:"profit"`
+	SettlementDate  string                  `json:"settlementDate"`
+	BuyerID         uint                    `json:"buyerId"`
+	BuyerType       string                  `json:"buyerType"`
+	BuyerAccountID  uint                    `json:"buyerAccountId"`
+	SellerID        uint                    `json:"sellerId"`
+	SellerType      string                  `json:"sellerType"`
+	SellerAccountID uint                    `json:"sellerAccountId"`
+	Status          string                  `json:"status"`
+	CreatedAt       string                  `json:"createdAt"`
+}
+
+func otcOfferToResponse(offer models.OtcOfferRecord) otcOfferResponse {
+	currentPrice := offer.StockListing.Price
+	deviationPct := 0.0
+	if currentPrice > 0 {
+		deviationPct = roundOtcDisplayValue(((offer.PricePerStock - currentPrice) / currentPrice) * 100)
+	}
+
+	return otcOfferResponse{
+		ID:              offer.ID,
+		StockListingID:  offer.StockListingID,
+		SellerHoldingID: offer.SellerHoldingID,
+		Ticker:          offer.StockListing.Ticker,
+		Name:            offer.StockListing.Name,
+		Exchange:        exchangeSummaryToResponse(offer.StockListing.Exchange.ToSummary()),
+		Amount:          offer.Amount,
+		PricePerStock:   offer.PricePerStock,
+		CurrentPrice:    currentPrice,
+		DeviationPct:    deviationPct,
+		SettlementDate:  offer.SettlementDate.UTC().Format("2006-01-02"),
+		Premium:         offer.Premium,
+		LastModified:    offer.LastModified.UTC().Format(time.RFC3339),
+		ModifiedByID:    offer.ModifiedByID,
+		ModifiedByType:  offer.ModifiedByType,
+		Status:          offer.Status,
+		BuyerID:         offer.BuyerID,
+		BuyerType:       offer.BuyerType,
+		BuyerAccountID:  offer.BuyerAccountID,
+		SellerID:        offer.SellerID,
+		SellerType:      offer.SellerType,
+		SellerAccountID: offer.SellerAccountID,
+	}
+}
+
+func otcContractToResponse(contract models.OtcContractRecord) otcContractResponse {
+	return otcContractResponse{
+		ID:              contract.ID,
+		OfferID:         contract.OfferID,
+		StockListingID:  contract.StockListingID,
+		SellerHoldingID: contract.SellerHoldingID,
+		Ticker:          contract.StockListing.Ticker,
+		Name:            contract.StockListing.Name,
+		Exchange:        exchangeSummaryToResponse(contract.StockListing.Exchange.ToSummary()),
+		Amount:          contract.Amount,
+		StrikePrice:     contract.StrikePrice,
+		CurrentPrice:    contract.StockListing.Price,
+		Premium:         contract.Premium,
+		Profit:          roundOtcDisplayValue((contract.StockListing.Price-contract.StrikePrice)*contract.Amount - contract.Premium),
+		SettlementDate:  contract.SettlementDate.UTC().Format("2006-01-02"),
+		BuyerID:         contract.BuyerID,
+		BuyerType:       contract.BuyerType,
+		BuyerAccountID:  contract.BuyerAccountID,
+		SellerID:        contract.SellerID,
+		SellerType:      contract.SellerType,
+		SellerAccountID: contract.SellerAccountID,
+		Status:          contract.Status,
+		CreatedAt:       contract.CreatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+func roundOtcDisplayValue(v float64) float64 {
+	return math.Round(v*100) / 100
+}
+
+func parseSettlementDate(raw string) (time.Time, error) {
+	if strings.TrimSpace(raw) == "" {
+		return time.Time{}, errBadSettlementDate()
+	}
+	if parsed, err := time.Parse(time.RFC3339, raw); err == nil {
+		return parsed.UTC(), nil
+	}
+	if parsed, err := time.Parse("2006-01-02", raw); err == nil {
+		return parsed.UTC(), nil
+	}
+	return time.Time{}, errBadSettlementDate()
+}
+
+func errBadSettlementDate() error {
+	return &badRequestError{message: "settlementDate must be RFC3339 or YYYY-MM-DD"}
+}
+
+type badRequestError struct {
+	message string
+}
+
+func (e *badRequestError) Error() string {
+	return e.message
+}

--- a/exchange-service/internal/handler/otc_http_handler_test.go
+++ b/exchange-service/internal/handler/otc_http_handler_test.go
@@ -1,0 +1,808 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/util"
+	"gorm.io/gorm"
+)
+
+func setupOtcHandler(t *testing.T, db *gorm.DB) *OtcHTTPHandler {
+	t.Helper()
+	seedOtcHandlerAccounts(t, db)
+	cfg := &config.Config{JWTSecret: testJWTSecret}
+	otcSvc := service.NewOtcService(repository.NewPortfolioRepository(db), repository.NewOtcRepository(db))
+	return NewOtcHTTPHandler(cfg, otcSvc)
+}
+
+func seedOtcHandlerAccounts(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	if err := db.Exec(`CREATE TABLE IF NOT EXISTS currencies (id integer primary key, kod text not null unique)`).Error; err != nil {
+		t.Fatalf("create currencies table: %v", err)
+	}
+	if err := db.Exec(`CREATE TABLE IF NOT EXISTS accounts (
+		id integer primary key,
+		client_id integer,
+		firma_id integer,
+		zaposleni_id integer,
+		currency_id integer not null,
+		stanje real not null default 0,
+		raspolozivo_stanje real not null default 0,
+		dnevna_potrosnja real not null default 0,
+		mesecna_potrosnja real not null default 0,
+		status text not null default 'aktivan'
+	)`).Error; err != nil {
+		t.Fatalf("create accounts table: %v", err)
+	}
+	if err := db.Exec(`INSERT OR IGNORE INTO currencies (id, kod) VALUES (1, 'USD')`).Error; err != nil {
+		t.Fatalf("seed currency: %v", err)
+	}
+	if err := db.Exec(`INSERT OR IGNORE INTO accounts (id, client_id, currency_id, stanje, raspolozivo_stanje, status) VALUES
+		(1, 200, 1, 1000, 1000, 'aktivan'),
+		(2, 100, 1, 1000, 1000, 'aktivan')`).Error; err != nil {
+		t.Fatalf("seed accounts: %v", err)
+	}
+}
+
+func clientWithoutTradingToken(t *testing.T) string {
+	return makeToken(t, util.Claims{
+		ClientID: 100, TokenSource: "client", TokenType: "access",
+		Permissions: []string{models.PermClientBasic},
+	})
+}
+
+func clientTradingToken(t *testing.T, clientID uint) string {
+	return makeToken(t, util.Claims{
+		ClientID: clientID, TokenSource: "client", TokenType: "access",
+		Permissions: []string{models.PermClientTrading, models.PermClientBasic},
+	})
+}
+
+func TestOtcHTTP_PublicStocks_AuthorizedClient(t *testing.T) {
+	db := newTestDB(t, "h_otc_public_stocks")
+	_, assetID := seedExchangeAndListing(t, db, "OTC")
+
+	sellerHolding := models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID, Quantity: 10,
+		PublicQuantity: 5, ReservedQuantity: 2, AvgBuyPrice: 90, AccountID: 1,
+		CreatedAt: time.Now().UTC(),
+	}
+	ownHolding := models.PortfolioHoldingRecord{
+		UserID: 100, UserType: "client", AssetID: assetID, Quantity: 4,
+		PublicQuantity: 4, AvgBuyPrice: 95, AccountID: 1,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(&[]models.PortfolioHoldingRecord{sellerHolding, ownHolding}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupOtcHandler(t, db)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/otc/public-stocks", nil)
+	req.Header.Set("Authorization", "Bearer "+clientToken(t))
+	rec := httptest.NewRecorder()
+
+	h.OtcRoutes(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Count  int `json:"count"`
+		Stocks []struct {
+			Ticker            string  `json:"ticker"`
+			AvailableQuantity float64 `json:"availableQuantity"`
+			SellerID          uint    `json:"sellerId"`
+		} `json:"stocks"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Count != 1 || len(body.Stocks) != 1 {
+		t.Fatalf("expected one public stock, got %+v", body)
+	}
+	if body.Stocks[0].Ticker != "OTC" || body.Stocks[0].AvailableQuantity != 3 || body.Stocks[0].SellerID != 200 {
+		t.Fatalf("unexpected public stock response: %+v", body.Stocks[0])
+	}
+}
+
+func TestOtcHTTP_PublicStocks_RequiresTradingPermission(t *testing.T) {
+	db := newTestDB(t, "h_otc_public_forbidden")
+	h := setupOtcHandler(t, db)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/otc/public-stocks", nil)
+	req.Header.Set("Authorization", "Bearer "+clientWithoutTradingToken(t))
+	rec := httptest.NewRecorder()
+
+	h.OtcRoutes(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOtcHTTP_OffersRequireTradingPermission(t *testing.T) {
+	db := newTestDB(t, "h_otc_offers_forbidden")
+	h := setupOtcHandler(t, db)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/otc/offers", nil)
+	req.Header.Set("Authorization", "Bearer "+clientWithoutTradingToken(t))
+	rec := httptest.NewRecorder()
+
+	h.OtcRoutes(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOtcHTTP_PublicStocks_WrongMethod(t *testing.T) {
+	db := newTestDB(t, "h_otc_public_method")
+	h := setupOtcHandler(t, db)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/otc/public-stocks", nil)
+	req.Header.Set("Authorization", "Bearer "+clientToken(t))
+	rec := httptest.NewRecorder()
+
+	h.OtcRoutes(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+	if body := rec.Body.String(); body == "" {
+		t.Fatal("expected non-empty method-not-allowed response")
+	}
+}
+
+func TestOtcHTTP_CreateOffer(t *testing.T) {
+	db := newTestDB(t, "h_otc_create_offer")
+	_, assetID := seedExchangeAndListing(t, db, "OFR")
+
+	holding := models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID, Quantity: 10,
+		PublicQuantity: 6, ReservedQuantity: 1, AvgBuyPrice: 90, AccountID: 1,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupOtcHandler(t, db)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/otc/offers",
+		strings.NewReader(fmt.Sprintf(`{"sellerHoldingId":%d,"buyerAccountId":2,"amount":3,"pricePerStock":105,"settlementDate":"2026-12-31","premium":25}`, holding.ID)),
+	)
+	req.Header.Set("Authorization", "Bearer "+clientToken(t))
+	rec := httptest.NewRecorder()
+
+	h.OtcRoutes(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		Offer struct {
+			ID             uint    `json:"id"`
+			Ticker         string  `json:"ticker"`
+			Amount         float64 `json:"amount"`
+			PricePerStock  float64 `json:"pricePerStock"`
+			CurrentPrice   float64 `json:"currentPrice"`
+			DeviationPct   float64 `json:"deviationPct"`
+			Status         string  `json:"status"`
+			BuyerID        uint    `json:"buyerId"`
+			SellerID       uint    `json:"sellerId"`
+			SettlementDate string  `json:"settlementDate"`
+		} `json:"offer"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Offer.ID == 0 || body.Offer.Ticker != "OFR" || body.Offer.Status != models.OtcOfferStatusPending {
+		t.Fatalf("unexpected offer response: %+v", body.Offer)
+	}
+	if body.Offer.Amount != 3 || body.Offer.PricePerStock != 105 || body.Offer.BuyerID != 100 || body.Offer.SellerID != 200 {
+		t.Fatalf("unexpected offer fields: %+v", body.Offer)
+	}
+	if body.Offer.CurrentPrice != 100 || body.Offer.DeviationPct != 5 {
+		t.Fatalf("unexpected offer market fields: %+v", body.Offer)
+	}
+}
+
+func TestOtcHTTP_CreateOffer_RejectsExcessAmount(t *testing.T) {
+	db := newTestDB(t, "h_otc_create_offer_excess")
+	_, assetID := seedExchangeAndListing(t, db, "EXC")
+
+	holding := models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID, Quantity: 10,
+		PublicQuantity: 4, ReservedQuantity: 1, AvgBuyPrice: 90, AccountID: 1,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupOtcHandler(t, db)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/otc/offers",
+		strings.NewReader(fmt.Sprintf(`{"sellerHoldingId":%d,"buyerAccountId":2,"amount":4,"pricePerStock":105,"settlementDate":"2026-12-31","premium":25}`, holding.ID)),
+	)
+	req.Header.Set("Authorization", "Bearer "+clientToken(t))
+	rec := httptest.NewRecorder()
+
+	h.OtcRoutes(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOtcHTTP_ListAndGetOffers(t *testing.T) {
+	db := newTestDB(t, "h_otc_list_get_offers")
+	_, assetID := seedExchangeAndListing(t, db, "LGO")
+
+	holding := models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID, Quantity: 10,
+		PublicQuantity: 6, AvgBuyPrice: 90, AccountID: 1,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupOtcHandler(t, db)
+	createReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/otc/offers",
+		strings.NewReader(fmt.Sprintf(`{"sellerHoldingId":%d,"buyerAccountId":2,"amount":3,"pricePerStock":105,"settlementDate":"2026-12-31","premium":25}`, holding.ID)),
+	)
+	createReq.Header.Set("Authorization", "Bearer "+clientToken(t))
+	createRec := httptest.NewRecorder()
+	h.OtcRoutes(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", createRec.Code, createRec.Body.String())
+	}
+
+	var created struct {
+		Offer struct {
+			ID uint `json:"id"`
+		} `json:"offer"`
+	}
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/otc/offers?status=pending", nil)
+	listReq.Header.Set("Authorization", "Bearer "+clientToken(t))
+	listRec := httptest.NewRecorder()
+	h.OtcRoutes(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", listRec.Code, listRec.Body.String())
+	}
+	var listed struct {
+		Count  int `json:"count"`
+		Offers []struct {
+			ID     uint   `json:"id"`
+			Ticker string `json:"ticker"`
+			Status string `json:"status"`
+		} `json:"offers"`
+	}
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
+		t.Fatal(err)
+	}
+	if listed.Count != 1 || listed.Offers[0].ID != created.Offer.ID || listed.Offers[0].Ticker != "LGO" {
+		t.Fatalf("unexpected offers list: %+v", listed)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/otc/offers/%d", created.Offer.ID), nil)
+	getReq.Header.Set("Authorization", "Bearer "+clientTradingToken(t, 200))
+	getRec := httptest.NewRecorder()
+	h.OtcRoutes(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("get status=%d body=%s", getRec.Code, getRec.Body.String())
+	}
+}
+
+func TestOtcHTTP_GetOffer_HidesFromUnrelatedParticipant(t *testing.T) {
+	db := newTestDB(t, "h_otc_get_offer_unrelated")
+	_, assetID := seedExchangeAndListing(t, db, "HID")
+
+	holding := models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID, Quantity: 10,
+		PublicQuantity: 6, AvgBuyPrice: 90, AccountID: 1,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupOtcHandler(t, db)
+	createReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/otc/offers",
+		strings.NewReader(fmt.Sprintf(`{"sellerHoldingId":%d,"buyerAccountId":2,"amount":3,"pricePerStock":105,"settlementDate":"2026-12-31","premium":25}`, holding.ID)),
+	)
+	createReq.Header.Set("Authorization", "Bearer "+clientToken(t))
+	createRec := httptest.NewRecorder()
+	h.OtcRoutes(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", createRec.Code, createRec.Body.String())
+	}
+	var created struct {
+		Offer struct {
+			ID uint `json:"id"`
+		} `json:"offer"`
+	}
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/otc/offers/%d", created.Offer.ID), nil)
+	getReq.Header.Set("Authorization", "Bearer "+clientTradingToken(t, 999))
+	getRec := httptest.NewRecorder()
+	h.OtcRoutes(getRec, getReq)
+	if getRec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unrelated participant, got %d body=%s", getRec.Code, getRec.Body.String())
+	}
+}
+
+func TestOtcHTTP_CounterOffer(t *testing.T) {
+	db := newTestDB(t, "h_otc_counter_offer")
+	_, assetID := seedExchangeAndListing(t, db, "CTR")
+
+	holding := models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID, Quantity: 10,
+		PublicQuantity: 6, AvgBuyPrice: 90, AccountID: 1,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupOtcHandler(t, db)
+	createReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/otc/offers",
+		strings.NewReader(fmt.Sprintf(`{"sellerHoldingId":%d,"buyerAccountId":2,"amount":3,"pricePerStock":105,"settlementDate":"2026-12-31","premium":25}`, holding.ID)),
+	)
+	createReq.Header.Set("Authorization", "Bearer "+clientToken(t))
+	createRec := httptest.NewRecorder()
+	h.OtcRoutes(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", createRec.Code, createRec.Body.String())
+	}
+	var created struct {
+		Offer struct {
+			ID uint `json:"id"`
+		} `json:"offer"`
+	}
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	counterReq := httptest.NewRequest(
+		http.MethodPost,
+		fmt.Sprintf("/api/v1/otc/offers/%d/counter", created.Offer.ID),
+		strings.NewReader(`{"amount":4,"pricePerStock":108,"settlementDate":"2027-01-31","premium":30}`),
+	)
+	counterReq.Header.Set("Authorization", "Bearer "+clientTradingToken(t, 200))
+	counterRec := httptest.NewRecorder()
+	h.OtcRoutes(counterRec, counterReq)
+	if counterRec.Code != http.StatusOK {
+		t.Fatalf("counter status=%d body=%s", counterRec.Code, counterRec.Body.String())
+	}
+
+	var body struct {
+		Offer struct {
+			ID             uint    `json:"id"`
+			Amount         float64 `json:"amount"`
+			PricePerStock  float64 `json:"pricePerStock"`
+			CurrentPrice   float64 `json:"currentPrice"`
+			DeviationPct   float64 `json:"deviationPct"`
+			Premium        float64 `json:"premium"`
+			ModifiedByID   uint    `json:"modifiedById"`
+			ModifiedByType string  `json:"modifiedByType"`
+		} `json:"offer"`
+	}
+	if err := json.Unmarshal(counterRec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Offer.ID != created.Offer.ID || body.Offer.Amount != 4 || body.Offer.PricePerStock != 108 || body.Offer.Premium != 30 {
+		t.Fatalf("unexpected counter response: %+v", body.Offer)
+	}
+	if body.Offer.CurrentPrice != 100 || body.Offer.DeviationPct != 8 {
+		t.Fatalf("unexpected counter market fields: %+v", body.Offer)
+	}
+	if body.Offer.ModifiedByID != 200 || body.Offer.ModifiedByType != "client" {
+		t.Fatalf("modifier not updated: %+v", body.Offer)
+	}
+}
+
+func TestOtcHTTP_CounterOffer_HidesFromUnrelatedParticipant(t *testing.T) {
+	db := newTestDB(t, "h_otc_counter_unrelated")
+	_, assetID := seedExchangeAndListing(t, db, "CUR")
+
+	holding := models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID, Quantity: 10,
+		PublicQuantity: 6, AvgBuyPrice: 90, AccountID: 1,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupOtcHandler(t, db)
+	createReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/otc/offers",
+		strings.NewReader(fmt.Sprintf(`{"sellerHoldingId":%d,"buyerAccountId":2,"amount":3,"pricePerStock":105,"settlementDate":"2026-12-31","premium":25}`, holding.ID)),
+	)
+	createReq.Header.Set("Authorization", "Bearer "+clientToken(t))
+	createRec := httptest.NewRecorder()
+	h.OtcRoutes(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", createRec.Code, createRec.Body.String())
+	}
+	var created struct {
+		Offer struct {
+			ID uint `json:"id"`
+		} `json:"offer"`
+	}
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	counterReq := httptest.NewRequest(
+		http.MethodPost,
+		fmt.Sprintf("/api/v1/otc/offers/%d/counter", created.Offer.ID),
+		strings.NewReader(`{"amount":4,"pricePerStock":108,"settlementDate":"2027-01-31","premium":30}`),
+	)
+	counterReq.Header.Set("Authorization", "Bearer "+clientTradingToken(t, 999))
+	counterRec := httptest.NewRecorder()
+	h.OtcRoutes(counterRec, counterReq)
+	if counterRec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got status=%d body=%s", counterRec.Code, counterRec.Body.String())
+	}
+}
+
+func TestOtcHTTP_DeclineOffer(t *testing.T) {
+	db := newTestDB(t, "h_otc_decline_offer")
+	_, assetID := seedExchangeAndListing(t, db, "DCL")
+
+	holding := models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID, Quantity: 10,
+		PublicQuantity: 6, AvgBuyPrice: 90, AccountID: 1,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupOtcHandler(t, db)
+	createReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/otc/offers",
+		strings.NewReader(fmt.Sprintf(`{"sellerHoldingId":%d,"buyerAccountId":2,"amount":3,"pricePerStock":105,"settlementDate":"2026-12-31","premium":25}`, holding.ID)),
+	)
+	createReq.Header.Set("Authorization", "Bearer "+clientToken(t))
+	createRec := httptest.NewRecorder()
+	h.OtcRoutes(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", createRec.Code, createRec.Body.String())
+	}
+	var created struct {
+		Offer struct {
+			ID uint `json:"id"`
+		} `json:"offer"`
+	}
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	declineReq := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/otc/offers/%d/decline", created.Offer.ID), nil)
+	declineReq.Header.Set("Authorization", "Bearer "+clientTradingToken(t, 200))
+	declineRec := httptest.NewRecorder()
+	h.OtcRoutes(declineRec, declineReq)
+	if declineRec.Code != http.StatusOK {
+		t.Fatalf("decline status=%d body=%s", declineRec.Code, declineRec.Body.String())
+	}
+	var body struct {
+		Offer struct {
+			Status       string `json:"status"`
+			ModifiedByID uint   `json:"modifiedById"`
+		} `json:"offer"`
+	}
+	if err := json.Unmarshal(declineRec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Offer.Status != models.OtcOfferStatusDeclined || body.Offer.ModifiedByID != 200 {
+		t.Fatalf("unexpected decline response: %+v", body.Offer)
+	}
+}
+
+func TestOtcHTTP_CancelOffer(t *testing.T) {
+	db := newTestDB(t, "h_otc_cancel_offer")
+	_, assetID := seedExchangeAndListing(t, db, "CNL")
+
+	holding := models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID, Quantity: 10,
+		PublicQuantity: 6, AvgBuyPrice: 90, AccountID: 1,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupOtcHandler(t, db)
+	createReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/otc/offers",
+		strings.NewReader(fmt.Sprintf(`{"sellerHoldingId":%d,"buyerAccountId":2,"amount":3,"pricePerStock":105,"settlementDate":"2026-12-31","premium":25}`, holding.ID)),
+	)
+	createReq.Header.Set("Authorization", "Bearer "+clientToken(t))
+	createRec := httptest.NewRecorder()
+	h.OtcRoutes(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", createRec.Code, createRec.Body.String())
+	}
+	var created struct {
+		Offer struct {
+			ID uint `json:"id"`
+		} `json:"offer"`
+	}
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	cancelReq := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/otc/offers/%d/cancel", created.Offer.ID), nil)
+	cancelReq.Header.Set("Authorization", "Bearer "+clientToken(t))
+	cancelRec := httptest.NewRecorder()
+	h.OtcRoutes(cancelRec, cancelReq)
+	if cancelRec.Code != http.StatusOK {
+		t.Fatalf("cancel status=%d body=%s", cancelRec.Code, cancelRec.Body.String())
+	}
+	var body struct {
+		Offer struct {
+			Status       string `json:"status"`
+			ModifiedByID uint   `json:"modifiedById"`
+		} `json:"offer"`
+	}
+	if err := json.Unmarshal(cancelRec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Offer.Status != models.OtcOfferStatusCancelled || body.Offer.ModifiedByID != 100 {
+		t.Fatalf("unexpected cancel response: %+v", body.Offer)
+	}
+}
+
+func TestOtcHTTP_AcceptOffer(t *testing.T) {
+	db := newTestDB(t, "h_otc_accept_offer")
+	_, assetID := seedExchangeAndListing(t, db, "ACP")
+
+	holding := models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID, Quantity: 10,
+		PublicQuantity: 6, ReservedQuantity: 1, AvgBuyPrice: 90, AccountID: 1,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupOtcHandler(t, db)
+	createReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/otc/offers",
+		strings.NewReader(fmt.Sprintf(`{"sellerHoldingId":%d,"buyerAccountId":2,"amount":3,"pricePerStock":105,"settlementDate":"2026-12-31","premium":25}`, holding.ID)),
+	)
+	createReq.Header.Set("Authorization", "Bearer "+clientToken(t))
+	createRec := httptest.NewRecorder()
+	h.OtcRoutes(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", createRec.Code, createRec.Body.String())
+	}
+	var created struct {
+		Offer struct {
+			ID uint `json:"id"`
+		} `json:"offer"`
+	}
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	acceptReq := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/otc/offers/%d/accept", created.Offer.ID), nil)
+	acceptReq.Header.Set("Authorization", "Bearer "+clientTradingToken(t, 200))
+	acceptRec := httptest.NewRecorder()
+	h.OtcRoutes(acceptRec, acceptReq)
+	if acceptRec.Code != http.StatusOK {
+		t.Fatalf("accept status=%d body=%s", acceptRec.Code, acceptRec.Body.String())
+	}
+
+	var body struct {
+		Contract struct {
+			ID           uint    `json:"id"`
+			OfferID      uint    `json:"offerId"`
+			Ticker       string  `json:"ticker"`
+			Amount       float64 `json:"amount"`
+			StrikePrice  float64 `json:"strikePrice"`
+			CurrentPrice float64 `json:"currentPrice"`
+			Premium      float64 `json:"premium"`
+			Profit       float64 `json:"profit"`
+			Status       string  `json:"status"`
+			BuyerID      uint    `json:"buyerId"`
+			SellerID     uint    `json:"sellerId"`
+		} `json:"contract"`
+	}
+	if err := json.Unmarshal(acceptRec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Contract.ID == 0 || body.Contract.OfferID != created.Offer.ID || body.Contract.Status != models.OtcContractStatusValid {
+		t.Fatalf("unexpected contract response: %+v", body.Contract)
+	}
+	if body.Contract.Ticker != "ACP" || body.Contract.Amount != 3 || body.Contract.StrikePrice != 105 || body.Contract.Premium != 25 {
+		t.Fatalf("unexpected contract terms: %+v", body.Contract)
+	}
+	if body.Contract.CurrentPrice != 100 || body.Contract.Profit != -40 {
+		t.Fatalf("unexpected contract market/profit fields: %+v", body.Contract)
+	}
+
+	var updatedHolding models.PortfolioHoldingRecord
+	if err := db.First(&updatedHolding, holding.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if updatedHolding.ReservedQuantity != 4 {
+		t.Fatalf("expected reserved quantity 4, got %.2f", updatedHolding.ReservedQuantity)
+	}
+}
+
+func TestOtcHTTP_ListContracts(t *testing.T) {
+	db := newTestDB(t, "h_otc_list_contracts")
+	_, assetID := seedExchangeAndListing(t, db, "CON")
+
+	holding := models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID, Quantity: 10,
+		PublicQuantity: 6, ReservedQuantity: 1, AvgBuyPrice: 90, AccountID: 1,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupOtcHandler(t, db)
+	createReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/otc/offers",
+		strings.NewReader(fmt.Sprintf(`{"sellerHoldingId":%d,"buyerAccountId":2,"amount":3,"pricePerStock":105,"settlementDate":"2026-12-31","premium":25}`, holding.ID)),
+	)
+	createReq.Header.Set("Authorization", "Bearer "+clientToken(t))
+	createRec := httptest.NewRecorder()
+	h.OtcRoutes(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", createRec.Code, createRec.Body.String())
+	}
+	var created struct {
+		Offer struct {
+			ID uint `json:"id"`
+		} `json:"offer"`
+	}
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	acceptReq := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/otc/offers/%d/accept", created.Offer.ID), nil)
+	acceptReq.Header.Set("Authorization", "Bearer "+clientTradingToken(t, 200))
+	acceptRec := httptest.NewRecorder()
+	h.OtcRoutes(acceptRec, acceptReq)
+	if acceptRec.Code != http.StatusOK {
+		t.Fatalf("accept status=%d body=%s", acceptRec.Code, acceptRec.Body.String())
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/otc/contracts?status=valid", nil)
+	listReq.Header.Set("Authorization", "Bearer "+clientToken(t))
+	listRec := httptest.NewRecorder()
+	h.OtcRoutes(listRec, listReq)
+	if listRec.Code != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", listRec.Code, listRec.Body.String())
+	}
+	var listed struct {
+		Count     int    `json:"count"`
+		Status    string `json:"status"`
+		Contracts []struct {
+			ID           uint    `json:"id"`
+			Ticker       string  `json:"ticker"`
+			Amount       float64 `json:"amount"`
+			StrikePrice  float64 `json:"strikePrice"`
+			CurrentPrice float64 `json:"currentPrice"`
+			Profit       float64 `json:"profit"`
+			Status       string  `json:"status"`
+			BuyerID      uint    `json:"buyerId"`
+			SellerID     uint    `json:"sellerId"`
+		} `json:"contracts"`
+	}
+	if err := json.Unmarshal(listRec.Body.Bytes(), &listed); err != nil {
+		t.Fatal(err)
+	}
+	if listed.Count != 1 || listed.Status != models.OtcContractStatusValid || len(listed.Contracts) != 1 {
+		t.Fatalf("unexpected contracts list: %+v", listed)
+	}
+	if listed.Contracts[0].Ticker != "CON" || listed.Contracts[0].Amount != 3 || listed.Contracts[0].StrikePrice != 105 {
+		t.Fatalf("unexpected contract response: %+v", listed.Contracts[0])
+	}
+	if listed.Contracts[0].CurrentPrice != 100 || listed.Contracts[0].Profit != -40 {
+		t.Fatalf("unexpected contract market/profit fields: %+v", listed.Contracts[0])
+	}
+	if listed.Contracts[0].BuyerID != 100 || listed.Contracts[0].SellerID != 200 || listed.Contracts[0].Status != models.OtcContractStatusValid {
+		t.Fatalf("unexpected participant/status fields: %+v", listed.Contracts[0])
+	}
+}
+
+func TestOtcHTTP_ListContracts_RejectsInvalidStatus(t *testing.T) {
+	db := newTestDB(t, "h_otc_list_contracts_bad_status")
+	h := setupOtcHandler(t, db)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/otc/contracts?status=pending", nil)
+	req.Header.Set("Authorization", "Bearer "+clientToken(t))
+	rec := httptest.NewRecorder()
+
+	h.OtcRoutes(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOtcHTTP_ListContracts_RequiresTradingPermission(t *testing.T) {
+	db := newTestDB(t, "h_otc_list_contracts_forbidden")
+	h := setupOtcHandler(t, db)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/otc/contracts", nil)
+	req.Header.Set("Authorization", "Bearer "+clientWithoutTradingToken(t))
+	rec := httptest.NewRecorder()
+
+	h.OtcRoutes(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOtcHTTP_AcceptOffer_RejectsBuyer(t *testing.T) {
+	db := newTestDB(t, "h_otc_accept_buyer")
+	_, assetID := seedExchangeAndListing(t, db, "ABY")
+
+	holding := models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID, Quantity: 10,
+		PublicQuantity: 6, AvgBuyPrice: 90, AccountID: 1,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	h := setupOtcHandler(t, db)
+	createReq := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/otc/offers",
+		strings.NewReader(fmt.Sprintf(`{"sellerHoldingId":%d,"buyerAccountId":2,"amount":3,"pricePerStock":105,"settlementDate":"2026-12-31","premium":25}`, holding.ID)),
+	)
+	createReq.Header.Set("Authorization", "Bearer "+clientToken(t))
+	createRec := httptest.NewRecorder()
+	h.OtcRoutes(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create status=%d body=%s", createRec.Code, createRec.Body.String())
+	}
+	var created struct {
+		Offer struct {
+			ID uint `json:"id"`
+		} `json:"offer"`
+	}
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+
+	acceptReq := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/otc/offers/%d/accept", created.Offer.ID), nil)
+	acceptReq.Header.Set("Authorization", "Bearer "+clientToken(t))
+	acceptRec := httptest.NewRecorder()
+	h.OtcRoutes(acceptRec, acceptReq)
+	if acceptRec.Code != http.StatusBadRequest {
+		t.Fatalf("expected buyer accept to fail with 400, got status=%d body=%s", acceptRec.Code, acceptRec.Body.String())
+	}
+}

--- a/exchange-service/internal/handler/portfolio_http_handler.go
+++ b/exchange-service/internal/handler/portfolio_http_handler.go
@@ -187,21 +187,40 @@ func (h *PortfolioHTTPHandler) setPublic(w http.ResponseWriter, r *http.Request,
 	}
 
 	var body struct {
-		IsPublic bool `json:"isPublic"`
+		IsPublic       *bool    `json:"isPublic"`
+		PublicQuantity *float64 `json:"publicQuantity"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid request body"})
 		return
 	}
 
-	if err := h.portfolioSvc.SetPublic(holdingID, body.IsPublic); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to update holding"})
+	switch {
+	case body.PublicQuantity != nil:
+		err = h.portfolioSvc.SetPublicQuantity(holdingID, *body.PublicQuantity)
+	case body.IsPublic != nil:
+		err = h.portfolioSvc.SetPublic(holdingID, *body.IsPublic)
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "publicQuantity or isPublic is required"})
+		return
+	}
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+
+	updated, err := h.portfolioSvc.GetHoldingByID(holdingID)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "holding not found"})
 		return
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"holdingId": holdingID,
-		"isPublic":  body.IsPublic,
+		"holdingId":        holdingID,
+		"isPublic":         updated.EffectivePublicQuantity() > 0,
+		"publicQuantity":   updated.EffectivePublicQuantity(),
+		"reservedQuantity": updated.ReservedQuantity,
+		"availableForOtc":  updated.AvailableForOTC(),
 	})
 }
 
@@ -232,6 +251,9 @@ type holdingResponse struct {
 	UnrealizedPnLPct float64 `json:"unrealizedPnLPct"`
 	RealizedProfit   float64 `json:"realizedProfit"`
 	IsPublic         bool    `json:"isPublic"`
+	PublicQuantity   float64 `json:"publicQuantity"`
+	ReservedQuantity float64 `json:"reservedQuantity"`
+	AvailableForOTC  float64 `json:"availableForOtc"`
 	AccountID        uint    `json:"accountId"`
 	CreatedAt        string  `json:"createdAt"`
 }
@@ -273,7 +295,10 @@ func holdingToResponse(h service.HoldingWithPnL) holdingResponse {
 		UnrealizedPnL:    h.UnrealizedPnL,
 		UnrealizedPnLPct: h.UnrealizedPnLPct,
 		RealizedProfit:   h.Holding.RealizedProfit,
-		IsPublic:         h.Holding.IsPublic,
+		IsPublic:         h.Holding.EffectivePublicQuantity() > 0,
+		PublicQuantity:   h.Holding.EffectivePublicQuantity(),
+		ReservedQuantity: h.Holding.ReservedQuantity,
+		AvailableForOTC:  h.Holding.AvailableForOTC(),
 		AccountID:        h.Holding.AccountID,
 		CreatedAt:        h.Holding.CreatedAt.UTC().Format(time.RFC3339),
 	}

--- a/exchange-service/internal/models/market_entities.go
+++ b/exchange-service/internal/models/market_entities.go
@@ -3,18 +3,18 @@ package models
 import "time"
 
 type MarketExchangeRecord struct {
-	ID             uint                  `gorm:"primaryKey"`
-	Name           string                `gorm:"not null"`
-	Acronym        string                `gorm:"not null;uniqueIndex"`
-	MICCode        string                `gorm:"column:mic_code;not null;uniqueIndex"`
-	Polity         string                `gorm:"not null"`
-	Currency       string                `gorm:"not null"`
-	Timezone       string                `gorm:"not null"`
-	WorkingHours   string                `gorm:"column:working_hours;not null"`
-	UseManualTime  bool                  `gorm:"column:use_manual_time;not null;default:false"`
-	ManualTimeOpen bool                  `gorm:"column:manual_time_open;not null;default:false"`
-	Enabled        bool                  `gorm:"not null;default:true"`
-	Listings       []MarketListingRecord `gorm:"foreignKey:ExchangeID"`
+	ID             uint                       `gorm:"primaryKey"`
+	Name           string                     `gorm:"not null"`
+	Acronym        string                     `gorm:"not null;uniqueIndex"`
+	MICCode        string                     `gorm:"column:mic_code;not null;uniqueIndex"`
+	Polity         string                     `gorm:"not null"`
+	Currency       string                     `gorm:"not null"`
+	Timezone       string                     `gorm:"not null"`
+	WorkingHours   string                     `gorm:"column:working_hours;not null"`
+	UseManualTime  bool                       `gorm:"column:use_manual_time;not null;default:false"`
+	ManualTimeOpen bool                       `gorm:"column:manual_time_open;not null;default:false"`
+	Enabled        bool                       `gorm:"not null;default:true"`
+	Listings       []MarketListingRecord      `gorm:"foreignKey:ExchangeID"`
 	WorkingDays    []ExchangeWorkingDayRecord `gorm:"foreignKey:ExchangeID"`
 }
 
@@ -202,12 +202,12 @@ type OrderRecord struct {
 func (OrderRecord) TableName() string { return "orders" }
 
 type OrderTransactionRecord struct {
-	ID           uint      `gorm:"primaryKey"`
-	OrderID      uint      `gorm:"column:order_id;not null;index"`
+	ID           uint        `gorm:"primaryKey"`
+	OrderID      uint        `gorm:"column:order_id;not null;index"`
 	Order        OrderRecord `gorm:"foreignKey:OrderID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
-	Quantity     int64     `gorm:"not null"`
-	PricePerUnit float64   `gorm:"column:price_per_unit;not null"`
-	ExecutedAt   time.Time `gorm:"column:executed_at;not null"`
+	Quantity     int64       `gorm:"not null"`
+	PricePerUnit float64     `gorm:"column:price_per_unit;not null"`
+	ExecutedAt   time.Time   `gorm:"column:executed_at;not null"`
 }
 
 func (OrderTransactionRecord) TableName() string { return "order_transactions" }
@@ -215,33 +215,118 @@ func (OrderTransactionRecord) TableName() string { return "order_transactions" }
 // Portfolio holdings — persistent, built from executed order transactions.
 
 type PortfolioHoldingRecord struct {
-	ID             uint                `gorm:"primaryKey"`
-	UserID         uint                `gorm:"column:user_id;not null;index:idx_portfolio_user_asset"`
-	UserType       string              `gorm:"column:user_type;not null"` // "client" or "bank" (all employees share the bank-owned portfolio)
-	AssetID        uint                `gorm:"column:asset_id;not null;index:idx_portfolio_user_asset"`
-	Asset          MarketListingRecord `gorm:"foreignKey:AssetID;constraint:OnUpdate:CASCADE,OnDelete:RESTRICT;"`
-	Quantity       float64             `gorm:"not null;default:0"`
-	AvgBuyPrice    float64             `gorm:"column:avg_buy_price;not null;default:0"`
-	IsPublic       bool                `gorm:"column:is_public;not null;default:false"`
-	AccountID      uint                `gorm:"column:account_id;not null"`
-	RealizedProfit float64             `gorm:"column:realized_profit;not null;default:0"`
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	ID               uint                `gorm:"primaryKey"`
+	UserID           uint                `gorm:"column:user_id;not null;index:idx_portfolio_user_asset"`
+	UserType         string              `gorm:"column:user_type;not null"` // "client" or "bank" (all employees share the bank-owned portfolio)
+	AssetID          uint                `gorm:"column:asset_id;not null;index:idx_portfolio_user_asset"`
+	Asset            MarketListingRecord `gorm:"foreignKey:AssetID;constraint:OnUpdate:CASCADE,OnDelete:RESTRICT;"`
+	Quantity         float64             `gorm:"not null;default:0"`
+	AvgBuyPrice      float64             `gorm:"column:avg_buy_price;not null;default:0"`
+	IsPublic         bool                `gorm:"column:is_public;not null;default:false"`
+	PublicQuantity   float64             `gorm:"column:public_quantity;not null;default:0"`
+	ReservedQuantity float64             `gorm:"column:reserved_quantity;not null;default:0"`
+	AccountID        uint                `gorm:"column:account_id;not null"`
+	RealizedProfit   float64             `gorm:"column:realized_profit;not null;default:0"`
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
 }
 
 func (PortfolioHoldingRecord) TableName() string { return "portfolio_holdings" }
 
+func (h PortfolioHoldingRecord) EffectivePublicQuantity() float64 {
+	if h.PublicQuantity > 0 {
+		return h.PublicQuantity
+	}
+	if h.IsPublic {
+		return h.Quantity
+	}
+	return 0
+}
+
+func (h PortfolioHoldingRecord) AvailableForOTC() float64 {
+	available := h.EffectivePublicQuantity() - h.ReservedQuantity
+	if available < 0 {
+		return 0
+	}
+	return available
+}
+
+const (
+	OtcOfferStatusPending   = "pending"
+	OtcOfferStatusAccepted  = "accepted"
+	OtcOfferStatusDeclined  = "declined"
+	OtcOfferStatusCancelled = "cancelled"
+)
+
+type OtcOfferRecord struct {
+	ID              uint                   `gorm:"primaryKey"`
+	StockListingID  uint                   `gorm:"column:stock_listing_id;not null;index"`
+	StockListing    MarketListingRecord    `gorm:"foreignKey:StockListingID;constraint:OnUpdate:CASCADE,OnDelete:RESTRICT;"`
+	SellerHoldingID uint                   `gorm:"column:seller_holding_id;not null;index"`
+	SellerHolding   PortfolioHoldingRecord `gorm:"foreignKey:SellerHoldingID;constraint:OnUpdate:CASCADE,OnDelete:RESTRICT;"`
+	Amount          float64                `gorm:"not null"`
+	PricePerStock   float64                `gorm:"column:price_per_stock;not null"`
+	SettlementDate  time.Time              `gorm:"column:settlement_date;type:date;not null"`
+	Premium         float64                `gorm:"not null"`
+	LastModified    time.Time              `gorm:"column:last_modified;not null"`
+	ModifiedByID    uint                   `gorm:"column:modified_by_id;not null"`
+	ModifiedByType  string                 `gorm:"column:modified_by_type;not null"`
+	Status          string                 `gorm:"not null;default:'pending';index"`
+	BuyerID         uint                   `gorm:"column:buyer_id;not null;index"`
+	BuyerType       string                 `gorm:"column:buyer_type;not null"`
+	BuyerAccountID  uint                   `gorm:"column:buyer_account_id;not null;index"`
+	SellerID        uint                   `gorm:"column:seller_id;not null;index"`
+	SellerType      string                 `gorm:"column:seller_type;not null"`
+	SellerAccountID uint                   `gorm:"column:seller_account_id;not null;index"`
+	BankID          *uint                  `gorm:"column:bank_id;index"`
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+func (OtcOfferRecord) TableName() string { return "otc_offers" }
+
+const (
+	OtcContractStatusValid     = "valid"
+	OtcContractStatusExercised = "exercised"
+	OtcContractStatusExpired   = "expired"
+)
+
+type OtcContractRecord struct {
+	ID              uint                   `gorm:"primaryKey"`
+	OfferID         *uint                  `gorm:"column:offer_id;index"`
+	StockListingID  uint                   `gorm:"column:stock_listing_id;not null;index"`
+	StockListing    MarketListingRecord    `gorm:"foreignKey:StockListingID;constraint:OnUpdate:CASCADE,OnDelete:RESTRICT;"`
+	SellerHoldingID uint                   `gorm:"column:seller_holding_id;not null;index"`
+	SellerHolding   PortfolioHoldingRecord `gorm:"foreignKey:SellerHoldingID;constraint:OnUpdate:CASCADE,OnDelete:RESTRICT;"`
+	Amount          float64                `gorm:"not null"`
+	StrikePrice     float64                `gorm:"column:strike_price;not null"`
+	Premium         float64                `gorm:"not null"`
+	SettlementDate  time.Time              `gorm:"column:settlement_date;type:date;not null;index"`
+	BuyerID         uint                   `gorm:"column:buyer_id;not null;index"`
+	BuyerType       string                 `gorm:"column:buyer_type;not null"`
+	BuyerAccountID  uint                   `gorm:"column:buyer_account_id;not null;index"`
+	SellerID        uint                   `gorm:"column:seller_id;not null;index"`
+	SellerType      string                 `gorm:"column:seller_type;not null"`
+	SellerAccountID uint                   `gorm:"column:seller_account_id;not null;index"`
+	Status          string                 `gorm:"not null;default:'valid';index"`
+	BankID          *uint                  `gorm:"column:bank_id;index"`
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+func (OtcContractRecord) TableName() string { return "otc_contracts" }
+
 // TaxRecord tracks capital gains tax (15%) owed per user per month.
 
 type TaxRecord struct {
-	ID        uint      `gorm:"primaryKey"`
-	UserID    uint      `gorm:"column:user_id;not null;index:idx_tax_user_period"`
-	UserType  string    `gorm:"column:user_type;not null"`
-	AssetID   uint      `gorm:"column:asset_id;not null"`
-	Period    string    `gorm:"not null;index:idx_tax_user_period"` // "YYYY-MM", e.g. "2026-04"
-	ProfitRSD float64   `gorm:"column:profit_rsd;not null"`
-	TaxRSD    float64   `gorm:"column:tax_rsd;not null"` // 15% of profit_rsd
-	Status    string    `gorm:"not null;default:'unpaid'"` // unpaid, paid
+	ID        uint    `gorm:"primaryKey"`
+	UserID    uint    `gorm:"column:user_id;not null;index:idx_tax_user_period"`
+	UserType  string  `gorm:"column:user_type;not null"`
+	AssetID   uint    `gorm:"column:asset_id;not null"`
+	Period    string  `gorm:"not null;index:idx_tax_user_period"` // "YYYY-MM", e.g. "2026-04"
+	ProfitRSD float64 `gorm:"column:profit_rsd;not null"`
+	TaxRSD    float64 `gorm:"column:tax_rsd;not null"`   // 15% of profit_rsd
+	Status    string  `gorm:"not null;default:'unpaid'"` // unpaid, paid
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/exchange-service/internal/repository/order_repository_test.go
+++ b/exchange-service/internal/repository/order_repository_test.go
@@ -241,8 +241,8 @@ func TestPortfolioRepository_BuyAndSellFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 	h3, _ := prepo.GetHoldingByID(h.ID)
-	if !h3.IsPublic {
-		t.Error("expected public flag set")
+	if !h3.IsPublic || h3.PublicQuantity != h3.Quantity {
+		t.Errorf("expected all remaining quantity public, got public=%v publicQty=%v qty=%v", h3.IsPublic, h3.PublicQuantity, h3.Quantity)
 	}
 
 	if err := prepo.ExerciseOptionHolding(h.ID, 50); err != nil {
@@ -251,6 +251,90 @@ func TestPortfolioRepository_BuyAndSellFlow(t *testing.T) {
 	h4, _ := prepo.GetHoldingByID(h.ID)
 	if h4.Quantity != 0 {
 		t.Errorf("expected 0 qty after exercise, got %v", h4.Quantity)
+	}
+}
+
+func TestPortfolioRepository_OTCPublicQuantityValidation(t *testing.T) {
+	_, _, prepo, _, assetID := seedExchangeAndAsset(t, "pr_otc_public_qty", "OTC")
+
+	if err := prepo.RecordBuyFill(1, "client", assetID, 10, 12, 100); err != nil {
+		t.Fatal(err)
+	}
+	h, err := prepo.GetHoldingByUserAndAsset(1, "client", assetID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := prepo.SetHoldingPublicQuantity(h.ID, 5); err != nil {
+		t.Fatalf("SetHoldingPublicQuantity: %v", err)
+	}
+	h, _ = prepo.GetHoldingByID(h.ID)
+	if h.PublicQuantity != 5 || h.ReservedQuantity != 0 || h.AvailableForOTC() != 5 {
+		t.Fatalf("unexpected OTC quantities: %+v available=%v", h, h.AvailableForOTC())
+	}
+
+	if err := prepo.ReserveHoldingQuantity(h.ID, 3); err != nil {
+		t.Fatalf("ReserveHoldingQuantity: %v", err)
+	}
+	h, _ = prepo.GetHoldingByID(h.ID)
+	if h.ReservedQuantity != 3 || h.AvailableForOTC() != 2 {
+		t.Fatalf("unexpected reserved quantity: reserved=%v available=%v", h.ReservedQuantity, h.AvailableForOTC())
+	}
+
+	if err := prepo.SetHoldingPublicQuantity(h.ID, 2); err == nil {
+		t.Fatal("expected public quantity below reserved quantity to fail")
+	}
+	if err := prepo.SetHoldingPublicQuantity(h.ID, 13); err == nil {
+		t.Fatal("expected public quantity above owned quantity to fail")
+	}
+	if err := prepo.ReserveHoldingQuantity(h.ID, 3); err == nil {
+		t.Fatal("expected reserving more than available OTC quantity to fail")
+	}
+	if _, err := prepo.RecordSellFill(1, "client", assetID, 10, 120); err == nil {
+		t.Fatal("expected selling below reserved quantity to fail")
+	}
+
+	if err := prepo.ReleaseHoldingReservedQuantity(h.ID, 2); err != nil {
+		t.Fatalf("ReleaseHoldingReservedQuantity: %v", err)
+	}
+	h, _ = prepo.GetHoldingByID(h.ID)
+	if h.ReservedQuantity != 1 || h.AvailableForOTC() != 4 {
+		t.Fatalf("unexpected quantities after release: reserved=%v available=%v", h.ReservedQuantity, h.AvailableForOTC())
+	}
+
+	if _, err := prepo.RecordSellFill(1, "client", assetID, 8, 120); err != nil {
+		t.Fatalf("RecordSellFill with enough unreserved quantity: %v", err)
+	}
+	h, _ = prepo.GetHoldingByID(h.ID)
+	if h.Quantity != 4 || h.PublicQuantity != 4 || h.AvailableForOTC() != 3 {
+		t.Fatalf("expected public quantity capped after sell, qty=%v public=%v available=%v", h.Quantity, h.PublicQuantity, h.AvailableForOTC())
+	}
+}
+
+func TestPortfolioRepository_OTCPublicQuantityRejectsNonStock(t *testing.T) {
+	db := openMarketRepositoryTestDB(t, "pr_otc_non_stock")
+	exch := models.MarketExchangeRecord{
+		Acronym: "FX", Name: "FX Exchange", MICCode: "FX1", Polity: "X", Currency: "USD",
+		Timezone: "UTC", WorkingHours: "09:00-17:00",
+	}
+	if err := db.Create(&exch).Error; err != nil {
+		t.Fatal(err)
+	}
+	listing := models.MarketListingRecord{
+		Ticker: "EUR/USD", Name: "Euro Dollar", Type: "forex",
+		ExchangeID: exch.ID, Price: 1.1, Ask: 1.11, Bid: 1.09, Volume: 1000,
+	}
+	if err := db.Create(&listing).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	prepo := NewPortfolioRepository(db)
+	if err := prepo.RecordBuyFill(1, "client", listing.ID, 10, 5, 1.1); err != nil {
+		t.Fatal(err)
+	}
+	h, _ := prepo.GetHoldingByUserAndAsset(1, "client", listing.ID)
+	if err := prepo.SetHoldingPublicQuantity(h.ID, 1); err == nil {
+		t.Fatal("expected non-stock public quantity to fail")
 	}
 }
 

--- a/exchange-service/internal/repository/otc_repository.go
+++ b/exchange-service/internal/repository/otc_repository.go
@@ -1,0 +1,395 @@
+package repository
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type OtcRepository struct {
+	db *gorm.DB
+}
+
+func NewOtcRepository(db *gorm.DB) *OtcRepository {
+	return &OtcRepository{db: db}
+}
+
+func (r *OtcRepository) CreateOffer(offer *models.OtcOfferRecord) error {
+	now := time.Now().UTC()
+	if offer.Status == "" {
+		offer.Status = models.OtcOfferStatusPending
+	}
+	if offer.LastModified.IsZero() {
+		offer.LastModified = now
+	}
+	return r.db.Create(offer).Error
+}
+
+type OtcAccountReference struct {
+	ID                uint
+	ClientID          *uint   `gorm:"column:client_id"`
+	FirmaID           *uint   `gorm:"column:firma_id"`
+	ZaposleniID       *uint   `gorm:"column:zaposleni_id"`
+	CurrencyCode      string  `gorm:"column:currency_kod"`
+	Stanje            float64 `gorm:"column:stanje"`
+	RaspolozivoStanje float64 `gorm:"column:raspolozivo_stanje"`
+	DnevnaPotrosnja   float64 `gorm:"column:dnevna_potrosnja"`
+	MesecnaPotrosnja  float64 `gorm:"column:mesecna_potrosnja"`
+	Status            string  `gorm:"column:status"`
+}
+
+func (a OtcAccountReference) IsOwnedBy(userID uint, userType string) bool {
+	switch userType {
+	case "client":
+		return a.ClientID != nil && *a.ClientID == userID
+	case "bank":
+		return a.ClientID == nil
+	default:
+		return false
+	}
+}
+
+func (r *OtcRepository) GetAccountReference(accountID uint) (*OtcAccountReference, error) {
+	return r.getAccountReference(r.db, accountID, false)
+}
+
+func (r *OtcRepository) GetOfferByID(id uint) (*models.OtcOfferRecord, error) {
+	var offer models.OtcOfferRecord
+	if err := r.offerPreloads(r.db).First(&offer, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &offer, nil
+}
+
+func (r *OtcRepository) ListOffersForParticipant(userID uint, userType, status string) ([]models.OtcOfferRecord, error) {
+	q := r.offerPreloads(r.db).
+		Where("(buyer_id = ? AND buyer_type = ?) OR (seller_id = ? AND seller_type = ?)",
+			userID, userType, userID, userType)
+	if status != "" {
+		q = q.Where("status = ?", status)
+	}
+
+	var offers []models.OtcOfferRecord
+	if err := q.Order("last_modified DESC, id DESC").Find(&offers).Error; err != nil {
+		return nil, err
+	}
+	return offers, nil
+}
+
+func (r *OtcRepository) UpdateOfferTerms(id uint, amount, pricePerStock float64, settlementDate time.Time, premium float64, modifiedByID uint, modifiedByType string) error {
+	return r.db.Model(&models.OtcOfferRecord{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"amount":           amount,
+		"price_per_stock":  pricePerStock,
+		"settlement_date":  settlementDate,
+		"premium":          premium,
+		"last_modified":    time.Now().UTC(),
+		"modified_by_id":   modifiedByID,
+		"modified_by_type": modifiedByType,
+	}).Error
+}
+
+func (r *OtcRepository) UpdateOfferStatus(id uint, status string, modifiedByID uint, modifiedByType string) error {
+	return r.db.Model(&models.OtcOfferRecord{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"status":           status,
+		"last_modified":    time.Now().UTC(),
+		"modified_by_id":   modifiedByID,
+		"modified_by_type": modifiedByType,
+	}).Error
+}
+
+func (r *OtcRepository) AcceptOfferAndCreateContract(offerID uint, sellerID uint, sellerType string) (*models.OtcContractRecord, error) {
+	var contractID uint
+	if err := r.db.Transaction(func(tx *gorm.DB) error {
+		var offer models.OtcOfferRecord
+		if err := r.offerPreloads(tx).First(&offer, offerID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("offer not found")
+			}
+			return err
+		}
+		if offer.Status != models.OtcOfferStatusPending {
+			return fmt.Errorf("only pending offers can be accepted")
+		}
+		if offer.SellerID != sellerID || offer.SellerType != sellerType {
+			return fmt.Errorf("only seller can accept an offer")
+		}
+
+		var holding models.PortfolioHoldingRecord
+		if err := tx.Preload("Asset").First(&holding, offer.SellerHoldingID).Error; err != nil {
+			return err
+		}
+		if holding.Asset.Type != string(models.ListingTypeStock) {
+			return fmt.Errorf("only stock holdings can be reserved for OTC")
+		}
+		if holding.AvailableForOTC() < offer.Amount {
+			return fmt.Errorf("insufficient public OTC quantity")
+		}
+		buyerAccount, err := r.getAccountReference(tx, offer.BuyerAccountID, true)
+		if err != nil {
+			return err
+		}
+		sellerAccount, err := r.getAccountReference(tx, offer.SellerAccountID, true)
+		if err != nil {
+			return err
+		}
+		if err := validatePremiumAccounts(offer, buyerAccount, sellerAccount); err != nil {
+			return err
+		}
+		if offer.Premium > 0 {
+			if buyerAccount.RaspolozivoStanje < offer.Premium {
+				return fmt.Errorf("insufficient funds for OTC premium")
+			}
+			if err := debitOtcPremium(tx, offer.BuyerAccountID, offer.Premium); err != nil {
+				return err
+			}
+			if err := creditOtcPremium(tx, offer.SellerAccountID, offer.Premium); err != nil {
+				return err
+			}
+		}
+
+		now := time.Now().UTC()
+		if err := tx.Model(&holding).Updates(map[string]interface{}{
+			"reserved_quantity": holding.ReservedQuantity + offer.Amount,
+			"updated_at":        now,
+		}).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&offer).Updates(map[string]interface{}{
+			"status":           models.OtcOfferStatusAccepted,
+			"last_modified":    now,
+			"modified_by_id":   sellerID,
+			"modified_by_type": sellerType,
+			"updated_at":       now,
+		}).Error; err != nil {
+			return err
+		}
+
+		sourceOfferID := offer.ID
+		contract := models.OtcContractRecord{
+			OfferID:         &sourceOfferID,
+			StockListingID:  offer.StockListingID,
+			SellerHoldingID: offer.SellerHoldingID,
+			Amount:          offer.Amount,
+			StrikePrice:     offer.PricePerStock,
+			Premium:         offer.Premium,
+			SettlementDate:  offer.SettlementDate,
+			BuyerID:         offer.BuyerID,
+			BuyerType:       offer.BuyerType,
+			BuyerAccountID:  offer.BuyerAccountID,
+			SellerID:        offer.SellerID,
+			SellerType:      offer.SellerType,
+			SellerAccountID: offer.SellerAccountID,
+			Status:          models.OtcContractStatusValid,
+			BankID:          offer.BankID,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		if err := tx.Create(&contract).Error; err != nil {
+			return err
+		}
+		contractID = contract.ID
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return r.GetContractByID(contractID)
+}
+
+func (r *OtcRepository) CreateContract(contract *models.OtcContractRecord) error {
+	if contract.Status == "" {
+		contract.Status = models.OtcContractStatusValid
+	}
+	return r.db.Create(contract).Error
+}
+
+func (r *OtcRepository) GetContractByID(id uint) (*models.OtcContractRecord, error) {
+	var contract models.OtcContractRecord
+	if err := r.contractPreloads(r.db).First(&contract, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &contract, nil
+}
+
+func (r *OtcRepository) ListContractsForParticipant(userID uint, userType, status string) ([]models.OtcContractRecord, error) {
+	q := r.contractPreloads(r.db).
+		Where("(buyer_id = ? AND buyer_type = ?) OR (seller_id = ? AND seller_type = ?)",
+			userID, userType, userID, userType)
+	if status != "" {
+		q = q.Where("status = ?", status)
+	}
+
+	var contracts []models.OtcContractRecord
+	if err := q.Order("created_at DESC, id DESC").Find(&contracts).Error; err != nil {
+		return nil, err
+	}
+	return contracts, nil
+}
+
+func (r *OtcRepository) ListExpiredValidContracts(referenceTime time.Time) ([]models.OtcContractRecord, error) {
+	var contracts []models.OtcContractRecord
+	if err := r.contractPreloads(r.db).
+		Where("status = ? AND settlement_date < ?", models.OtcContractStatusValid, referenceTime).
+		Order("settlement_date ASC, id ASC").
+		Find(&contracts).Error; err != nil {
+		return nil, err
+	}
+	return contracts, nil
+}
+
+func (r *OtcRepository) ExpireValidContracts(referenceTime time.Time) (int, error) {
+	expiredCount := 0
+	err := r.db.Transaction(func(tx *gorm.DB) error {
+		var contracts []models.OtcContractRecord
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("status = ? AND settlement_date < ?", models.OtcContractStatusValid, referenceTime).
+			Order("settlement_date ASC, id ASC").
+			Find(&contracts).Error; err != nil {
+			return err
+		}
+
+		now := time.Now().UTC()
+		for _, contract := range contracts {
+			var holding models.PortfolioHoldingRecord
+			if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&holding, contract.SellerHoldingID).Error; err != nil {
+				return err
+			}
+
+			newReservedQuantity := holding.ReservedQuantity - contract.Amount
+			if newReservedQuantity < 0 {
+				newReservedQuantity = 0
+			}
+			if err := tx.Model(&holding).Updates(map[string]interface{}{
+				"reserved_quantity": newReservedQuantity,
+				"updated_at":        now,
+			}).Error; err != nil {
+				return err
+			}
+
+			result := tx.Model(&models.OtcContractRecord{}).
+				Where("id = ? AND status = ?", contract.ID, models.OtcContractStatusValid).
+				Updates(map[string]interface{}{
+					"status":     models.OtcContractStatusExpired,
+					"updated_at": now,
+				})
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.RowsAffected > 0 {
+				expiredCount++
+			}
+		}
+		return nil
+	})
+	return expiredCount, err
+}
+
+func (r *OtcRepository) UpdateContractStatus(id uint, status string) error {
+	return r.db.Model(&models.OtcContractRecord{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"status":     status,
+		"updated_at": time.Now().UTC(),
+	}).Error
+}
+
+func (r *OtcRepository) offerPreloads(db *gorm.DB) *gorm.DB {
+	return db.
+		Preload("StockListing").
+		Preload("StockListing.Exchange").
+		Preload("SellerHolding").
+		Preload("SellerHolding.Asset").
+		Preload("SellerHolding.Asset.Exchange")
+}
+
+func (r *OtcRepository) contractPreloads(db *gorm.DB) *gorm.DB {
+	return db.
+		Preload("StockListing").
+		Preload("StockListing.Exchange").
+		Preload("SellerHolding").
+		Preload("SellerHolding.Asset").
+		Preload("SellerHolding.Asset.Exchange")
+}
+
+func (r *OtcRepository) getAccountReference(db *gorm.DB, accountID uint, lock bool) (*OtcAccountReference, error) {
+	if accountID == 0 {
+		return nil, nil
+	}
+	q := db.Table("accounts").
+		Select("accounts.id, accounts.client_id, accounts.firma_id, accounts.zaposleni_id, currencies.kod AS currency_kod, accounts.stanje, accounts.raspolozivo_stanje, accounts.dnevna_potrosnja, accounts.mesecna_potrosnja, accounts.status").
+		Joins("LEFT JOIN currencies ON currencies.id = accounts.currency_id").
+		Where("accounts.id = ?", accountID)
+	if lock {
+		q = q.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+
+	var account OtcAccountReference
+	if err := q.First(&account).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &account, nil
+}
+
+func validatePremiumAccounts(offer models.OtcOfferRecord, buyerAccount, sellerAccount *OtcAccountReference) error {
+	if buyerAccount == nil {
+		return fmt.Errorf("buyer account not found")
+	}
+	if sellerAccount == nil {
+		return fmt.Errorf("seller account not found")
+	}
+	if buyerAccount.Status != "aktivan" {
+		return fmt.Errorf("buyer account is not active")
+	}
+	if sellerAccount.Status != "aktivan" {
+		return fmt.Errorf("seller account is not active")
+	}
+	expectedCurrency := offer.StockListing.Exchange.Currency
+	if buyerAccount.CurrencyCode != expectedCurrency || sellerAccount.CurrencyCode != expectedCurrency {
+		return fmt.Errorf("premium account currency must match stock currency")
+	}
+	if !buyerAccount.IsOwnedBy(offer.BuyerID, offer.BuyerType) {
+		return fmt.Errorf("buyer account does not belong to buyer")
+	}
+	if !sellerAccount.IsOwnedBy(offer.SellerID, offer.SellerType) {
+		return fmt.Errorf("seller account does not belong to seller")
+	}
+	return nil
+}
+
+func debitOtcPremium(tx *gorm.DB, accountID uint, amount float64) error {
+	result := tx.Table("accounts").
+		Where("id = ? AND raspolozivo_stanje >= ?", accountID, amount).
+		Updates(map[string]interface{}{
+			"stanje":             gorm.Expr("stanje - ?", amount),
+			"raspolozivo_stanje": gorm.Expr("raspolozivo_stanje - ?", amount),
+			"dnevna_potrosnja":   gorm.Expr("dnevna_potrosnja + ?", amount),
+			"mesecna_potrosnja":  gorm.Expr("mesecna_potrosnja + ?", amount),
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("insufficient funds for OTC premium")
+	}
+	return nil
+}
+
+func creditOtcPremium(tx *gorm.DB, accountID uint, amount float64) error {
+	return tx.Table("accounts").
+		Where("id = ?", accountID).
+		Updates(map[string]interface{}{
+			"stanje":             gorm.Expr("stanje + ?", amount),
+			"raspolozivo_stanje": gorm.Expr("raspolozivo_stanje + ?", amount),
+		}).Error
+}

--- a/exchange-service/internal/repository/otc_repository_test.go
+++ b/exchange-service/internal/repository/otc_repository_test.go
@@ -1,0 +1,448 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"gorm.io/gorm"
+)
+
+func seedOtcOfferFixture(t *testing.T, name string) (*OtcRepository, *models.OtcOfferRecord) {
+	t.Helper()
+	_, _, portfolioRepo, _, assetID := seedExchangeAndAsset(t, name, "OTC"+name[:1])
+	seedOtcAccountFixtures(t, portfolioRepo.db)
+
+	if err := portfolioRepo.RecordBuyFill(20, "client", assetID, 1, 12, 100); err != nil {
+		t.Fatalf("seed holding: %v", err)
+	}
+	holding, err := portfolioRepo.GetHoldingByUserAndAsset(20, "client", assetID)
+	if err != nil {
+		t.Fatalf("load holding: %v", err)
+	}
+	if err := portfolioRepo.SetHoldingPublicQuantity(holding.ID, 8); err != nil {
+		t.Fatalf("public quantity: %v", err)
+	}
+
+	offer := &models.OtcOfferRecord{
+		StockListingID:  assetID,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC),
+		Premium:         25,
+		ModifiedByID:    10,
+		ModifiedByType:  "client",
+		BuyerID:         10,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerID:        20,
+		SellerType:      "client",
+		SellerAccountID: holding.AccountID,
+	}
+
+	return NewOtcRepository(portfolioRepo.db), offer
+}
+
+func seedOtcAccountFixtures(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	if err := db.Exec(`CREATE TABLE IF NOT EXISTS currencies (id integer primary key, kod text not null unique)`).Error; err != nil {
+		t.Fatalf("create currencies table: %v", err)
+	}
+	if err := db.Exec(`CREATE TABLE IF NOT EXISTS accounts (
+		id integer primary key,
+		client_id integer,
+		firma_id integer,
+		zaposleni_id integer,
+		currency_id integer not null,
+		stanje real not null default 0,
+		raspolozivo_stanje real not null default 0,
+		dnevna_potrosnja real not null default 0,
+		mesecna_potrosnja real not null default 0,
+		status text not null default 'aktivan'
+	)`).Error; err != nil {
+		t.Fatalf("create accounts table: %v", err)
+	}
+	if err := db.Exec(`INSERT OR IGNORE INTO currencies (id, kod) VALUES (1, 'USD')`).Error; err != nil {
+		t.Fatalf("seed currency: %v", err)
+	}
+	if err := db.Exec(`INSERT OR IGNORE INTO accounts (id, client_id, currency_id, stanje, raspolozivo_stanje, status) VALUES
+		(1, 20, 1, 1000, 1000, 'aktivan'),
+		(2, 10, 1, 1000, 1000, 'aktivan')`).Error; err != nil {
+		t.Fatalf("seed accounts: %v", err)
+	}
+}
+
+func TestOtcRepository_CreateAndGetOffer(t *testing.T) {
+	repo, offer := seedOtcOfferFixture(t, "create_get")
+
+	if err := repo.CreateOffer(offer); err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+	if offer.ID == 0 {
+		t.Fatal("expected offer ID")
+	}
+	if offer.Status != models.OtcOfferStatusPending {
+		t.Fatalf("expected default pending status, got %q", offer.Status)
+	}
+	if offer.LastModified.IsZero() {
+		t.Fatal("expected LastModified to be set")
+	}
+
+	got, err := repo.GetOfferByID(offer.ID)
+	if err != nil {
+		t.Fatalf("GetOfferByID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected offer")
+	}
+	if got.StockListing.Ticker == "" || got.SellerHolding.ID == 0 {
+		t.Fatalf("expected preloaded stock listing and seller holding, got %+v", got)
+	}
+}
+
+func TestOtcRepository_GetOfferByID_NotFound(t *testing.T) {
+	repo, _ := seedOtcOfferFixture(t, "not_found")
+
+	got, err := repo.GetOfferByID(9999)
+	if err != nil {
+		t.Fatalf("GetOfferByID: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestOtcRepository_ListOffersForParticipant(t *testing.T) {
+	repo, offer := seedOtcOfferFixture(t, "list")
+	if err := repo.CreateOffer(offer); err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	buyerOffers, err := repo.ListOffersForParticipant(10, "client", "")
+	if err != nil {
+		t.Fatalf("ListOffersForParticipant buyer: %v", err)
+	}
+	if len(buyerOffers) != 1 {
+		t.Fatalf("expected buyer to see 1 offer, got %d", len(buyerOffers))
+	}
+
+	sellerOffers, err := repo.ListOffersForParticipant(20, "client", models.OtcOfferStatusPending)
+	if err != nil {
+		t.Fatalf("ListOffersForParticipant seller: %v", err)
+	}
+	if len(sellerOffers) != 1 {
+		t.Fatalf("expected seller to see 1 pending offer, got %d", len(sellerOffers))
+	}
+
+	none, err := repo.ListOffersForParticipant(30, "client", "")
+	if err != nil {
+		t.Fatalf("ListOffersForParticipant none: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("expected unrelated participant to see no offers, got %d", len(none))
+	}
+}
+
+func TestOtcRepository_UpdateTermsAndStatus(t *testing.T) {
+	repo, offer := seedOtcOfferFixture(t, "update")
+	if err := repo.CreateOffer(offer); err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	newDate := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	if err := repo.UpdateOfferTerms(offer.ID, 4, 108, newDate, 30, 20, "client"); err != nil {
+		t.Fatalf("UpdateOfferTerms: %v", err)
+	}
+	got, err := repo.GetOfferByID(offer.ID)
+	if err != nil {
+		t.Fatalf("GetOfferByID: %v", err)
+	}
+	if got.Amount != 4 || got.PricePerStock != 108 || got.Premium != 30 || got.ModifiedByID != 20 {
+		t.Fatalf("terms not updated: %+v", got)
+	}
+
+	if err := repo.UpdateOfferStatus(offer.ID, models.OtcOfferStatusAccepted, 20, "client"); err != nil {
+		t.Fatalf("UpdateOfferStatus: %v", err)
+	}
+	got, err = repo.GetOfferByID(offer.ID)
+	if err != nil {
+		t.Fatalf("GetOfferByID after status: %v", err)
+	}
+	if got.Status != models.OtcOfferStatusAccepted {
+		t.Fatalf("expected accepted status, got %q", got.Status)
+	}
+}
+
+func TestOtcRepository_AcceptOfferAndCreateContract(t *testing.T) {
+	repo, offer := seedOtcOfferFixture(t, "accept")
+	if err := repo.CreateOffer(offer); err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	contract, err := repo.AcceptOfferAndCreateContract(offer.ID, offer.SellerID, offer.SellerType)
+	if err != nil {
+		t.Fatalf("AcceptOfferAndCreateContract: %v", err)
+	}
+	if contract.ID == 0 || contract.Status != models.OtcContractStatusValid {
+		t.Fatalf("expected valid contract, got %+v", contract)
+	}
+	if contract.Amount != offer.Amount || contract.StrikePrice != offer.PricePerStock || contract.Premium != offer.Premium {
+		t.Fatalf("contract terms do not match offer: %+v", contract)
+	}
+
+	updatedOffer, err := repo.GetOfferByID(offer.ID)
+	if err != nil {
+		t.Fatalf("GetOfferByID: %v", err)
+	}
+	if updatedOffer.Status != models.OtcOfferStatusAccepted {
+		t.Fatalf("expected accepted offer status, got %q", updatedOffer.Status)
+	}
+
+	var holding models.PortfolioHoldingRecord
+	if err := repo.db.First(&holding, offer.SellerHoldingID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if holding.ReservedQuantity != offer.Amount {
+		t.Fatalf("expected reserved quantity %.2f, got %.2f", offer.Amount, holding.ReservedQuantity)
+	}
+
+	var buyerBalance, sellerBalance float64
+	if err := repo.db.Table("accounts").Select("raspolozivo_stanje").Where("id = ?", offer.BuyerAccountID).Scan(&buyerBalance).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.db.Table("accounts").Select("raspolozivo_stanje").Where("id = ?", offer.SellerAccountID).Scan(&sellerBalance).Error; err != nil {
+		t.Fatal(err)
+	}
+	if buyerBalance != 975 || sellerBalance != 1025 {
+		t.Fatalf("expected premium transfer buyer=975 seller=1025, got buyer=%.2f seller=%.2f", buyerBalance, sellerBalance)
+	}
+}
+
+func TestOtcRepository_AcceptOfferRejectsInsufficientPremiumFunds(t *testing.T) {
+	repo, offer := seedOtcOfferFixture(t, "accept_no_funds")
+	if err := repo.db.Table("accounts").Where("id = ?", offer.BuyerAccountID).Updates(map[string]interface{}{
+		"stanje":             10,
+		"raspolozivo_stanje": 10,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.CreateOffer(offer); err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	_, err := repo.AcceptOfferAndCreateContract(offer.ID, offer.SellerID, offer.SellerType)
+	if err == nil {
+		t.Fatal("expected insufficient premium funds error")
+	}
+
+	got, err := repo.GetOfferByID(offer.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != models.OtcOfferStatusPending {
+		t.Fatalf("expected offer to remain pending, got %q", got.Status)
+	}
+	var holding models.PortfolioHoldingRecord
+	if err := repo.db.First(&holding, offer.SellerHoldingID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if holding.ReservedQuantity != 0 {
+		t.Fatalf("expected no additional reservation after failed premium payment, got %.2f", holding.ReservedQuantity)
+	}
+}
+
+func TestOtcRepository_AcceptOfferRejectsWrongSeller(t *testing.T) {
+	repo, offer := seedOtcOfferFixture(t, "accept_wrong_seller")
+	if err := repo.CreateOffer(offer); err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	_, err := repo.AcceptOfferAndCreateContract(offer.ID, 999, offer.SellerType)
+	if err == nil {
+		t.Fatal("expected seller validation error")
+	}
+}
+
+func seedOtcContractFixture(t *testing.T, name string) (*OtcRepository, *models.OtcOfferRecord, *models.OtcContractRecord) {
+	t.Helper()
+	repo, offer := seedOtcOfferFixture(t, name)
+	if err := repo.CreateOffer(offer); err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	contract := &models.OtcContractRecord{
+		OfferID:         &offer.ID,
+		StockListingID:  offer.StockListingID,
+		SellerHoldingID: offer.SellerHoldingID,
+		Amount:          offer.Amount,
+		StrikePrice:     offer.PricePerStock,
+		Premium:         offer.Premium,
+		SettlementDate:  offer.SettlementDate,
+		BuyerID:         offer.BuyerID,
+		BuyerType:       offer.BuyerType,
+		BuyerAccountID:  offer.BuyerAccountID,
+		SellerID:        offer.SellerID,
+		SellerType:      offer.SellerType,
+		SellerAccountID: offer.SellerAccountID,
+		BankID:          offer.BankID,
+	}
+
+	return repo, offer, contract
+}
+
+func TestOtcRepository_CreateAndGetContract(t *testing.T) {
+	repo, offer, contract := seedOtcContractFixture(t, "contract_create")
+
+	if err := repo.CreateContract(contract); err != nil {
+		t.Fatalf("CreateContract: %v", err)
+	}
+	if contract.ID == 0 {
+		t.Fatal("expected contract ID")
+	}
+	if contract.Status != models.OtcContractStatusValid {
+		t.Fatalf("expected default valid status, got %q", contract.Status)
+	}
+
+	got, err := repo.GetContractByID(contract.ID)
+	if err != nil {
+		t.Fatalf("GetContractByID: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected contract")
+	}
+	if got.OfferID == nil || *got.OfferID != offer.ID {
+		t.Fatalf("expected source offer ID %d, got %+v", offer.ID, got.OfferID)
+	}
+	if got.StockListing.Ticker == "" || got.SellerHolding.ID == 0 {
+		t.Fatalf("expected preloaded stock listing and seller holding, got %+v", got)
+	}
+}
+
+func TestOtcRepository_GetContractByID_NotFound(t *testing.T) {
+	repo, _, _ := seedOtcContractFixture(t, "contract_nf")
+
+	got, err := repo.GetContractByID(9999)
+	if err != nil {
+		t.Fatalf("GetContractByID: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestOtcRepository_ListContractsForParticipant(t *testing.T) {
+	repo, _, contract := seedOtcContractFixture(t, "contract_list")
+	if err := repo.CreateContract(contract); err != nil {
+		t.Fatalf("CreateContract: %v", err)
+	}
+
+	buyerContracts, err := repo.ListContractsForParticipant(contract.BuyerID, contract.BuyerType, "")
+	if err != nil {
+		t.Fatalf("ListContractsForParticipant buyer: %v", err)
+	}
+	if len(buyerContracts) != 1 {
+		t.Fatalf("expected buyer to see 1 contract, got %d", len(buyerContracts))
+	}
+
+	sellerContracts, err := repo.ListContractsForParticipant(contract.SellerID, contract.SellerType, models.OtcContractStatusValid)
+	if err != nil {
+		t.Fatalf("ListContractsForParticipant seller: %v", err)
+	}
+	if len(sellerContracts) != 1 {
+		t.Fatalf("expected seller to see 1 valid contract, got %d", len(sellerContracts))
+	}
+
+	none, err := repo.ListContractsForParticipant(999, "client", "")
+	if err != nil {
+		t.Fatalf("ListContractsForParticipant unrelated: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("expected unrelated participant to see no contracts, got %d", len(none))
+	}
+}
+
+func TestOtcRepository_ContractStatusAndExpiredQuery(t *testing.T) {
+	repo, _, contract := seedOtcContractFixture(t, "contract_status")
+	contract.SettlementDate = time.Now().UTC().Add(-24 * time.Hour)
+	if err := repo.CreateContract(contract); err != nil {
+		t.Fatalf("CreateContract: %v", err)
+	}
+
+	expired, err := repo.ListExpiredValidContracts(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("ListExpiredValidContracts: %v", err)
+	}
+	if len(expired) != 1 {
+		t.Fatalf("expected 1 expired valid contract, got %d", len(expired))
+	}
+
+	if err := repo.UpdateContractStatus(contract.ID, models.OtcContractStatusExpired); err != nil {
+		t.Fatalf("UpdateContractStatus: %v", err)
+	}
+	got, err := repo.GetContractByID(contract.ID)
+	if err != nil {
+		t.Fatalf("GetContractByID: %v", err)
+	}
+	if got.Status != models.OtcContractStatusExpired {
+		t.Fatalf("expected expired status, got %q", got.Status)
+	}
+
+	expired, err = repo.ListExpiredValidContracts(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("ListExpiredValidContracts after status: %v", err)
+	}
+	if len(expired) != 0 {
+		t.Fatalf("expected no valid expired contracts after status update, got %d", len(expired))
+	}
+}
+
+func TestOtcRepository_ExpireValidContractsReleasesReservedQuantity(t *testing.T) {
+	repo, offer := seedOtcOfferFixture(t, "contract_expire")
+	if err := repo.CreateOffer(offer); err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	contract, err := repo.AcceptOfferAndCreateContract(offer.ID, offer.SellerID, offer.SellerType)
+	if err != nil {
+		t.Fatalf("AcceptOfferAndCreateContract: %v", err)
+	}
+	pastSettlement := time.Now().UTC().Add(-24 * time.Hour)
+	if err := repo.db.Model(&models.OtcContractRecord{}).
+		Where("id = ?", contract.ID).
+		Update("settlement_date", pastSettlement).Error; err != nil {
+		t.Fatalf("backdate contract: %v", err)
+	}
+
+	expired, err := repo.ExpireValidContracts(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("ExpireValidContracts: %v", err)
+	}
+	if expired != 1 {
+		t.Fatalf("expected one expired contract, got %d", expired)
+	}
+
+	got, err := repo.GetContractByID(contract.ID)
+	if err != nil {
+		t.Fatalf("GetContractByID: %v", err)
+	}
+	if got.Status != models.OtcContractStatusExpired {
+		t.Fatalf("expected expired contract status, got %q", got.Status)
+	}
+
+	var holding models.PortfolioHoldingRecord
+	if err := repo.db.First(&holding, offer.SellerHoldingID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if holding.ReservedQuantity != 0 {
+		t.Fatalf("expected reserved quantity to be released, got %.2f", holding.ReservedQuantity)
+	}
+
+	expiredAgain, err := repo.ExpireValidContracts(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("ExpireValidContracts second run: %v", err)
+	}
+	if expiredAgain != 0 {
+		t.Fatalf("expected idempotent second run, got %d", expiredAgain)
+	}
+}

--- a/exchange-service/internal/repository/portfolio_repository.go
+++ b/exchange-service/internal/repository/portfolio_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
@@ -48,6 +49,33 @@ func (r *PortfolioRepository) ListHoldingsForUser(userID uint, userType string) 
 	if err := r.db.Preload("Asset").Preload("Asset.Exchange").
 		Where("user_id = ? AND user_type = ? AND quantity > 0", userID, userType).
 		Order("created_at ASC").Find(&records).Error; err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+// ListPublicOTCHoldings returns stock holdings with available public OTC quantity,
+// excluding the requester so buyers do not see their own advertised shares.
+func (r *PortfolioRepository) ListPublicOTCHoldings(excludeUserID uint, excludeUserType string) ([]models.PortfolioHoldingRecord, error) {
+	var records []models.PortfolioHoldingRecord
+	query := r.db.Preload("Asset").Preload("Asset.Exchange").
+		Joins("JOIN market_listings ON market_listings.id = portfolio_holdings.asset_id").
+		Where("portfolio_holdings.quantity > 0").
+		Where("market_listings.type = ?", string(models.ListingTypeStock)).
+		Where(`(
+			portfolio_holdings.public_quantity > portfolio_holdings.reserved_quantity
+			OR (
+				portfolio_holdings.is_public = ?
+				AND portfolio_holdings.public_quantity = 0
+				AND portfolio_holdings.quantity > portfolio_holdings.reserved_quantity
+			)
+		)`, true)
+
+	if excludeUserType != "" {
+		query = query.Where("NOT (portfolio_holdings.user_id = ? AND portfolio_holdings.user_type = ?)", excludeUserID, excludeUserType)
+	}
+
+	if err := query.Order("market_listings.ticker ASC, portfolio_holdings.id ASC").Find(&records).Error; err != nil {
 		return nil, err
 	}
 	return records, nil
@@ -109,10 +137,27 @@ func (r *PortfolioRepository) RecordSellFill(userID uint, userType string, asset
 		if newQty < 0 {
 			newQty = 0
 		}
+		if newQty < h.ReservedQuantity {
+			return fmt.Errorf("cannot sell reserved OTC quantity")
+		}
+		publicQuantity := h.PublicQuantity
+		isPublic := h.IsPublic
+		if publicQuantity > newQty {
+			publicQuantity = newQty
+		}
+		if newQty == 0 {
+			publicQuantity = 0
+			isPublic = false
+		}
+		if publicQuantity > 0 {
+			isPublic = true
+		}
 
 		return tx.Model(&h).Updates(map[string]interface{}{
 			"quantity":        newQty,
 			"realized_profit": h.RealizedProfit + realizedProfit,
+			"is_public":       isPublic,
+			"public_quantity": publicQuantity,
 			"updated_at":      time.Now().UTC(),
 		}).Error
 	})
@@ -135,10 +180,95 @@ func (r *PortfolioRepository) ExerciseOptionHolding(id uint, exerciseProfit floa
 	})
 }
 
-// SetHoldingPublic toggles the is_public flag on a holding (used for OTC shares).
+// SetHoldingPublic toggles the legacy is_public flag on a holding (used for OTC shares).
 func (r *PortfolioRepository) SetHoldingPublic(id uint, isPublic bool) error {
-	return r.db.Model(&models.PortfolioHoldingRecord{}).Where("id = ?", id).Updates(map[string]interface{}{
-		"is_public":  isPublic,
-		"updated_at": time.Now().UTC(),
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		var h models.PortfolioHoldingRecord
+		if err := tx.Preload("Asset").First(&h, id).Error; err != nil {
+			return err
+		}
+
+		publicQuantity := 0.0
+		if isPublic {
+			publicQuantity = h.Quantity
+		}
+
+		return setHoldingPublicQuantity(tx, &h, publicQuantity)
+	})
+}
+
+func (r *PortfolioRepository) SetHoldingPublicQuantity(id uint, publicQuantity float64) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		var h models.PortfolioHoldingRecord
+		if err := tx.Preload("Asset").First(&h, id).Error; err != nil {
+			return err
+		}
+		return setHoldingPublicQuantity(tx, &h, publicQuantity)
+	})
+}
+
+func (r *PortfolioRepository) ReserveHoldingQuantity(id uint, quantity float64) error {
+	if quantity <= 0 {
+		return fmt.Errorf("reserved quantity must be positive")
+	}
+
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		var h models.PortfolioHoldingRecord
+		if err := tx.Preload("Asset").First(&h, id).Error; err != nil {
+			return err
+		}
+		if h.Asset.Type != string(models.ListingTypeStock) {
+			return fmt.Errorf("only stock holdings can be reserved for OTC")
+		}
+		if h.AvailableForOTC() < quantity {
+			return fmt.Errorf("insufficient public OTC quantity")
+		}
+
+		return tx.Model(&h).Updates(map[string]interface{}{
+			"reserved_quantity": h.ReservedQuantity + quantity,
+			"updated_at":        time.Now().UTC(),
+		}).Error
+	})
+}
+
+func (r *PortfolioRepository) ReleaseHoldingReservedQuantity(id uint, quantity float64) error {
+	if quantity <= 0 {
+		return fmt.Errorf("released quantity must be positive")
+	}
+
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		var h models.PortfolioHoldingRecord
+		if err := tx.First(&h, id).Error; err != nil {
+			return err
+		}
+		if quantity > h.ReservedQuantity {
+			return fmt.Errorf("released quantity exceeds reserved OTC quantity")
+		}
+
+		return tx.Model(&h).Updates(map[string]interface{}{
+			"reserved_quantity": h.ReservedQuantity - quantity,
+			"updated_at":        time.Now().UTC(),
+		}).Error
+	})
+}
+
+func setHoldingPublicQuantity(tx *gorm.DB, h *models.PortfolioHoldingRecord, publicQuantity float64) error {
+	if publicQuantity < 0 {
+		return fmt.Errorf("public quantity cannot be negative")
+	}
+	if h.Asset.Type != string(models.ListingTypeStock) && publicQuantity > 0 {
+		return fmt.Errorf("only stock holdings can be public for OTC")
+	}
+	if publicQuantity > h.Quantity {
+		return fmt.Errorf("public quantity cannot exceed owned quantity")
+	}
+	if publicQuantity < h.ReservedQuantity {
+		return fmt.Errorf("public quantity cannot be below reserved OTC quantity")
+	}
+
+	return tx.Model(h).Updates(map[string]interface{}{
+		"is_public":       publicQuantity > 0,
+		"public_quantity": publicQuantity,
+		"updated_at":      time.Now().UTC(),
 	}).Error
 }

--- a/exchange-service/internal/repository/portfolio_repository_test.go
+++ b/exchange-service/internal/repository/portfolio_repository_test.go
@@ -1,0 +1,91 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"gorm.io/gorm"
+)
+
+func seedRepositoryListing(t *testing.T, db *gorm.DB, ticker, listingType string) uint {
+	t.Helper()
+	exchange := models.MarketExchangeRecord{
+		Acronym:      "X" + ticker,
+		Name:         "Exchange " + ticker,
+		MICCode:      "M" + ticker,
+		Polity:       "US",
+		Currency:     "USD",
+		Timezone:     "UTC",
+		WorkingHours: "09:30-16:00",
+		Enabled:      true,
+	}
+	if err := db.Create(&exchange).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	listing := models.MarketListingRecord{
+		Ticker:      ticker,
+		Name:        ticker + " Corp",
+		ExchangeID:  exchange.ID,
+		LastRefresh: time.Now().UTC(),
+		Price:       100,
+		Ask:         101,
+		Bid:         99,
+		Volume:      1000,
+		Type:        listingType,
+	}
+	if err := db.Create(&listing).Error; err != nil {
+		t.Fatal(err)
+	}
+	return listing.ID
+}
+
+func TestPortfolioRepository_ListPublicOTCHoldings(t *testing.T) {
+	db := openMarketRepositoryTestDB(t, "portfolio_public_otc")
+	repo := NewPortfolioRepository(db)
+
+	publicStockID := seedRepositoryListing(t, db, "PUB", string(models.ListingTypeStock))
+	legacyStockID := seedRepositoryListing(t, db, "LEG", string(models.ListingTypeStock))
+	privateStockID := seedRepositoryListing(t, db, "PRI", string(models.ListingTypeStock))
+	reservedStockID := seedRepositoryListing(t, db, "RES", string(models.ListingTypeStock))
+	ownStockID := seedRepositoryListing(t, db, "OWN", string(models.ListingTypeStock))
+	forexID := seedRepositoryListing(t, db, "FX", "forex")
+
+	holdings := []models.PortfolioHoldingRecord{
+		{UserID: 200, UserType: "client", AssetID: publicStockID, Quantity: 10, PublicQuantity: 6, ReservedQuantity: 2, AvgBuyPrice: 90, AccountID: 1},
+		{UserID: 201, UserType: "client", AssetID: legacyStockID, Quantity: 8, IsPublic: true, AvgBuyPrice: 80, AccountID: 1},
+		{UserID: 202, UserType: "client", AssetID: privateStockID, Quantity: 5, AvgBuyPrice: 75, AccountID: 1},
+		{UserID: 203, UserType: "client", AssetID: reservedStockID, Quantity: 5, PublicQuantity: 5, ReservedQuantity: 5, AvgBuyPrice: 70, AccountID: 1},
+		{UserID: 100, UserType: "client", AssetID: ownStockID, Quantity: 5, PublicQuantity: 5, AvgBuyPrice: 60, AccountID: 1},
+		{UserID: 204, UserType: "client", AssetID: forexID, Quantity: 5, PublicQuantity: 5, AvgBuyPrice: 1.1, AccountID: 1},
+	}
+	if err := db.Create(&holdings).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := repo.ListPublicOTCHoldings(100, "client")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("expected 2 public OTC stock holdings, got %d", len(records))
+	}
+
+	seen := map[string]float64{}
+	for _, record := range records {
+		seen[record.Asset.Ticker] = record.AvailableForOTC()
+	}
+	if seen["PUB"] != 4 {
+		t.Fatalf("expected PUB available quantity 4, got %v", seen["PUB"])
+	}
+	if seen["LEG"] != 8 {
+		t.Fatalf("expected legacy public LEG available quantity 8, got %v", seen["LEG"])
+	}
+	if _, ok := seen["OWN"]; ok {
+		t.Fatal("requester should not see own public holding")
+	}
+	if _, ok := seen["FX"]; ok {
+		t.Fatal("non-stock holding should not be listed for OTC")
+	}
+}

--- a/exchange-service/internal/service/cron_service.go
+++ b/exchange-service/internal/service/cron_service.go
@@ -36,6 +36,15 @@ func StartCronJobs(db *gorm.DB, portfolioSvc *PortfolioService, rateProvider Rat
 		slog.Error("Failed to add order executor cron job", "error", err)
 	}
 
+	// OTC option expiry: release reserved shares after settlement date passes.
+	otcSvc := NewOtcService(repository.NewPortfolioRepository(db), repository.NewOtcRepository(db))
+	_, err = c.AddFunc("@every 1h", func() {
+		expireDueOtcContracts(otcSvc)
+	})
+	if err != nil {
+		slog.Error("Failed to add OTC expiry cron job", "error", err)
+	}
+
 	// Monthly tax collection: runs at 02:00 on the 1st of each month.
 	taxRepo := repository.NewTaxRepository(db)
 	taxSvc := NewTaxService(taxRepo, marketRepo, rateProvider)
@@ -58,6 +67,17 @@ func StartCronJobs(db *gorm.DB, portfolioSvc *PortfolioService, rateProvider Rat
 	c.Start()
 	slog.Info("Exchange-service cron jobs started", "jobs", len(c.Entries()))
 	return c
+}
+
+func expireDueOtcContracts(otcSvc *OtcService) {
+	expired, err := otcSvc.ExpireDueContracts(time.Now().UTC())
+	if err != nil {
+		slog.Error("Failed to expire OTC contracts", "error", err)
+		return
+	}
+	if expired > 0 {
+		slog.Info("Expired OTC contracts", "count", expired)
+	}
 }
 
 func refreshListingPrices(db *gorm.DB) {

--- a/exchange-service/internal/service/db_integration_test.go
+++ b/exchange-service/internal/service/db_integration_test.go
@@ -123,8 +123,16 @@ func TestPortfolioService_RecordFillAndList(t *testing.T) {
 		t.Fatalf("SetPublic: %v", err)
 	}
 	again, _ := psvc.GetHoldingByID(got.ID)
-	if !again.IsPublic {
-		t.Error("expected IsPublic=true after SetPublic")
+	if !again.IsPublic || again.PublicQuantity != again.Quantity {
+		t.Errorf("expected SetPublic to expose all remaining shares, got isPublic=%v publicQty=%v qty=%v", again.IsPublic, again.PublicQuantity, again.Quantity)
+	}
+
+	if err := psvc.SetPublicQuantity(got.ID, 3); err != nil {
+		t.Fatalf("SetPublicQuantity: %v", err)
+	}
+	again, _ = psvc.GetHoldingByID(got.ID)
+	if again.PublicQuantity != 3 || again.AvailableForOTC() != 3 {
+		t.Errorf("unexpected OTC quantities after SetPublicQuantity: public=%v available=%v", again.PublicQuantity, again.AvailableForOTC())
 	}
 
 	// ListHoldings (raw, no PnL).

--- a/exchange-service/internal/service/otc_service.go
+++ b/exchange-service/internal/service/otc_service.go
@@ -1,0 +1,395 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+var ErrOtcOfferNotFound = errors.New("otc offer not found")
+
+type OtcService struct {
+	portfolioRepo *repository.PortfolioRepository
+	otcRepo       *repository.OtcRepository
+}
+
+func NewOtcService(portfolioRepo *repository.PortfolioRepository, otcRepo *repository.OtcRepository) *OtcService {
+	return &OtcService{portfolioRepo: portfolioRepo, otcRepo: otcRepo}
+}
+
+type PublicOtcStock struct {
+	HoldingID         uint
+	SellerID          uint
+	SellerType        string
+	AssetID           uint
+	Ticker            string
+	Name              string
+	Exchange          string
+	Currency          string
+	Price             float64
+	Ask               float64
+	Bid               float64
+	PublicQuantity    float64
+	ReservedQuantity  float64
+	AvailableQuantity float64
+	LastRefresh       time.Time
+}
+
+func (s *OtcService) ListPublicStocks(requesterID uint, requesterType string) ([]PublicOtcStock, error) {
+	holdings, err := s.portfolioRepo.ListPublicOTCHoldings(requesterID, requesterType)
+	if err != nil {
+		return nil, err
+	}
+
+	stocks := make([]PublicOtcStock, 0, len(holdings))
+	for _, holding := range holdings {
+		available := holding.AvailableForOTC()
+		if available <= 0 || holding.Asset.Type != string(models.ListingTypeStock) {
+			continue
+		}
+		stocks = append(stocks, PublicOtcStock{
+			HoldingID:         holding.ID,
+			SellerID:          holding.UserID,
+			SellerType:        holding.UserType,
+			AssetID:           holding.AssetID,
+			Ticker:            holding.Asset.Ticker,
+			Name:              holding.Asset.Name,
+			Exchange:          holding.Asset.Exchange.Acronym,
+			Currency:          holding.Asset.Exchange.Currency,
+			Price:             holding.Asset.Price,
+			Ask:               holding.Asset.Ask,
+			Bid:               holding.Asset.Bid,
+			PublicQuantity:    holding.EffectivePublicQuantity(),
+			ReservedQuantity:  holding.ReservedQuantity,
+			AvailableQuantity: available,
+			LastRefresh:       holding.Asset.LastRefresh,
+		})
+	}
+
+	return stocks, nil
+}
+
+type CreateOtcOfferInput struct {
+	BuyerID         uint
+	BuyerType       string
+	BuyerAccountID  uint
+	SellerHoldingID uint
+	Amount          float64
+	PricePerStock   float64
+	SettlementDate  time.Time
+	Premium         float64
+}
+
+func (s *OtcService) CreateOffer(input CreateOtcOfferInput) (*models.OtcOfferRecord, error) {
+	if !hasParticipantIdentity(input.BuyerID, input.BuyerType) {
+		return nil, fmt.Errorf("buyer identity is required")
+	}
+	if input.SellerHoldingID == 0 {
+		return nil, fmt.Errorf("seller holding is required")
+	}
+	if input.BuyerAccountID == 0 {
+		return nil, fmt.Errorf("buyer account is required")
+	}
+	if err := validateOtcTerms(input.Amount, input.PricePerStock, input.SettlementDate, input.Premium); err != nil {
+		return nil, err
+	}
+
+	holding, err := s.portfolioRepo.GetHoldingByID(input.SellerHoldingID)
+	if err != nil {
+		return nil, err
+	}
+	if holding == nil {
+		return nil, fmt.Errorf("seller holding not found")
+	}
+	if holding.UserID == input.BuyerID && holding.UserType == input.BuyerType {
+		return nil, fmt.Errorf("buyer cannot create an OTC offer for their own holding")
+	}
+	if holding.Asset.Type != string(models.ListingTypeStock) {
+		return nil, fmt.Errorf("only stock holdings can be offered through OTC")
+	}
+	if input.Amount > holding.AvailableForOTC() {
+		return nil, fmt.Errorf("amount exceeds available OTC quantity")
+	}
+	buyerAccount, err := s.otcRepo.GetAccountReference(input.BuyerAccountID)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateOtcAccountForParticipant(buyerAccount, input.BuyerID, input.BuyerType, holding.Asset.Exchange.Currency, "buyer"); err != nil {
+		return nil, err
+	}
+	if holding.AccountID == 0 {
+		return nil, fmt.Errorf("seller holding account is required")
+	}
+	sellerAccount, err := s.otcRepo.GetAccountReference(holding.AccountID)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateOtcAccountForParticipant(sellerAccount, holding.UserID, holding.UserType, holding.Asset.Exchange.Currency, "seller"); err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC()
+	offer := &models.OtcOfferRecord{
+		StockListingID:  holding.AssetID,
+		SellerHoldingID: holding.ID,
+		Amount:          input.Amount,
+		PricePerStock:   input.PricePerStock,
+		SettlementDate:  input.SettlementDate.UTC(),
+		Premium:         input.Premium,
+		LastModified:    now,
+		ModifiedByID:    input.BuyerID,
+		ModifiedByType:  input.BuyerType,
+		Status:          models.OtcOfferStatusPending,
+		BuyerID:         input.BuyerID,
+		BuyerType:       input.BuyerType,
+		BuyerAccountID:  input.BuyerAccountID,
+		SellerID:        holding.UserID,
+		SellerType:      holding.UserType,
+		SellerAccountID: holding.AccountID,
+	}
+	if err := s.otcRepo.CreateOffer(offer); err != nil {
+		return nil, err
+	}
+
+	created, err := s.otcRepo.GetOfferByID(offer.ID)
+	if err != nil {
+		return nil, err
+	}
+	return created, nil
+}
+
+type CounterOtcOfferInput struct {
+	OfferID        uint
+	ModifiedByID   uint
+	ModifiedByType string
+	Amount         float64
+	PricePerStock  float64
+	SettlementDate time.Time
+	Premium        float64
+}
+
+func (s *OtcService) CounterOffer(input CounterOtcOfferInput) (*models.OtcOfferRecord, error) {
+	if !hasParticipantIdentity(input.ModifiedByID, input.ModifiedByType) {
+		return nil, fmt.Errorf("modifier identity is required")
+	}
+	if input.OfferID == 0 {
+		return nil, fmt.Errorf("offer id is required")
+	}
+	if err := validateOtcTerms(input.Amount, input.PricePerStock, input.SettlementDate, input.Premium); err != nil {
+		return nil, err
+	}
+
+	offer, err := s.otcRepo.GetOfferByID(input.OfferID)
+	if err != nil {
+		return nil, err
+	}
+	if offer == nil || !isOfferParticipant(*offer, input.ModifiedByID, input.ModifiedByType) {
+		return nil, ErrOtcOfferNotFound
+	}
+	if offer.Status != models.OtcOfferStatusPending {
+		return nil, fmt.Errorf("only pending offers can be countered")
+	}
+
+	holding, err := s.portfolioRepo.GetHoldingByID(offer.SellerHoldingID)
+	if err != nil {
+		return nil, err
+	}
+	if holding == nil {
+		return nil, fmt.Errorf("seller holding not found")
+	}
+	if holding.Asset.Type != string(models.ListingTypeStock) {
+		return nil, fmt.Errorf("only stock holdings can be offered through OTC")
+	}
+	if input.Amount > holding.AvailableForOTC() {
+		return nil, fmt.Errorf("amount exceeds available OTC quantity")
+	}
+
+	if err := s.otcRepo.UpdateOfferTerms(
+		offer.ID,
+		input.Amount,
+		input.PricePerStock,
+		input.SettlementDate.UTC(),
+		input.Premium,
+		input.ModifiedByID,
+		input.ModifiedByType,
+	); err != nil {
+		return nil, err
+	}
+
+	updated, err := s.otcRepo.GetOfferByID(offer.ID)
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func (s *OtcService) DeclineOffer(offerID uint, sellerID uint, sellerType string) (*models.OtcOfferRecord, error) {
+	return s.updateOfferStatusForParticipant(offerID, sellerID, sellerType, models.OtcOfferStatusDeclined)
+}
+
+func (s *OtcService) CancelOffer(offerID uint, buyerID uint, buyerType string) (*models.OtcOfferRecord, error) {
+	return s.updateOfferStatusForParticipant(offerID, buyerID, buyerType, models.OtcOfferStatusCancelled)
+}
+
+func (s *OtcService) AcceptOffer(offerID uint, sellerID uint, sellerType string) (*models.OtcContractRecord, error) {
+	if !hasParticipantIdentity(sellerID, sellerType) {
+		return nil, fmt.Errorf("seller identity is required")
+	}
+	if offerID == 0 {
+		return nil, fmt.Errorf("offer id is required")
+	}
+
+	contract, err := s.otcRepo.AcceptOfferAndCreateContract(offerID, sellerID, sellerType)
+	if err != nil {
+		if err.Error() == "offer not found" {
+			return nil, ErrOtcOfferNotFound
+		}
+		return nil, err
+	}
+	return contract, nil
+}
+
+func (s *OtcService) ListOffersForParticipant(userID uint, userType string, status string) ([]models.OtcOfferRecord, error) {
+	if err := validateOfferStatusFilter(status); err != nil {
+		return nil, err
+	}
+	return s.otcRepo.ListOffersForParticipant(userID, userType, status)
+}
+
+func (s *OtcService) ListContractsForParticipant(userID uint, userType string, status string) ([]models.OtcContractRecord, error) {
+	if err := validateContractStatusFilter(status); err != nil {
+		return nil, err
+	}
+	return s.otcRepo.ListContractsForParticipant(userID, userType, status)
+}
+
+func (s *OtcService) ExpireDueContracts(referenceTime time.Time) (int, error) {
+	if referenceTime.IsZero() {
+		referenceTime = time.Now().UTC()
+	}
+	return s.otcRepo.ExpireValidContracts(referenceTime.UTC())
+}
+
+func (s *OtcService) GetOfferForParticipant(offerID uint, userID uint, userType string) (*models.OtcOfferRecord, error) {
+	offer, err := s.otcRepo.GetOfferByID(offerID)
+	if err != nil {
+		return nil, err
+	}
+	if offer == nil {
+		return nil, ErrOtcOfferNotFound
+	}
+	if !isOfferParticipant(*offer, userID, userType) {
+		return nil, ErrOtcOfferNotFound
+	}
+	return offer, nil
+}
+
+func isOfferParticipant(offer models.OtcOfferRecord, userID uint, userType string) bool {
+	return (offer.BuyerID == userID && offer.BuyerType == userType) ||
+		(offer.SellerID == userID && offer.SellerType == userType)
+}
+
+func validateOfferStatusFilter(status string) error {
+	switch status {
+	case "", models.OtcOfferStatusPending, models.OtcOfferStatusAccepted, models.OtcOfferStatusDeclined, models.OtcOfferStatusCancelled:
+		return nil
+	default:
+		return fmt.Errorf("invalid offer status")
+	}
+}
+
+func validateContractStatusFilter(status string) error {
+	switch status {
+	case "", models.OtcContractStatusValid, models.OtcContractStatusExercised, models.OtcContractStatusExpired:
+		return nil
+	default:
+		return fmt.Errorf("invalid contract status")
+	}
+}
+
+func (s *OtcService) updateOfferStatusForParticipant(offerID uint, userID uint, userType string, status string) (*models.OtcOfferRecord, error) {
+	if !hasParticipantIdentity(userID, userType) {
+		return nil, fmt.Errorf("participant identity is required")
+	}
+	if offerID == 0 {
+		return nil, fmt.Errorf("offer id is required")
+	}
+
+	offer, err := s.otcRepo.GetOfferByID(offerID)
+	if err != nil {
+		return nil, err
+	}
+	if offer == nil || !isOfferParticipant(*offer, userID, userType) {
+		return nil, ErrOtcOfferNotFound
+	}
+	if offer.Status != models.OtcOfferStatusPending {
+		return nil, fmt.Errorf("only pending offers can be updated")
+	}
+
+	switch status {
+	case models.OtcOfferStatusDeclined:
+		if offer.SellerID != userID || offer.SellerType != userType {
+			return nil, fmt.Errorf("only seller can decline an offer")
+		}
+	case models.OtcOfferStatusCancelled:
+		if offer.BuyerID != userID || offer.BuyerType != userType {
+			return nil, fmt.Errorf("only buyer can cancel an offer")
+		}
+	default:
+		return nil, fmt.Errorf("unsupported offer status update")
+	}
+
+	if err := s.otcRepo.UpdateOfferStatus(offer.ID, status, userID, userType); err != nil {
+		return nil, err
+	}
+	updated, err := s.otcRepo.GetOfferByID(offer.ID)
+	if err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+func validateOtcTerms(amount, pricePerStock float64, settlementDate time.Time, premium float64) error {
+	if amount <= 0 {
+		return fmt.Errorf("amount must be positive")
+	}
+	if pricePerStock <= 0 {
+		return fmt.Errorf("price per stock must be positive")
+	}
+	if premium < 0 {
+		return fmt.Errorf("premium cannot be negative")
+	}
+	if settlementDate.IsZero() {
+		return fmt.Errorf("settlement date is required")
+	}
+	if !settlementDate.After(time.Now().UTC()) {
+		return fmt.Errorf("settlement date must be in the future")
+	}
+	return nil
+}
+
+func validateOtcAccountForParticipant(account *repository.OtcAccountReference, userID uint, userType string, expectedCurrency string, role string) error {
+	if account == nil {
+		return fmt.Errorf("%s account not found", role)
+	}
+	if account.Status != "aktivan" {
+		return fmt.Errorf("%s account is not active", role)
+	}
+	if account.CurrencyCode != expectedCurrency {
+		return fmt.Errorf("%s account currency must match stock currency", role)
+	}
+	if !account.IsOwnedBy(userID, userType) {
+		return fmt.Errorf("%s account does not belong to participant", role)
+	}
+	return nil
+}
+
+func hasParticipantIdentity(userID uint, userType string) bool {
+	if userType == "" {
+		return false
+	}
+	return userType != string(models.PortfolioOwnerTypeClient) || userID != 0
+}

--- a/exchange-service/internal/service/otc_service_test.go
+++ b/exchange-service/internal/service/otc_service_test.go
@@ -1,0 +1,586 @@
+package service_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+	"gorm.io/gorm"
+)
+
+func setupOtcServiceFixture(t *testing.T, name string) (*service.OtcService, *models.PortfolioHoldingRecord, *repository.OtcRepository) {
+	t.Helper()
+	db := openTestDB(t, name)
+	seedOtcAccountTables(t, db)
+	assetID := seedAsset(t, db, "OTC"+name[:1], 100, "USD")
+	holding := seedOtcHolding(t, db, assetID, 200, "client", 10, 6, 1)
+	portfolioRepo := repository.NewPortfolioRepository(db)
+	otcRepo := repository.NewOtcRepository(db)
+	return service.NewOtcService(portfolioRepo, otcRepo), holding, otcRepo
+}
+
+func seedOtcAccountTables(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	if err := db.Exec(`CREATE TABLE IF NOT EXISTS currencies (id integer primary key, kod text not null unique)`).Error; err != nil {
+		t.Fatalf("create currencies table: %v", err)
+	}
+	if err := db.Exec(`CREATE TABLE IF NOT EXISTS accounts (
+		id integer primary key,
+		client_id integer,
+		firma_id integer,
+		zaposleni_id integer,
+		currency_id integer not null,
+		stanje real not null default 0,
+		raspolozivo_stanje real not null default 0,
+		dnevna_potrosnja real not null default 0,
+		mesecna_potrosnja real not null default 0,
+		status text not null default 'aktivan'
+	)`).Error; err != nil {
+		t.Fatalf("create accounts table: %v", err)
+	}
+	if err := db.Exec(`INSERT OR IGNORE INTO currencies (id, kod) VALUES (1, 'USD')`).Error; err != nil {
+		t.Fatalf("seed currency: %v", err)
+	}
+	if err := db.Exec(`INSERT OR IGNORE INTO accounts (id, client_id, currency_id, stanje, raspolozivo_stanje, status) VALUES
+		(1, 200, 1, 1000, 1000, 'aktivan'),
+		(2, 100, 1, 1000, 1000, 'aktivan')`).Error; err != nil {
+		t.Fatalf("seed accounts: %v", err)
+	}
+}
+
+func seedOtcHolding(t *testing.T, db *gorm.DB, assetID uint, userID uint, userType string, quantity, publicQuantity, reservedQuantity float64) *models.PortfolioHoldingRecord {
+	t.Helper()
+	holding := &models.PortfolioHoldingRecord{
+		UserID: userID, UserType: userType, AssetID: assetID, Quantity: quantity,
+		PublicQuantity: publicQuantity, ReservedQuantity: reservedQuantity,
+		AvgBuyPrice: 90, AccountID: 1, CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(holding).Error; err != nil {
+		t.Fatal(err)
+	}
+	return holding
+}
+
+func TestOtcService_CreateOffer(t *testing.T) {
+	svc, holding, otcRepo := setupOtcServiceFixture(t, "otc_create_offer")
+
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+	if offer.ID == 0 || offer.Status != models.OtcOfferStatusPending {
+		t.Fatalf("expected persisted pending offer, got %+v", offer)
+	}
+	if offer.BuyerID != 100 || offer.SellerID != 200 || offer.StockListingID != holding.AssetID {
+		t.Fatalf("unexpected offer ownership/listing fields: %+v", offer)
+	}
+
+	offers, err := otcRepo.ListOffersForParticipant(100, "client", models.OtcOfferStatusPending)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(offers) != 1 {
+		t.Fatalf("expected buyer to see created offer, got %d", len(offers))
+	}
+}
+
+func TestOtcService_CreateOfferRejectsOwnHolding(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_create_self")
+
+	_, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         200,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          1,
+		PricePerStock:   100,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         10,
+	})
+	if err == nil || !strings.Contains(err.Error(), "own holding") {
+		t.Fatalf("expected own holding error, got %v", err)
+	}
+}
+
+func TestOtcService_CreateOfferRejectsUnavailableQuantity(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_create_excess")
+
+	_, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          6,
+		PricePerStock:   100,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         10,
+	})
+	if err == nil || !strings.Contains(err.Error(), "available OTC quantity") {
+		t.Fatalf("expected available quantity error, got %v", err)
+	}
+}
+
+func TestOtcService_ListAndGetOffersForParticipant(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_list_get")
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	buyerOffers, err := svc.ListOffersForParticipant(100, "client", models.OtcOfferStatusPending)
+	if err != nil {
+		t.Fatalf("ListOffersForParticipant buyer: %v", err)
+	}
+	if len(buyerOffers) != 1 || buyerOffers[0].ID != offer.ID {
+		t.Fatalf("expected buyer to see created offer, got %+v", buyerOffers)
+	}
+
+	sellerOffer, err := svc.GetOfferForParticipant(offer.ID, 200, "client")
+	if err != nil {
+		t.Fatalf("GetOfferForParticipant seller: %v", err)
+	}
+	if sellerOffer.ID != offer.ID {
+		t.Fatalf("expected offer %d, got %d", offer.ID, sellerOffer.ID)
+	}
+}
+
+func TestOtcService_GetOfferForParticipantRejectsUnrelatedUser(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_get_unrelated")
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	_, err = svc.GetOfferForParticipant(offer.ID, 999, "client")
+	if !errors.Is(err, service.ErrOtcOfferNotFound) {
+		t.Fatalf("expected ErrOtcOfferNotFound for unrelated participant, got %v", err)
+	}
+}
+
+func TestOtcService_ListOffersRejectsInvalidStatus(t *testing.T) {
+	svc, _, _ := setupOtcServiceFixture(t, "otc_list_bad_status")
+
+	_, err := svc.ListOffersForParticipant(100, "client", "mystery")
+	if err == nil || !strings.Contains(err.Error(), "invalid offer status") {
+		t.Fatalf("expected invalid status error, got %v", err)
+	}
+}
+
+func TestOtcService_CounterOffer(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_counter")
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	newDate := time.Now().UTC().AddDate(0, 2, 0)
+	updated, err := svc.CounterOffer(service.CounterOtcOfferInput{
+		OfferID:        offer.ID,
+		ModifiedByID:   200,
+		ModifiedByType: "client",
+		Amount:         4,
+		PricePerStock:  108,
+		SettlementDate: newDate,
+		Premium:        30,
+	})
+	if err != nil {
+		t.Fatalf("CounterOffer: %v", err)
+	}
+	if updated.Amount != 4 || updated.PricePerStock != 108 || updated.Premium != 30 {
+		t.Fatalf("terms were not updated: %+v", updated)
+	}
+	if updated.ModifiedByID != 200 || updated.ModifiedByType != "client" {
+		t.Fatalf("modifier not updated: %+v", updated)
+	}
+}
+
+func TestOtcService_CounterOfferRejectsUnrelatedParticipant(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_counter_unrelated")
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	_, err = svc.CounterOffer(service.CounterOtcOfferInput{
+		OfferID:        offer.ID,
+		ModifiedByID:   999,
+		ModifiedByType: "client",
+		Amount:         4,
+		PricePerStock:  108,
+		SettlementDate: time.Now().UTC().AddDate(0, 2, 0),
+		Premium:        30,
+	})
+	if !errors.Is(err, service.ErrOtcOfferNotFound) {
+		t.Fatalf("expected ErrOtcOfferNotFound, got %v", err)
+	}
+}
+
+func TestOtcService_CounterOfferRejectsNonPendingOffer(t *testing.T) {
+	svc, holding, otcRepo := setupOtcServiceFixture(t, "otc_counter_status")
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+	if err := otcRepo.UpdateOfferStatus(offer.ID, models.OtcOfferStatusDeclined, 200, "client"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = svc.CounterOffer(service.CounterOtcOfferInput{
+		OfferID:        offer.ID,
+		ModifiedByID:   100,
+		ModifiedByType: "client",
+		Amount:         4,
+		PricePerStock:  108,
+		SettlementDate: time.Now().UTC().AddDate(0, 2, 0),
+		Premium:        30,
+	})
+	if err == nil || !strings.Contains(err.Error(), "pending") {
+		t.Fatalf("expected pending status error, got %v", err)
+	}
+}
+
+func TestOtcService_DeclineOffer(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_decline")
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	updated, err := svc.DeclineOffer(offer.ID, 200, "client")
+	if err != nil {
+		t.Fatalf("DeclineOffer: %v", err)
+	}
+	if updated.Status != models.OtcOfferStatusDeclined || updated.ModifiedByID != 200 {
+		t.Fatalf("expected seller decline status, got %+v", updated)
+	}
+}
+
+func TestOtcService_CancelOffer(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_cancel")
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	updated, err := svc.CancelOffer(offer.ID, 100, "client")
+	if err != nil {
+		t.Fatalf("CancelOffer: %v", err)
+	}
+	if updated.Status != models.OtcOfferStatusCancelled || updated.ModifiedByID != 100 {
+		t.Fatalf("expected buyer cancel status, got %+v", updated)
+	}
+}
+
+func TestOtcService_DeclineOfferRejectsBuyer(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_decline_buyer")
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	_, err = svc.DeclineOffer(offer.ID, 100, "client")
+	if err == nil || !strings.Contains(err.Error(), "only seller") {
+		t.Fatalf("expected seller-only decline error, got %v", err)
+	}
+}
+
+func TestOtcService_CancelOfferRejectsSeller(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_cancel_seller")
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	_, err = svc.CancelOffer(offer.ID, 200, "client")
+	if err == nil || !strings.Contains(err.Error(), "only buyer") {
+		t.Fatalf("expected buyer-only cancel error, got %v", err)
+	}
+}
+
+func TestOtcService_AcceptOfferCreatesContractAndReservesQuantity(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_accept")
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	contract, err := svc.AcceptOffer(offer.ID, 200, "client")
+	if err != nil {
+		t.Fatalf("AcceptOffer: %v", err)
+	}
+	if contract.ID == 0 || contract.Status != models.OtcContractStatusValid {
+		t.Fatalf("expected valid contract, got %+v", contract)
+	}
+	if contract.Amount != 3 || contract.StrikePrice != 105 || contract.Premium != 25 {
+		t.Fatalf("unexpected contract terms: %+v", contract)
+	}
+
+	acceptedOffer, err := svc.GetOfferForParticipant(offer.ID, 100, "client")
+	if err != nil {
+		t.Fatalf("GetOfferForParticipant: %v", err)
+	}
+	if acceptedOffer.Status != models.OtcOfferStatusAccepted {
+		t.Fatalf("expected accepted offer, got %q", acceptedOffer.Status)
+	}
+
+	publicStocks, err := svc.ListPublicStocks(100, "client")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(publicStocks) != 1 || publicStocks[0].ReservedQuantity != 4 || publicStocks[0].AvailableQuantity != 2 {
+		t.Fatalf("expected reserved quantity to include accepted amount, got %+v", publicStocks)
+	}
+}
+
+func TestOtcService_ListContractsForParticipant(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_contracts")
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+	contract, err := svc.AcceptOffer(offer.ID, 200, "client")
+	if err != nil {
+		t.Fatalf("AcceptOffer: %v", err)
+	}
+
+	buyerContracts, err := svc.ListContractsForParticipant(100, "client", models.OtcContractStatusValid)
+	if err != nil {
+		t.Fatalf("ListContractsForParticipant buyer: %v", err)
+	}
+	if len(buyerContracts) != 1 || buyerContracts[0].ID != contract.ID {
+		t.Fatalf("expected buyer contract %d, got %+v", contract.ID, buyerContracts)
+	}
+
+	sellerContracts, err := svc.ListContractsForParticipant(200, "client", "")
+	if err != nil {
+		t.Fatalf("ListContractsForParticipant seller: %v", err)
+	}
+	if len(sellerContracts) != 1 || sellerContracts[0].ID != contract.ID {
+		t.Fatalf("expected seller contract %d, got %+v", contract.ID, sellerContracts)
+	}
+
+	none, err := svc.ListContractsForParticipant(999, "client", "")
+	if err != nil {
+		t.Fatalf("ListContractsForParticipant unrelated: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("expected unrelated participant to see no contracts, got %+v", none)
+	}
+}
+
+func TestOtcService_ListContractsRejectsInvalidStatus(t *testing.T) {
+	svc, _, _ := setupOtcServiceFixture(t, "otc_contracts_bad_status")
+
+	_, err := svc.ListContractsForParticipant(100, "client", "pending")
+	if err == nil || !strings.Contains(err.Error(), "invalid contract status") {
+		t.Fatalf("expected invalid contract status error, got %v", err)
+	}
+}
+
+func TestOtcService_ExpireDueContracts(t *testing.T) {
+	db := openTestDB(t, "otc_expire_due")
+	seedOtcAccountTables(t, db)
+	assetID := seedAsset(t, db, "OTCE", 100, "USD")
+	holding := seedOtcHolding(t, db, assetID, 200, "client", 10, 6, 1)
+	portfolioRepo := repository.NewPortfolioRepository(db)
+	otcRepo := repository.NewOtcRepository(db)
+	svc := service.NewOtcService(portfolioRepo, otcRepo)
+
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+	contract, err := svc.AcceptOffer(offer.ID, 200, "client")
+	if err != nil {
+		t.Fatalf("AcceptOffer: %v", err)
+	}
+	if err := db.Model(&models.OtcContractRecord{}).
+		Where("id = ?", contract.ID).
+		Update("settlement_date", time.Now().UTC().Add(-24*time.Hour)).Error; err != nil {
+		t.Fatalf("backdate contract: %v", err)
+	}
+
+	expired, err := svc.ExpireDueContracts(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("ExpireDueContracts: %v", err)
+	}
+	if expired != 1 {
+		t.Fatalf("expected one expired contract, got %d", expired)
+	}
+
+	contracts, err := svc.ListContractsForParticipant(100, "client", models.OtcContractStatusExpired)
+	if err != nil {
+		t.Fatalf("ListContractsForParticipant expired: %v", err)
+	}
+	if len(contracts) != 1 || contracts[0].ID != contract.ID {
+		t.Fatalf("expected expired contract %d, got %+v", contract.ID, contracts)
+	}
+}
+
+func TestOtcService_AcceptOfferRejectsBuyer(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_accept_buyer")
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	_, err = svc.AcceptOffer(offer.ID, 100, "client")
+	if err == nil || !strings.Contains(err.Error(), "only seller") {
+		t.Fatalf("expected seller-only accept error, got %v", err)
+	}
+}
+
+func TestOtcService_AcceptOfferRejectsNonPending(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_accept_non_pending")
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID:         100,
+		BuyerType:       "client",
+		BuyerAccountID:  2,
+		SellerHoldingID: holding.ID,
+		Amount:          3,
+		PricePerStock:   105,
+		SettlementDate:  time.Now().UTC().AddDate(0, 1, 0),
+		Premium:         25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+	if _, err := svc.CancelOffer(offer.ID, 100, "client"); err != nil {
+		t.Fatalf("CancelOffer: %v", err)
+	}
+
+	_, err = svc.AcceptOffer(offer.ID, 200, "client")
+	if err == nil || !strings.Contains(err.Error(), "pending") {
+		t.Fatalf("expected pending status error, got %v", err)
+	}
+}

--- a/exchange-service/internal/service/portfolio_service.go
+++ b/exchange-service/internal/service/portfolio_service.go
@@ -137,6 +137,18 @@ func (s *PortfolioService) SetPublic(holdingID uint, isPublic bool) error {
 	return s.portfolioRepo.SetHoldingPublic(holdingID, isPublic)
 }
 
+func (s *PortfolioService) SetPublicQuantity(holdingID uint, publicQuantity float64) error {
+	return s.portfolioRepo.SetHoldingPublicQuantity(holdingID, publicQuantity)
+}
+
+func (s *PortfolioService) ReserveOTCQuantity(holdingID uint, quantity float64) error {
+	return s.portfolioRepo.ReserveHoldingQuantity(holdingID, quantity)
+}
+
+func (s *PortfolioService) ReleaseOTCReservedQuantity(holdingID uint, quantity float64) error {
+	return s.portfolioRepo.ReleaseHoldingReservedQuantity(holdingID, quantity)
+}
+
 // ExerciseOption exercises an in-the-money option held in the portfolio.
 //
 // Validations:

--- a/payment-service/internal/repository/account_repo.go
+++ b/payment-service/internal/repository/account_repo.go
@@ -29,7 +29,7 @@ func (r *AccountRepository) FindByID(id uint) (*models.Account, error) {
 
 func (r *AccountRepository) FindByIDForUpdate(tx *gorm.DB, id uint) (*models.Account, error) {
 	var account models.Account
-	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+	if err := tx.Clauses(clause.Locking{Strength: "UPDATE", Table: clause.Table{Name: "accounts"}}).
 		Table("accounts").
 		Select("accounts.*, currencies.kod as currency_kod").
 		Joins("LEFT JOIN currencies ON currencies.id = accounts.currency_id").
@@ -55,7 +55,7 @@ func (r *AccountRepository) FindByBrojRacuna(brojRacuna string) (*models.Account
 
 func (r *AccountRepository) FindByBrojRacunaForUpdate(tx *gorm.DB, brojRacuna string) (*models.Account, error) {
 	var account models.Account
-	if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+	if err := tx.Clauses(clause.Locking{Strength: "UPDATE", Table: clause.Table{Name: "accounts"}}).
 		Table("accounts").
 		Select("accounts.*, currencies.kod as currency_kod").
 		Joins("LEFT JOIN currencies ON currencies.id = accounts.currency_id").


### PR DESCRIPTION
## Summary
- Adds the Sprint 6 backend foundation for local OTC trading.
- Adds public stock visibility, OTC offer negotiation, and concluded contract read APIs.
- Adds portfolio public/reserved quantity support.
- Fixes backend CI Docker build context for service-level Dockerfiles.

## Details
- Added OTC repository, service, HTTP handler, models, and tests in `exchange-service`.
- Added local same-bank OTC flow:
  - list public stocks
  - create offer
  - accept/reject/counter/cancel offer
  - create option contract after accepted offer
  - list concluded OTC contracts with status filtering
- Added contract metadata including current price and buyer profit preview.
- Added public/reserved quantity handling so shares under active contracts cannot be incorrectly reused.
- Added expiry cleanup for valid OTC contracts.
- Fixed service Docker builds in CI for services that use service-local Dockerfile context.
- Included payment row-locking fix needed for safe verification settlement.

## Testing
- `go test ./...` in `exchange-service`
- `go test ./...` in `payment-service`
- `go test ./...` in `transfer-service`
- `go test ./...` in `loan-service`
- Docker builds verified for affected backend services
- GitHub Actions passed on the source branch

## Notes
- This PR does not implement SAGA execution.
- This PR does not implement interbank OTC protocol communication.
- This PR does not implement supervisor approval workflows.
- This PR does not implement margin or tax logic.
