### PR TITLE
feat(funds): sprint 8 investment-fund domain end-to-end

### DIFF
--- a/employee-service/internal/handler/employee_handler.go
+++ b/employee-service/internal/handler/employee_handler.go
@@ -6,6 +6,7 @@ import (
 
 	employeev1 "github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/gen/proto/employee/v1"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/middleware"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/models"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/repository"
 	svc "github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/service"
@@ -166,7 +167,11 @@ func (h *EmployeeHandler) SetEmployeeActive(ctx context.Context, req *employeev1
 }
 
 func (h *EmployeeHandler) UpdateEmployeePermissions(ctx context.Context, req *employeev1.UpdateEmployeePermissionsRequest) (*employeev1.UpdateEmployeePermissionsResponse, error) {
-	emp, err := h.svc.UpdateEmployeePermissions(uint(req.Id), req.PermissionNames)
+	var actorID uint
+	if claims, ok := middleware.GetClaimsFromContext(ctx); ok && claims != nil {
+		actorID = claims.EmployeeID
+	}
+	emp, err := h.svc.UpdateEmployeePermissionsBy(uint(req.Id), req.PermissionNames, actorID)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}

--- a/employee-service/internal/repository/employee_repo.go
+++ b/employee-service/internal/repository/employee_repo.go
@@ -121,3 +121,15 @@ func (r *EmployeeRepository) UsernameExists(username string, excludeID uint) (bo
 		Count(&count).Error
 	return count > 0, err
 }
+
+// ReassignFundsManagedBy moves every investment fund managed by oldManagerID to
+// be managed by newManagerID. Uses a raw UPDATE because the investment_funds
+// table is owned by the exchange-service but shares the database; only the
+// manager_id column is touched here.
+func (r *EmployeeRepository) ReassignFundsManagedBy(oldManagerID, newManagerID uint) (int64, error) {
+	res := r.db.Exec(
+		"UPDATE investment_funds SET manager_id = ?, updated_at = NOW() WHERE manager_id = ?",
+		newManagerID, oldManagerID,
+	)
+	return res.RowsAffected, res.Error
+}

--- a/employee-service/internal/repository/interfaces.go
+++ b/employee-service/internal/repository/interfaces.go
@@ -14,6 +14,7 @@ type EmployeeRepositoryInterface interface {
 	SetPermissions(emp *models.Employee, permissions []models.Permission) error
 	EmailExists(email string, excludeID uint) (bool, error)
 	UsernameExists(username string, excludeID uint) (bool, error)
+	ReassignFundsManagedBy(oldManagerID, newManagerID uint) (int64, error)
 }
 
 // PermissionRepositoryInterface defines the methods used by EmployeeService.

--- a/employee-service/internal/service/employee_service.go
+++ b/employee-service/internal/service/employee_service.go
@@ -229,9 +229,25 @@ func (s *EmployeeService) SetEmployeeActive(id uint, aktivan bool) error {
 }
 
 func (s *EmployeeService) UpdateEmployeePermissions(id uint, permissionNames []string) (*models.Employee, error) {
+	return s.UpdateEmployeePermissionsBy(id, permissionNames, 0)
+}
+
+// UpdateEmployeePermissionsBy is the same as UpdateEmployeePermissions but
+// records the actor performing the change. When the supervisor permission is
+// removed from `id`, every investment fund managed by that employee is
+// reassigned to `actorID` so funds are never left orphaned.
+func (s *EmployeeService) UpdateEmployeePermissionsBy(id uint, permissionNames []string, actorID uint) (*models.Employee, error) {
 	emp, err := s.employeeRepo.FindByID(id)
 	if err != nil {
 		return nil, fmt.Errorf("employee not found")
+	}
+
+	hadSupervisor := false
+	for _, p := range emp.Permissions {
+		if p.Name == models.PermEmployeeSupervisor {
+			hadSupervisor = true
+			break
+		}
 	}
 
 	perms, err := s.permRepo.FindByNamesForSubject(permissionNames, models.PermissionSubjectEmployee)
@@ -242,8 +258,25 @@ func (s *EmployeeService) UpdateEmployeePermissions(id uint, permissionNames []s
 		return nil, fmt.Errorf("employees can only be assigned employee permissions")
 	}
 
+	hasSupervisor := false
+	for _, p := range perms {
+		if p.Name == models.PermEmployeeSupervisor {
+			hasSupervisor = true
+			break
+		}
+	}
+
 	if err := s.employeeRepo.SetPermissions(emp, perms); err != nil {
 		return nil, err
+	}
+
+	// Supervisor demoted: reassign funds to the admin doing the change so they
+	// don't become orphaned. Done after the permission swap so a future read
+	// of fund.manager_id reflects the new owner.
+	if hadSupervisor && !hasSupervisor && actorID != 0 {
+		if _, err := s.employeeRepo.ReassignFundsManagedBy(id, actorID); err != nil {
+			return nil, fmt.Errorf("permisije promenjene, ali reasignacija fondova nije uspela: %w", err)
+		}
 	}
 
 	updated, err := s.employeeRepo.FindByID(id)

--- a/employee-service/internal/service/employee_service_test.go
+++ b/employee-service/internal/service/employee_service_test.go
@@ -83,6 +83,10 @@ func (m *mockEmployeeRepo) SetPermissions(emp *models.Employee, permissions []mo
 	return nil
 }
 
+func (m *mockEmployeeRepo) ReassignFundsManagedBy(oldManagerID, newManagerID uint) (int64, error) {
+	return 0, nil
+}
+
 func (m *mockEmployeeRepo) EmailExists(email string, excludeID uint) (bool, error) {
 	if m.emailExistsFn != nil {
 		return m.emailExistsFn(email, excludeID)

--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -62,7 +62,10 @@ func main() {
 	sagaOrchestrator := service.NewSagaOrchestrator(sagaRepo, db)
 	sagaRetryRunner := service.NewSagaRetryRunner(sagaRepo, otcRepo, sagaOrchestrator)
 
-	cronScheduler := service.StartCronJobs(db, portfolioSvc, rateProvider, sagaRetryRunner)
+	fundRepo := repository.NewFundRepository(db)
+	fundSvc := service.NewFundService(fundRepo, portfolioRepo, marketRepo, orderRepo, rateProvider)
+
+	cronScheduler := service.StartCronJobs(db, portfolioSvc, rateProvider, sagaRetryRunner, fundSvc)
 
 	go func() {
 		slog.Info("Running market data seed in background...")
@@ -78,13 +81,15 @@ func main() {
 	marketH := handler.NewMarketHTTPHandler(cfg, marketSvc, marketRepo)
 
 	orderSvc := service.NewOrderService(orderRepo, marketRepo, rateProvider)
-	orderH := handler.NewOrderHTTPHandler(cfg, orderSvc)
+	orderH := handler.NewOrderHTTPHandler(cfg, orderSvc).WithFundService(fundSvc)
 	portfolioH := handler.NewPortfolioHTTPHandler(cfg, portfolioSvc)
 	otcSvc := service.NewOtcService(portfolioRepo, otcRepo).WithOrchestrator(sagaOrchestrator)
 	otcH := handler.NewOtcHTTPHandler(cfg, otcSvc).WithSagaQuerier(sagaRepo)
 
 	taxCollector := service.NewTaxCollector(taxSvc, orderRepo, taxRepo)
 	taxH := handler.NewTaxHTTPHandler(cfg, taxSvc, taxCollector)
+
+	fundH := handler.NewFundHTTPHandler(cfg, fundSvc)
 
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
@@ -132,6 +137,8 @@ func main() {
 	httpMux.Handle("/api/v1/orders", middleware.CORS(http.HandlerFunc(orderH.OrdersCollection)))
 	httpMux.Handle("/api/v1/orders/", middleware.CORS(http.HandlerFunc(orderH.OrderRoutes)))
 	httpMux.Handle("/api/v1/tax/", middleware.CORS(http.HandlerFunc(taxH.TaxRoutes)))
+	httpMux.Handle("/api/v1/funds", middleware.CORS(http.HandlerFunc(fundH.FundRoutes)))
+	httpMux.Handle("/api/v1/funds/", middleware.CORS(http.HandlerFunc(fundH.FundRoutes)))
 	httpMux.Handle("/", middleware.CORS(gwMux))
 
 	httpServer := &http.Server{

--- a/exchange-service/internal/database/database.go
+++ b/exchange-service/internal/database/database.go
@@ -47,6 +47,10 @@ func Migrate(db *gorm.DB) error {
 		&models.TaxRecord{},
 		&models.SagaTransactionRecord{},
 		&models.SagaStepRecord{},
+		&models.InvestmentFundRecord{},
+		&models.ClientFundTransactionRecord{},
+		&models.ClientFundPositionRecord{},
+		&models.FundPerformanceHistoryRecord{},
 	); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}

--- a/exchange-service/internal/handler/fund_http_handler.go
+++ b/exchange-service/internal/handler/fund_http_handler.go
@@ -1,0 +1,513 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/util"
+)
+
+type FundHTTPHandler struct {
+	cfg *config.Config
+	svc *service.FundService
+}
+
+func NewFundHTTPHandler(cfg *config.Config, svc *service.FundService) *FundHTTPHandler {
+	return &FundHTTPHandler{cfg: cfg, svc: svc}
+}
+
+// FundRoutes dispatches /api/v1/funds/... requests.
+//
+//	GET    /api/v1/funds                            list all funds
+//	POST   /api/v1/funds                            create fund (supervisor)
+//	GET    /api/v1/funds/{id}                       fund summary + holdings
+//	GET    /api/v1/funds/{id}/performance           daily performance series
+//	GET    /api/v1/funds/{id}/holdings              holdings list
+//	POST   /api/v1/funds/{id}/invest                invest in fund
+//	POST   /api/v1/funds/{id}/withdraw              withdraw from fund
+//	GET    /api/v1/funds/positions/mine             positions of caller
+//	POST   /api/v1/funds/{id}/orders                supervisor places buy-for-fund order metadata (validation only)
+//	POST   /api/v1/funds/transfer-ownership         admin-triggered ownership transfer
+func (h *FundHTTPHandler) FundRoutes(w http.ResponseWriter, r *http.Request) {
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/funds"), "/")
+	if path == "" {
+		switch r.Method {
+		case http.MethodGet:
+			h.listFunds(w, r)
+		case http.MethodPost:
+			h.createFund(w, r)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+		return
+	}
+
+	parts := strings.Split(path, "/")
+	switch {
+	case len(parts) == 2 && parts[0] == "positions" && parts[1] == "mine":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.listMyPositions(w, r)
+	case len(parts) == 1 && parts[0] == "transfer-ownership":
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.transferOwnership(w, r)
+	case len(parts) == 1:
+		id, err := strconv.ParseUint(parts[0], 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid fund id"})
+			return
+		}
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.getFund(w, r, uint(id))
+	case len(parts) == 2:
+		id, err := strconv.ParseUint(parts[0], 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid fund id"})
+			return
+		}
+		switch parts[1] {
+		case "performance":
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			h.getPerformance(w, r, uint(id))
+		case "holdings":
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			h.listHoldings(w, r, uint(id))
+		case "invest":
+			if r.Method != http.MethodPost {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			h.investInFund(w, r, uint(id))
+		case "withdraw":
+			if r.Method != http.MethodPost {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			h.withdrawFromFund(w, r, uint(id))
+		case "validate-order":
+			if r.Method != http.MethodPost {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			h.validateFundOrder(w, r, uint(id))
+		default:
+			http.NotFound(w, r)
+		}
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// --- handlers ---
+
+func (h *FundHTTPHandler) listFunds(w http.ResponseWriter, r *http.Request) {
+	if _, ok := requireAuthenticatedHTTP(w, r, h.cfg); !ok {
+		return
+	}
+
+	funds, err := h.svc.ListFunds()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "neuspesno citanje fondova"})
+		return
+	}
+
+	items := make([]map[string]interface{}, 0, len(funds))
+	for i := range funds {
+		summary, err := h.svc.SummariseFund(&funds[i])
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "neuspesan izracun fonda"})
+			return
+		}
+		items = append(items, summariseToJSON(summary))
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"funds": items, "count": len(items)})
+}
+
+func (h *FundHTTPHandler) createFund(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireSupervisorHTTP(w, claims) {
+		return
+	}
+
+	var body struct {
+		Naziv         string  `json:"naziv"`
+		Opis          string  `json:"opis"`
+		MinimalniUlog float64 `json:"minimalniUlog"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "neispravan zahtev"})
+		return
+	}
+
+	fund, err := h.svc.CreateFund(service.CreateFundInput{
+		Naziv:         body.Naziv,
+		Opis:          body.Opis,
+		MinimalniUlog: body.MinimalniUlog,
+		ManagerID:     claims.EmployeeID,
+	})
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+	summary, err := h.svc.SummariseFund(fund)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "neuspesan izracun fonda"})
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]interface{}{"fund": summariseToJSON(summary)})
+}
+
+func (h *FundHTTPHandler) getFund(w http.ResponseWriter, r *http.Request, fundID uint) {
+	if _, ok := requireAuthenticatedHTTP(w, r, h.cfg); !ok {
+		return
+	}
+	fund, err := h.svc.GetFund(fundID)
+	if err != nil {
+		if errors.Is(err, service.ErrFundNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"message": "fond nije pronadjen"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+		return
+	}
+	summary, err := h.svc.SummariseFund(fund)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"fund": summariseToJSON(summary)})
+}
+
+func (h *FundHTTPHandler) getPerformance(w http.ResponseWriter, r *http.Request, fundID uint) {
+	if _, ok := requireAuthenticatedHTTP(w, r, h.cfg); !ok {
+		return
+	}
+	granularity := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("granularity")))
+	records, err := h.svc.GetPerformance(fundID, granularity)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+	items := make([]map[string]interface{}, 0, len(records))
+	for _, rec := range records {
+		items = append(items, map[string]interface{}{
+			"date":      rec.Date.Format("2006-01-02"),
+			"fundValue": rec.FundValue,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"performance": items,
+		"count":       len(items),
+		"granularity": granularity,
+	})
+}
+
+func (h *FundHTTPHandler) listHoldings(w http.ResponseWriter, r *http.Request, fundID uint) {
+	if _, ok := requireAuthenticatedHTTP(w, r, h.cfg); !ok {
+		return
+	}
+	if _, err := h.svc.GetFund(fundID); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "fond nije pronadjen"})
+		return
+	}
+	holdings, err := h.svc.ListFundHoldings(fundID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+		return
+	}
+	items := make([]map[string]interface{}, 0, len(holdings))
+	for _, h := range holdings {
+		items = append(items, map[string]interface{}{
+			"id":                 h.ID,
+			"assetId":            h.AssetID,
+			"ticker":             h.Asset.Ticker,
+			"name":               h.Asset.Name,
+			"price":              h.Asset.Price,
+			"change":             0.0,
+			"volume":             h.Asset.Volume,
+			"quantity":           h.Quantity,
+			"avgBuyPrice":        h.AvgBuyPrice,
+			"acquisitionDate":    h.CreatedAt.Format("2006-01-02"),
+			"initialMarginCost":  0.0,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"holdings": items, "count": len(items)})
+}
+
+func (h *FundHTTPHandler) investInFund(w http.ResponseWriter, r *http.Request, fundID uint) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+
+	var body struct {
+		SourceAccountID uint    `json:"sourceAccountId"`
+		Amount          float64 `json:"amount"`
+		// Optional: when a supervisor invests on the bank's behalf they may
+		// supply this flag; otherwise the request is treated as the caller's
+		// own contribution.
+		AsBank bool `json:"asBank"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "neispravan zahtev"})
+		return
+	}
+
+	clientID, clientType, err := fundParticipantIdentity(claims, body.AsBank)
+	if err != nil {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": err.Error()})
+		return
+	}
+
+	txRec, err := h.svc.InvestInFund(service.InvestInFundInput{
+		FundID:          fundID,
+		ClientID:        clientID,
+		ClientType:      clientType,
+		SourceAccountID: body.SourceAccountID,
+		Amount:          body.Amount,
+	})
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]interface{}{
+		"transaction": map[string]interface{}{
+			"id":         txRec.ID,
+			"fundId":     txRec.FundID,
+			"amount":     txRec.Iznos,
+			"isInflow":   txRec.IsInflow,
+			"timestamp":  txRec.Timestamp.Format("2006-01-02T15:04:05Z07:00"),
+			"clientType": txRec.ClientType,
+		},
+	})
+}
+
+func (h *FundHTTPHandler) withdrawFromFund(w http.ResponseWriter, r *http.Request, fundID uint) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+
+	var body struct {
+		DestinationAccountID uint    `json:"destinationAccountId"`
+		Amount               float64 `json:"amount"`
+		WithdrawAll          bool    `json:"withdrawAll"`
+		AsBank               bool    `json:"asBank"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "neispravan zahtev"})
+		return
+	}
+
+	clientID, clientType, err := fundParticipantIdentity(claims, body.AsBank)
+	if err != nil {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": err.Error()})
+		return
+	}
+
+	result, err := h.svc.WithdrawFromFund(service.WithdrawFromFundInput{
+		FundID:               fundID,
+		ClientID:             clientID,
+		ClientType:           clientType,
+		DestinationAccountID: body.DestinationAccountID,
+		Amount:               body.Amount,
+		WithdrawAll:          body.WithdrawAll,
+	})
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+	liquidated := make([]map[string]interface{}, 0, len(result.LiquidatedItems))
+	for _, item := range result.LiquidatedItems {
+		liquidated = append(liquidated, map[string]interface{}{
+			"assetId":     item.AssetID,
+			"ticker":      item.Ticker,
+			"quantity":    item.Quantity,
+			"pricePerRSD": item.PricePerRSD,
+			"totalRSD":    item.TotalRSD,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"grossWithdrawn":   result.GrossWithdrawn,
+		"commission":       result.Commission,
+		"netToAccount":     result.NetToAccount,
+		"liquidated":       result.Liquidated,
+		"liquidatedItems":  liquidated,
+	})
+}
+
+func (h *FundHTTPHandler) listMyPositions(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+
+	if claims.TokenSource == "employee" {
+		// Supervisors view the funds they manage; agents/basic employees see
+		// nothing here.
+		if !util.HasPermission(claims, models.PermEmployeeSupervisor) {
+			writeJSON(w, http.StatusOK, map[string]interface{}{"funds": []interface{}{}, "count": 0})
+			return
+		}
+		funds, err := h.svc.ListFundsByManager(claims.EmployeeID)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+			return
+		}
+		items := make([]map[string]interface{}, 0, len(funds))
+		for i := range funds {
+			summary, err := h.svc.SummariseFund(&funds[i])
+			if err != nil {
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+				return
+			}
+			items = append(items, summariseToJSON(summary))
+		}
+		writeJSON(w, http.StatusOK, map[string]interface{}{"funds": items, "count": len(items), "role": "supervisor"})
+		return
+	}
+
+	// Client view: own positions.
+	views, err := h.svc.ListClientFundPositions(claims.ClientID, "client")
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+		return
+	}
+	items := make([]map[string]interface{}, 0, len(views))
+	for _, v := range views {
+		items = append(items, map[string]interface{}{
+			"fundId":             v.FundID,
+			"naziv":              v.FundNaziv,
+			"ukupanUlozeniRSD":   v.UkupanUlozeniRSD,
+			"udeoProcenat":       v.UdeoProcenat,
+			"trenutnaVrednost":   v.TrenutnaVrednost,
+			"profitRSD":          v.ProfitRSD,
+			"fundValueRSD":       v.FundValueRSD,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"positions": items, "count": len(items), "role": "client"})
+}
+
+func (h *FundHTTPHandler) transferOwnership(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	// Only employees with admin permission can issue this call (it is also
+	// invoked internally from employee-service when a supervisor permission is
+	// removed — that path uses an admin token).
+	if claims.TokenSource != "employee" || !util.HasPermission(claims, models.PermEmployeeAdmin) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "admin only"})
+		return
+	}
+
+	var body struct {
+		OldManagerID uint `json:"oldManagerId"`
+		NewManagerID uint `json:"newManagerId"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "neispravan zahtev"})
+		return
+	}
+	moved, err := h.svc.ReassignManagedFunds(body.OldManagerID, body.NewManagerID)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"reassigned": moved})
+}
+
+func (h *FundHTTPHandler) validateFundOrder(w http.ResponseWriter, r *http.Request, fundID uint) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireSupervisorHTTP(w, claims) {
+		return
+	}
+	var body struct {
+		AssetCurrency string `json:"assetCurrency"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	fund, err := h.svc.GetFund(fundID)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "fond nije pronadjen"})
+		return
+	}
+	if _, err := h.svc.ValidateFundBuyOrder(fundID, claims.EmployeeID, fund.AccountID, body.AssetCurrency); err != nil {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"fundId":    fund.ID,
+		"accountId": fund.AccountID,
+		"ok":        true,
+	})
+}
+
+// fundParticipantIdentity maps a JWT into (clientID, clientType) for the
+// fund domain. Clients always invest as themselves; supervisors can pass
+// `asBank=true` to invest on behalf of the bank (clientID=0, type="bank").
+func fundParticipantIdentity(claims *util.Claims, asBank bool) (uint, string, error) {
+	if asBank {
+		if claims.TokenSource != "employee" {
+			return 0, "", errors.New("samo zaposleni mogu investirati u ime banke")
+		}
+		if !util.HasPermission(claims, models.PermEmployeeSupervisor) {
+			return 0, "", errors.New("samo supervisor moze investirati u ime banke")
+		}
+		return 0, "bank", nil
+	}
+	if claims.TokenSource == "client" {
+		if !util.HasPermission(claims, models.PermClientTrading) {
+			return 0, "", errors.New("klijent nema canTrade permisiju")
+		}
+		return claims.ClientID, "client", nil
+	}
+	return 0, "", errors.New("nepoznat ucesnik")
+}
+
+func summariseToJSON(s *service.FundSummary) map[string]interface{} {
+	if s == nil || s.Fund == nil {
+		return map[string]interface{}{}
+	}
+	return map[string]interface{}{
+		"id":                 s.Fund.ID,
+		"naziv":              s.Fund.Naziv,
+		"opis":               s.Fund.Opis,
+		"minimalniUlog":      s.Fund.MinimalniUlog,
+		"managerId":          s.Fund.ManagerID,
+		"accountId":          s.Fund.AccountID,
+		"datumKreiranja":     s.Fund.DatumKreiranja.Format("2006-01-02"),
+		"fundValueRSD":       s.FundValueRSD,
+		"liquidCashRSD":      s.LiquidCashRSD,
+		"holdingsValueRSD":   s.HoldingsValueRSD,
+		"totalInvestedRSD":   s.TotalInvestedRSD,
+		"profitRSD":          s.ProfitRSD,
+		"participantsCount":  s.ParticipantsCount,
+		"withdrawalCommRate": s.WithdrawalCommRate,
+	}
+}

--- a/exchange-service/internal/handler/order_http_handler.go
+++ b/exchange-service/internal/handler/order_http_handler.go
@@ -14,12 +14,20 @@ import (
 )
 
 type OrderHTTPHandler struct {
-	cfg *config.Config
-	svc *service.OrderService
+	cfg     *config.Config
+	svc     *service.OrderService
+	fundSvc *service.FundService
 }
 
 func NewOrderHTTPHandler(cfg *config.Config, svc *service.OrderService) *OrderHTTPHandler {
 	return &OrderHTTPHandler{cfg: cfg, svc: svc}
+}
+
+// WithFundService wires the optional fund service used to validate
+// supervisor buy orders placed on behalf of an investment fund.
+func (h *OrderHTTPHandler) WithFundService(fundSvc *service.FundService) *OrderHTTPHandler {
+	h.fundSvc = fundSvc
+	return h
 }
 
 // OrdersCollection handles /api/v1/orders (no trailing ID).
@@ -94,6 +102,27 @@ func (h *OrderHTTPHandler) createOrder(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID, userType := callerIdentity(claims)
+
+	// Supervisor placing a buy order for an investment fund: hijack the user
+	// identity so the order is owned by the fund (not the bank). Validation
+	// (supervisor manages the fund, account belongs to fund) happens here.
+	if body.FundID != 0 {
+		if h.fundSvc == nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "fund service not available"})
+			return
+		}
+		if claims.TokenSource != "employee" || !util.HasPermission(claims, models.PermEmployeeSupervisor) {
+			writeJSON(w, http.StatusForbidden, map[string]string{"message": "samo supervisor moze trgovati za fond"})
+			return
+		}
+		fund, err := h.fundSvc.ValidateFundBuyOrder(body.FundID, claims.EmployeeID, body.AccountID, "")
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+			return
+		}
+		userID = fund.ID
+		userType = models.PortfolioOwnerFund
+	}
 
 	// Auto-detect order type from provided values when the client sends "market".
 	// Both values → stop_limit; limit only → limit; stop only → stop.
@@ -375,6 +404,10 @@ type createOrderRequest struct {
 	IsMargin     bool     `json:"isMargin"`
 	AccountID    uint     `json:"accountId"`
 	AfterHours   bool     `json:"afterHours"`
+	// FundID is set when a supervisor places a buy order on behalf of an
+	// investment fund — the order is then owned by the fund (UserType="fund",
+	// UserID=fund.ID) instead of the bank.
+	FundID uint `json:"fundId"`
 }
 
 type orderResponse struct {

--- a/exchange-service/internal/models/fund.go
+++ b/exchange-service/internal/models/fund.go
@@ -1,0 +1,79 @@
+package models
+
+import "time"
+
+// InvestmentFundRecord represents a bank-managed investment fund. The fund is
+// always denominated in RSD and owns a dedicated bank account (AccountID) that
+// holds the fund's liquid cash. Securities purchased on behalf of the fund are
+// tracked in the portfolio_holdings table with user_type = "fund" and
+// user_id = fund.id.
+type InvestmentFundRecord struct {
+	ID             uint      `gorm:"primaryKey"`
+	Naziv          string    `gorm:"not null;uniqueIndex"`
+	Opis           string    `gorm:"type:text;not null"`
+	MinimalniUlog  float64   `gorm:"column:minimalni_ulog;not null"`
+	ManagerID      uint      `gorm:"column:manager_id;not null;index"`
+	AccountID      uint      `gorm:"column:account_id;not null;uniqueIndex"`
+	DatumKreiranja time.Time `gorm:"column:datum_kreiranja;not null"`
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+func (InvestmentFundRecord) TableName() string { return "investment_funds" }
+
+const (
+	FundTransactionStatusPending   = "pending"
+	FundTransactionStatusCompleted = "completed"
+	FundTransactionStatusFailed    = "failed"
+)
+
+// ClientFundTransactionRecord logs each cash flow between a client (or the
+// bank, when supervisors top the fund up on its behalf) and a fund. IsInflow
+// is true for investments and false for withdrawals.
+type ClientFundTransactionRecord struct {
+	ID         uint      `gorm:"primaryKey"`
+	ClientID   uint      `gorm:"column:client_id;not null;index:idx_fund_tx_client"`
+	ClientType string    `gorm:"column:client_type;not null;index:idx_fund_tx_client"` // "client" or "bank"
+	FundID     uint      `gorm:"column:fund_id;not null;index"`
+	AccountID  uint      `gorm:"column:account_id;not null"`
+	Iznos      float64   `gorm:"not null"`
+	Status     string    `gorm:"not null;default:'completed'"`
+	IsInflow   bool      `gorm:"column:is_inflow;not null"`
+	Timestamp  time.Time `gorm:"not null"`
+	CreatedAt  time.Time
+}
+
+func (ClientFundTransactionRecord) TableName() string { return "client_fund_transactions" }
+
+// ClientFundPositionRecord tracks the cumulative principal a participant has
+// invested in a fund. Withdrawals subtract from UkupanUlozeniIznos pro-rata so
+// the position reflects net contributed capital.
+type ClientFundPositionRecord struct {
+	ID                    uint      `gorm:"primaryKey"`
+	ClientID              uint      `gorm:"column:client_id;not null;index:idx_fund_pos_client_fund"`
+	ClientType            string    `gorm:"column:client_type;not null;index:idx_fund_pos_client_fund"`
+	FundID                uint      `gorm:"column:fund_id;not null;index:idx_fund_pos_client_fund"`
+	UkupanUlozeniIznos    float64   `gorm:"column:ukupan_ulozeni_iznos;not null;default:0"`
+	DatumPoslednjePromene time.Time `gorm:"column:datum_poslednje_promene;not null"`
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+}
+
+func (ClientFundPositionRecord) TableName() string { return "client_fund_positions" }
+
+// FundPerformanceHistoryRecord stores a daily snapshot of the fund's total
+// value (cash + market value of securities, in RSD).
+type FundPerformanceHistoryRecord struct {
+	ID        uint      `gorm:"primaryKey"`
+	FundID    uint      `gorm:"column:fund_id;not null;index:idx_fund_perf_fund_date"`
+	Date      time.Time `gorm:"type:date;not null;index:idx_fund_perf_fund_date"`
+	FundValue float64   `gorm:"column:fund_value;not null"`
+	CreatedAt time.Time
+}
+
+func (FundPerformanceHistoryRecord) TableName() string { return "fund_performance_history" }
+
+// User-type strings used inside portfolio holdings and order rows for the
+// fund owner. The other two ("client" and "bank") are defined elsewhere; this
+// constant is the additional owner type introduced with investment funds.
+const PortfolioOwnerFund = "fund"

--- a/exchange-service/internal/repository/fund_repository.go
+++ b/exchange-service/internal/repository/fund_repository.go
@@ -1,0 +1,478 @@
+package repository
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type FundRepository struct {
+	db *gorm.DB
+}
+
+func NewFundRepository(db *gorm.DB) *FundRepository {
+	return &FundRepository{db: db}
+}
+
+// FundAccountRef mirrors the shape OtcAccountReference exposes, but is scoped
+// to operations the fund service needs.
+type FundAccountRef struct {
+	ID                uint    `gorm:"column:id"`
+	BrojRacuna        string  `gorm:"column:broj_racuna"`
+	ClientID          *uint   `gorm:"column:client_id"`
+	FirmaID           *uint   `gorm:"column:firma_id"`
+	ZaposleniID       *uint   `gorm:"column:zaposleni_id"`
+	CurrencyID        uint    `gorm:"column:currency_id"`
+	CurrencyCode      string  `gorm:"column:currency_kod"`
+	Status            string  `gorm:"column:status"`
+	Stanje            float64 `gorm:"column:stanje"`
+	RaspolozivoStanje float64 `gorm:"column:raspolozivo_stanje"`
+}
+
+func (a FundAccountRef) IsBankOwned() bool {
+	return a.ClientID == nil && a.FirmaID == nil && a.ZaposleniID == nil
+}
+
+func (a FundAccountRef) BelongsToClient(clientID uint) bool {
+	return a.ClientID != nil && *a.ClientID == clientID
+}
+
+func (r *FundRepository) DB() *gorm.DB { return r.db }
+
+// CreditAccount credits the given account by amount (no questions asked) and
+// is exposed for the fund-service auto-liquidation flow.
+func (r *FundRepository) CreditAccount(accountID uint, amount float64) error {
+	return creditFundAccount(r.db, accountID, amount)
+}
+
+func (r *FundRepository) GetAccountByID(accountID uint) (*FundAccountRef, error) {
+	return getFundAccountRef(r.db, accountID, false)
+}
+
+func (r *FundRepository) findOrCreateRSDCurrencyID(tx *gorm.DB) (uint, error) {
+	var id uint
+	err := tx.Table("currencies").Select("id").Where("kod = ?", "RSD").Limit(1).Scan(&id).Error
+	if err != nil {
+		return 0, err
+	}
+	if id != 0 {
+		return id, nil
+	}
+	// Seed RSD if missing — fund creation should not fail because the row was
+	// never inserted.
+	now := time.Now().UTC()
+	result := tx.Exec(`INSERT INTO currencies (kod, naziv, simbol, drzava, aktivan, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"RSD", "Srpski dinar", "RSD", "Srbija", true, now, now)
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	if err := tx.Table("currencies").Select("id").Where("kod = ?", "RSD").Limit(1).Scan(&id).Error; err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+// CreateFundWithAccount creates a fund and its dedicated bank-owned RSD account
+// inside a single transaction.
+func (r *FundRepository) CreateFundWithAccount(naziv, opis string, minimalniUlog float64, managerID uint) (*models.InvestmentFundRecord, error) {
+	var createdFund models.InvestmentFundRecord
+	err := r.db.Transaction(func(tx *gorm.DB) error {
+		// Duplicate-name check first to return a friendly error.
+		var existing int64
+		if err := tx.Model(&models.InvestmentFundRecord{}).Where("naziv = ?", naziv).Count(&existing).Error; err != nil {
+			return err
+		}
+		if existing > 0 {
+			return fmt.Errorf("fond sa nazivom %q vec postoji", naziv)
+		}
+
+		currencyID, err := r.findOrCreateRSDCurrencyID(tx)
+		if err != nil {
+			return fmt.Errorf("RSD currency lookup failed: %w", err)
+		}
+
+		now := time.Now().UTC()
+		expires := now.AddDate(50, 0, 0)
+		accountNumber := generateFundAccountNumber()
+
+		// Insert directly: account-service is the canonical owner of the
+		// `accounts` schema but the column set is stable. We mark the fund's
+		// account as bank-owned (no client/firma/zaposleni FK).
+		insert := tx.Exec(`INSERT INTO accounts
+			(broj_racuna, currency_id, tip, vrsta, podvrsta, stanje, raspolozivo_stanje,
+			 dnevni_limit, mesecni_limit, dnevna_potrosnja, mesecna_potrosnja,
+			 datum_isteka, odrzavanje_racuna, naziv, status, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			accountNumber, currencyID, "tekuci", "poslovni", "fondacija",
+			0.0, 0.0, 1_000_000_000.0, 10_000_000_000.0, 0.0, 0.0,
+			expires, 0.0, "Fond: "+naziv, "aktivan", now, now,
+		)
+		if insert.Error != nil {
+			return fmt.Errorf("failed to create fund account: %w", insert.Error)
+		}
+
+		var accountID uint
+		if err := tx.Table("accounts").Select("id").Where("broj_racuna = ?", accountNumber).Limit(1).Scan(&accountID).Error; err != nil {
+			return fmt.Errorf("failed to resolve fund account id: %w", err)
+		}
+
+		fund := models.InvestmentFundRecord{
+			Naziv:          naziv,
+			Opis:           opis,
+			MinimalniUlog:  minimalniUlog,
+			ManagerID:      managerID,
+			AccountID:      accountID,
+			DatumKreiranja: now,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+		if err := tx.Create(&fund).Error; err != nil {
+			return err
+		}
+		createdFund = fund
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &createdFund, nil
+}
+
+func (r *FundRepository) GetFundByID(id uint) (*models.InvestmentFundRecord, error) {
+	var fund models.InvestmentFundRecord
+	if err := r.db.First(&fund, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &fund, nil
+}
+
+func (r *FundRepository) ListFunds() ([]models.InvestmentFundRecord, error) {
+	var funds []models.InvestmentFundRecord
+	if err := r.db.Order("naziv ASC").Find(&funds).Error; err != nil {
+		return nil, err
+	}
+	return funds, nil
+}
+
+func (r *FundRepository) ListFundsByManager(managerID uint) ([]models.InvestmentFundRecord, error) {
+	var funds []models.InvestmentFundRecord
+	if err := r.db.Where("manager_id = ?", managerID).Order("naziv ASC").Find(&funds).Error; err != nil {
+		return nil, err
+	}
+	return funds, nil
+}
+
+// ReassignFundsManager transfers all funds currently managed by oldManagerID to
+// newManagerID. Returns the count of funds moved.
+func (r *FundRepository) ReassignFundsManager(oldManagerID, newManagerID uint) (int64, error) {
+	res := r.db.Model(&models.InvestmentFundRecord{}).
+		Where("manager_id = ?", oldManagerID).
+		Updates(map[string]interface{}{
+			"manager_id": newManagerID,
+			"updated_at": time.Now().UTC(),
+		})
+	return res.RowsAffected, res.Error
+}
+
+// --- positions & transactions ---
+
+func (r *FundRepository) GetPosition(clientID uint, clientType string, fundID uint) (*models.ClientFundPositionRecord, error) {
+	var pos models.ClientFundPositionRecord
+	if err := r.db.Where("client_id = ? AND client_type = ? AND fund_id = ?", clientID, clientType, fundID).
+		First(&pos).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &pos, nil
+}
+
+func (r *FundRepository) ListPositionsForClient(clientID uint, clientType string) ([]models.ClientFundPositionRecord, error) {
+	var positions []models.ClientFundPositionRecord
+	if err := r.db.Where("client_id = ? AND client_type = ? AND ukupan_ulozeni_iznos > 0", clientID, clientType).
+		Order("updated_at DESC").Find(&positions).Error; err != nil {
+		return nil, err
+	}
+	return positions, nil
+}
+
+func (r *FundRepository) ListPositionsForFund(fundID uint) ([]models.ClientFundPositionRecord, error) {
+	var positions []models.ClientFundPositionRecord
+	if err := r.db.Where("fund_id = ? AND ukupan_ulozeni_iznos > 0", fundID).
+		Order("updated_at DESC").Find(&positions).Error; err != nil {
+		return nil, err
+	}
+	return positions, nil
+}
+
+func (r *FundRepository) TotalInvestedInFund(fundID uint) (float64, error) {
+	var total float64
+	err := r.db.Model(&models.ClientFundPositionRecord{}).
+		Where("fund_id = ?", fundID).
+		Select("COALESCE(SUM(ukupan_ulozeni_iznos), 0)").
+		Scan(&total).Error
+	return total, err
+}
+
+// RecordInvestment debits the source account, credits the fund's account,
+// inserts a ClientFundTransactionRecord (is_inflow=true) and upserts the
+// ClientFundPositionRecord — all in a single DB transaction.
+func (r *FundRepository) RecordInvestment(
+	clientID uint, clientType string,
+	fundID uint, sourceAccountID, fundAccountID uint, amount float64,
+) (*models.ClientFundTransactionRecord, error) {
+	var txRecord models.ClientFundTransactionRecord
+	err := r.db.Transaction(func(tx *gorm.DB) error {
+		if err := debitFundAccount(tx, sourceAccountID, amount); err != nil {
+			return err
+		}
+		if err := creditFundAccount(tx, fundAccountID, amount); err != nil {
+			return err
+		}
+		now := time.Now().UTC()
+		txRecord = models.ClientFundTransactionRecord{
+			ClientID:   clientID,
+			ClientType: clientType,
+			FundID:     fundID,
+			AccountID:  sourceAccountID,
+			Iznos:      amount,
+			Status:     models.FundTransactionStatusCompleted,
+			IsInflow:   true,
+			Timestamp:  now,
+			CreatedAt:  now,
+		}
+		if err := tx.Create(&txRecord).Error; err != nil {
+			return err
+		}
+		return upsertPosition(tx, clientID, clientType, fundID, amount)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &txRecord, nil
+}
+
+// RecordWithdrawal credits the destination account from the fund's account and
+// reduces the client's position by the withdrawal amount (clamped at zero).
+func (r *FundRepository) RecordWithdrawal(
+	clientID uint, clientType string,
+	fundID uint, fundAccountID, destinationAccountID uint, amount float64, commission float64,
+) (*models.ClientFundTransactionRecord, error) {
+	var txRecord models.ClientFundTransactionRecord
+	err := r.db.Transaction(func(tx *gorm.DB) error {
+		if err := debitFundAccount(tx, fundAccountID, amount); err != nil {
+			return err
+		}
+		netToClient := amount - commission
+		if netToClient < 0 {
+			netToClient = 0
+		}
+		if err := creditFundAccount(tx, destinationAccountID, netToClient); err != nil {
+			return err
+		}
+		now := time.Now().UTC()
+		txRecord = models.ClientFundTransactionRecord{
+			ClientID:   clientID,
+			ClientType: clientType,
+			FundID:     fundID,
+			AccountID:  destinationAccountID,
+			Iznos:      amount,
+			Status:     models.FundTransactionStatusCompleted,
+			IsInflow:   false,
+			Timestamp:  now,
+			CreatedAt:  now,
+		}
+		if err := tx.Create(&txRecord).Error; err != nil {
+			return err
+		}
+		return reducePosition(tx, clientID, clientType, fundID, amount)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &txRecord, nil
+}
+
+func (r *FundRepository) ListTransactionsForFund(fundID uint) ([]models.ClientFundTransactionRecord, error) {
+	var txs []models.ClientFundTransactionRecord
+	if err := r.db.Where("fund_id = ?", fundID).Order("timestamp DESC").Find(&txs).Error; err != nil {
+		return nil, err
+	}
+	return txs, nil
+}
+
+func (r *FundRepository) ListTransactionsForClient(clientID uint, clientType string) ([]models.ClientFundTransactionRecord, error) {
+	var txs []models.ClientFundTransactionRecord
+	if err := r.db.Where("client_id = ? AND client_type = ?", clientID, clientType).
+		Order("timestamp DESC").Find(&txs).Error; err != nil {
+		return nil, err
+	}
+	return txs, nil
+}
+
+// --- performance ---
+
+func (r *FundRepository) SavePerformanceSnapshot(fundID uint, snapshotDate time.Time, value float64) error {
+	now := time.Now().UTC()
+	rec := models.FundPerformanceHistoryRecord{
+		FundID:    fundID,
+		Date:      snapshotDate,
+		FundValue: value,
+		CreatedAt: now,
+	}
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "fund_id"}, {Name: "date"}},
+		DoUpdates: clause.AssignmentColumns([]string{"fund_value"}),
+	}).Create(&rec).Error
+}
+
+func (r *FundRepository) ListPerformance(fundID uint, from, to time.Time) ([]models.FundPerformanceHistoryRecord, error) {
+	var recs []models.FundPerformanceHistoryRecord
+	if err := r.db.Where("fund_id = ? AND date BETWEEN ? AND ?", fundID, from, to).
+		Order("date ASC").Find(&recs).Error; err != nil {
+		return nil, err
+	}
+	return recs, nil
+}
+
+// --- helpers ---
+
+func getFundAccountRef(db *gorm.DB, accountID uint, lock bool) (*FundAccountRef, error) {
+	if accountID == 0 {
+		return nil, nil
+	}
+	q := db.Table("accounts").
+		Select("accounts.id, accounts.broj_racuna, accounts.client_id, accounts.firma_id, accounts.zaposleni_id, accounts.currency_id, currencies.kod AS currency_kod, accounts.status, accounts.stanje, accounts.raspolozivo_stanje").
+		Joins("LEFT JOIN currencies ON currencies.id = accounts.currency_id").
+		Where("accounts.id = ?", accountID)
+	if lock {
+		q = q.Clauses(clause.Locking{Strength: "UPDATE"})
+	}
+	var ref FundAccountRef
+	if err := q.First(&ref).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &ref, nil
+}
+
+func debitFundAccount(tx *gorm.DB, accountID uint, amount float64) error {
+	if amount <= 0 {
+		return nil
+	}
+	res := tx.Table("accounts").
+		Where("id = ? AND raspolozivo_stanje >= ?", accountID, amount).
+		Updates(map[string]interface{}{
+			"stanje":             gorm.Expr("stanje - ?", amount),
+			"raspolozivo_stanje": gorm.Expr("raspolozivo_stanje - ?", amount),
+		})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return fmt.Errorf("nedovoljno sredstava na racunu")
+	}
+	return nil
+}
+
+func creditFundAccount(tx *gorm.DB, accountID uint, amount float64) error {
+	if amount <= 0 {
+		return nil
+	}
+	return tx.Table("accounts").Where("id = ?", accountID).
+		Updates(map[string]interface{}{
+			"stanje":             gorm.Expr("stanje + ?", amount),
+			"raspolozivo_stanje": gorm.Expr("raspolozivo_stanje + ?", amount),
+		}).Error
+}
+
+func upsertPosition(tx *gorm.DB, clientID uint, clientType string, fundID uint, delta float64) error {
+	var pos models.ClientFundPositionRecord
+	err := tx.Where("client_id = ? AND client_type = ? AND fund_id = ?", clientID, clientType, fundID).
+		First(&pos).Error
+	now := time.Now().UTC()
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		pos = models.ClientFundPositionRecord{
+			ClientID:              clientID,
+			ClientType:            clientType,
+			FundID:                fundID,
+			UkupanUlozeniIznos:    delta,
+			DatumPoslednjePromene: now,
+			CreatedAt:             now,
+			UpdatedAt:             now,
+		}
+		return tx.Create(&pos).Error
+	}
+	if err != nil {
+		return err
+	}
+	return tx.Model(&pos).Updates(map[string]interface{}{
+		"ukupan_ulozeni_iznos":    pos.UkupanUlozeniIznos + delta,
+		"datum_poslednje_promene": now,
+		"updated_at":              now,
+	}).Error
+}
+
+func reducePosition(tx *gorm.DB, clientID uint, clientType string, fundID uint, amount float64) error {
+	var pos models.ClientFundPositionRecord
+	err := tx.Where("client_id = ? AND client_type = ? AND fund_id = ?", clientID, clientType, fundID).
+		First(&pos).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	newValue := pos.UkupanUlozeniIznos - amount
+	if newValue < 0 {
+		newValue = 0
+	}
+	now := time.Now().UTC()
+	return tx.Model(&pos).Updates(map[string]interface{}{
+		"ukupan_ulozeni_iznos":    newValue,
+		"datum_poslednje_promene": now,
+		"updated_at":              now,
+	}).Error
+}
+
+// generateFundAccountNumber produces an 18-digit bank-owned account number in
+// the same family the account-service uses (333 / 0001 / random / check / 12).
+// The format is independent of the account-service util to avoid a cross-module
+// import.
+func generateFundAccountNumber() string {
+	const bankCode = "333"
+	const branchCode = "0001"
+	const typeCode = "12"
+	for {
+		random := fmt.Sprintf("%08d", rand.Int63n(100_000_000))
+		prefix := bankCode + branchCode + random
+		sum := digitSum(prefix) + digitSum(typeCode)
+		check := (11 - (sum % 11)) % 11
+		if check == 10 {
+			continue
+		}
+		return prefix + fmt.Sprintf("%d", check) + typeCode
+	}
+}
+
+func digitSum(s string) int {
+	sum := 0
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			sum += int(c - '0')
+		}
+	}
+	return sum
+}

--- a/exchange-service/internal/service/cron_service.go
+++ b/exchange-service/internal/service/cron_service.go
@@ -16,7 +16,7 @@ import (
 // portfolioSvc is created in main and shared with the portfolio HTTP handler.
 // sagaRetry is optional; when non-nil it is invoked every 5 minutes to retry
 // stuck SAGA compensations.
-func StartCronJobs(db *gorm.DB, portfolioSvc *PortfolioService, rateProvider RateProviderInterface, sagaRetry *SagaRetryRunner) *cron.Cron {
+func StartCronJobs(db *gorm.DB, portfolioSvc *PortfolioService, rateProvider RateProviderInterface, sagaRetry *SagaRetryRunner, fundSvc *FundService) *cron.Cron {
 	c := cron.New()
 
 	// Refresh listing prices every 15 minutes.
@@ -74,6 +74,20 @@ func StartCronJobs(db *gorm.DB, portfolioSvc *PortfolioService, rateProvider Rat
 	})
 	if err != nil {
 		slog.Error("Failed to add tax collection cron job", "error", err)
+	}
+
+	// Daily fund performance snapshot: runs at 23:55 UTC every day.
+	if fundSvc != nil {
+		_, err = c.AddFunc("55 23 * * *", func() {
+			if err := fundSvc.RecordDailyPerformance(time.Now().UTC()); err != nil {
+				slog.Error("Failed to record fund performance snapshots", "error", err)
+				return
+			}
+			slog.Info("Recorded daily fund performance snapshots")
+		})
+		if err != nil {
+			slog.Error("Failed to add fund snapshot cron job", "error", err)
+		}
 	}
 
 	c.Start()

--- a/exchange-service/internal/service/fund_service.go
+++ b/exchange-service/internal/service/fund_service.go
@@ -1,0 +1,635 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+var (
+	ErrFundNotFound     = errors.New("investicioni fond nije pronadjen")
+	ErrFundPositionNone = errors.New("klijent nema poziciju u fondu")
+)
+
+// fundWithdrawalCommissionRate is the % commission charged to clients on a
+// withdrawal (zero for supervisors topping up/withdrawing on the bank's behalf).
+const fundWithdrawalCommissionRate = 0.005 // 0.5%
+
+// FundService is the entry point for the FOND domain. It owns:
+//   - Investment-fund CRUD (supervisors only)
+//   - Investments and withdrawals by clients and the bank
+//   - Derived computations (fund value, profit, share, position value)
+//   - Daily performance snapshots
+type FundService struct {
+	fundRepo      *repository.FundRepository
+	portfolioRepo *repository.PortfolioRepository
+	marketRepo    *repository.MarketRepository
+	orderRepo     *repository.OrderRepository
+	rateProvider  RateProviderInterface
+}
+
+func NewFundService(
+	fundRepo *repository.FundRepository,
+	portfolioRepo *repository.PortfolioRepository,
+	marketRepo *repository.MarketRepository,
+	orderRepo *repository.OrderRepository,
+	rateProvider RateProviderInterface,
+) *FundService {
+	return &FundService{
+		fundRepo:      fundRepo,
+		portfolioRepo: portfolioRepo,
+		marketRepo:    marketRepo,
+		orderRepo:     orderRepo,
+		rateProvider:  rateProvider,
+	}
+}
+
+// --- DTOs ---
+
+type CreateFundInput struct {
+	Naziv         string
+	Opis          string
+	MinimalniUlog float64
+	ManagerID     uint // supervisor creating the fund
+}
+
+type InvestInFundInput struct {
+	FundID          uint
+	ClientID        uint
+	ClientType      string // "client" or "bank"
+	SourceAccountID uint
+	Amount          float64
+}
+
+type WithdrawFromFundInput struct {
+	FundID               uint
+	ClientID             uint
+	ClientType           string // "client" or "bank"
+	DestinationAccountID uint
+	Amount               float64 // 0 means "withdraw whole position"
+	WithdrawAll          bool
+}
+
+type FundSummary struct {
+	Fund                *models.InvestmentFundRecord
+	FundValueRSD        float64
+	LiquidCashRSD       float64
+	HoldingsValueRSD    float64
+	TotalInvestedRSD    float64
+	ProfitRSD           float64
+	ManagerID           uint
+	ParticipantsCount   int
+	WithdrawalCommRate  float64
+}
+
+type FundPositionView struct {
+	FundID            uint
+	FundNaziv         string
+	UkupanUlozeniRSD  float64
+	UdeoProcenat      float64 // % share of total invested
+	TrenutnaVrednost  float64 // share * fund value
+	ProfitRSD         float64 // current value - invested
+	FundValueRSD      float64
+}
+
+type WithdrawResult struct {
+	GrossWithdrawn  float64
+	Commission      float64
+	NetToAccount    float64
+	Liquidated      bool
+	LiquidatedItems []LiquidatedItem
+}
+
+type LiquidatedItem struct {
+	AssetID     uint
+	Ticker      string
+	Quantity    float64
+	PricePerRSD float64
+	TotalRSD    float64
+}
+
+// --- Create / Read ---
+
+func (s *FundService) CreateFund(input CreateFundInput) (*models.InvestmentFundRecord, error) {
+	naziv := strings.TrimSpace(input.Naziv)
+	if naziv == "" {
+		return nil, fmt.Errorf("naziv fonda je obavezan")
+	}
+	if input.MinimalniUlog <= 0 {
+		return nil, fmt.Errorf("minimalni ulog mora biti pozitivan")
+	}
+	if input.ManagerID == 0 {
+		return nil, fmt.Errorf("menadzer (supervisor) je obavezan")
+	}
+	return s.fundRepo.CreateFundWithAccount(naziv, strings.TrimSpace(input.Opis), input.MinimalniUlog, input.ManagerID)
+}
+
+func (s *FundService) GetFund(id uint) (*models.InvestmentFundRecord, error) {
+	fund, err := s.fundRepo.GetFundByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if fund == nil {
+		return nil, ErrFundNotFound
+	}
+	return fund, nil
+}
+
+func (s *FundService) ListFunds() ([]models.InvestmentFundRecord, error) {
+	return s.fundRepo.ListFunds()
+}
+
+func (s *FundService) ListFundsByManager(managerID uint) ([]models.InvestmentFundRecord, error) {
+	return s.fundRepo.ListFundsByManager(managerID)
+}
+
+// SummariseFund returns the derived view of a fund used by the discovery /
+// detail pages.
+func (s *FundService) SummariseFund(fund *models.InvestmentFundRecord) (*FundSummary, error) {
+	account, err := s.fundRepo.GetAccountByID(fund.AccountID)
+	if err != nil {
+		return nil, err
+	}
+	liquid := 0.0
+	if account != nil {
+		liquid = account.Stanje
+	}
+
+	holdings, err := s.portfolioRepo.ListHoldingsForUser(fund.ID, models.PortfolioOwnerFund)
+	if err != nil {
+		return nil, err
+	}
+
+	holdingsValue := 0.0
+	for i := range holdings {
+		h := &holdings[i]
+		holdingsValue += s.holdingValueInRSD(h)
+	}
+
+	invested, err := s.fundRepo.TotalInvestedInFund(fund.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	participants, err := s.fundRepo.ListPositionsForFund(fund.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	fundValue := round2RSD(liquid + holdingsValue)
+	return &FundSummary{
+		Fund:                fund,
+		FundValueRSD:        fundValue,
+		LiquidCashRSD:       round2RSD(liquid),
+		HoldingsValueRSD:    round2RSD(holdingsValue),
+		TotalInvestedRSD:    round2RSD(invested),
+		ProfitRSD:           round2RSD(fundValue - invested),
+		ManagerID:           fund.ManagerID,
+		ParticipantsCount:   len(participants),
+		WithdrawalCommRate:  fundWithdrawalCommissionRate,
+	}, nil
+}
+
+// --- Investing ---
+
+func (s *FundService) InvestInFund(input InvestInFundInput) (*models.ClientFundTransactionRecord, error) {
+	if input.Amount <= 0 {
+		return nil, fmt.Errorf("iznos uplate mora biti pozitivan")
+	}
+	if input.SourceAccountID == 0 {
+		return nil, fmt.Errorf("izvorni racun je obavezan")
+	}
+	if input.ClientType != "client" && input.ClientType != "bank" {
+		return nil, fmt.Errorf("nepoznat tip ucesnika")
+	}
+
+	fund, err := s.GetFund(input.FundID)
+	if err != nil {
+		return nil, err
+	}
+	if input.Amount < fund.MinimalniUlog {
+		// Allow follow-on contributions below the minimum if a position already exists.
+		pos, err := s.fundRepo.GetPosition(input.ClientID, input.ClientType, fund.ID)
+		if err != nil {
+			return nil, err
+		}
+		if pos == nil || pos.UkupanUlozeniIznos <= 0 {
+			return nil, fmt.Errorf("minimalni ulog je %.2f RSD", fund.MinimalniUlog)
+		}
+	}
+
+	source, err := s.fundRepo.GetAccountByID(input.SourceAccountID)
+	if err != nil {
+		return nil, err
+	}
+	if source == nil {
+		return nil, fmt.Errorf("izvorni racun nije pronadjen")
+	}
+	if source.Status != "aktivan" {
+		return nil, fmt.Errorf("izvorni racun nije aktivan")
+	}
+	if source.CurrencyCode != "RSD" {
+		return nil, fmt.Errorf("uplata u fond mora biti sa RSD racuna")
+	}
+
+	switch input.ClientType {
+	case "client":
+		if !source.BelongsToClient(input.ClientID) {
+			return nil, fmt.Errorf("racun ne pripada klijentu")
+		}
+	case "bank":
+		if !source.IsBankOwned() {
+			return nil, fmt.Errorf("izabrani racun nije bankin racun")
+		}
+	}
+	if source.RaspolozivoStanje < input.Amount {
+		return nil, fmt.Errorf("nedovoljno sredstava na izvornom racunu")
+	}
+
+	return s.fundRepo.RecordInvestment(input.ClientID, input.ClientType, fund.ID, source.ID, fund.AccountID, round2RSD(input.Amount))
+}
+
+// --- Withdrawals & liquidation ---
+
+// WithdrawFromFund withdraws cash from a fund. Auto-liquidates fund holdings
+// at current market price if the requested amount exceeds liquid cash.
+// Commission is charged to clients (not to bank-on-behalf withdrawals).
+func (s *FundService) WithdrawFromFund(input WithdrawFromFundInput) (*WithdrawResult, error) {
+	if input.ClientType != "client" && input.ClientType != "bank" {
+		return nil, fmt.Errorf("nepoznat tip ucesnika")
+	}
+	if input.DestinationAccountID == 0 {
+		return nil, fmt.Errorf("destinacioni racun je obavezan")
+	}
+
+	fund, err := s.GetFund(input.FundID)
+	if err != nil {
+		return nil, err
+	}
+
+	pos, err := s.fundRepo.GetPosition(input.ClientID, input.ClientType, fund.ID)
+	if err != nil {
+		return nil, err
+	}
+	if pos == nil || pos.UkupanUlozeniIznos <= 0 {
+		return nil, ErrFundPositionNone
+	}
+
+	summary, err := s.SummariseFund(fund)
+	if err != nil {
+		return nil, err
+	}
+
+	clientShare := 0.0
+	if summary.TotalInvestedRSD > 0 {
+		clientShare = pos.UkupanUlozeniIznos / summary.TotalInvestedRSD
+	}
+	maxAvailable := round2RSD(clientShare * summary.FundValueRSD)
+
+	requested := round2RSD(input.Amount)
+	if input.WithdrawAll || requested <= 0 {
+		requested = maxAvailable
+	}
+	if requested <= 0 {
+		return nil, fmt.Errorf("fond nema vrednost za isplatu")
+	}
+	if requested > maxAvailable+0.01 {
+		return nil, fmt.Errorf("iznos prevazilazi udeo klijenta (%.2f RSD)", maxAvailable)
+	}
+
+	destination, err := s.fundRepo.GetAccountByID(input.DestinationAccountID)
+	if err != nil {
+		return nil, err
+	}
+	if destination == nil {
+		return nil, fmt.Errorf("destinacioni racun nije pronadjen")
+	}
+	if destination.Status != "aktivan" {
+		return nil, fmt.Errorf("destinacioni racun nije aktivan")
+	}
+	if destination.CurrencyCode != "RSD" {
+		return nil, fmt.Errorf("isplata mora ici na RSD racun")
+	}
+	switch input.ClientType {
+	case "client":
+		if !destination.BelongsToClient(input.ClientID) {
+			return nil, fmt.Errorf("destinacioni racun ne pripada klijentu")
+		}
+	case "bank":
+		if !destination.IsBankOwned() {
+			return nil, fmt.Errorf("destinacioni racun mora biti bankin")
+		}
+	}
+
+	// Auto-liquidate fund holdings if liquid cash is insufficient.
+	liquidatedItems := []LiquidatedItem{}
+	liquidated := false
+	if summary.LiquidCashRSD < requested {
+		shortfall := requested - summary.LiquidCashRSD
+		items, err := s.liquidateFundHoldings(fund, shortfall)
+		if err != nil {
+			return nil, fmt.Errorf("auto-likvidacija nije uspela: %w", err)
+		}
+		liquidatedItems = items
+		liquidated = len(items) > 0
+	}
+
+	commission := 0.0
+	if input.ClientType == "client" {
+		commission = round2RSD(requested * fundWithdrawalCommissionRate)
+	}
+
+	_, err = s.fundRepo.RecordWithdrawal(input.ClientID, input.ClientType, fund.ID, fund.AccountID, destination.ID, requested, commission)
+	if err != nil {
+		return nil, err
+	}
+
+	return &WithdrawResult{
+		GrossWithdrawn:  requested,
+		Commission:      commission,
+		NetToAccount:    round2RSD(requested - commission),
+		Liquidated:      liquidated,
+		LiquidatedItems: liquidatedItems,
+	}, nil
+}
+
+// liquidateFundHoldings sells fund holdings at the current market price until
+// the fund has at least `requiredRSD` in liquid cash. Cash proceeds are
+// credited to the fund's RSD account. Returns the per-asset liquidations.
+//
+// This is a simplified market-sell flow (no commission, no order routing) that
+// mirrors what the order executor does on a fill, scoped to fund-owned assets.
+func (s *FundService) liquidateFundHoldings(fund *models.InvestmentFundRecord, requiredRSD float64) ([]LiquidatedItem, error) {
+	holdings, err := s.portfolioRepo.ListHoldingsForUser(fund.ID, models.PortfolioOwnerFund)
+	if err != nil {
+		return nil, err
+	}
+
+	liquidated := []LiquidatedItem{}
+	remaining := requiredRSD
+	now := time.Now().UTC()
+
+	for i := range holdings {
+		if remaining <= 0 {
+			break
+		}
+		h := &holdings[i]
+		if h.Quantity <= 0 {
+			continue
+		}
+		priceRSD := s.assetPriceInRSD(&h.Asset)
+		if priceRSD <= 0 {
+			continue
+		}
+		holdingValueRSD := round2RSD(priceRSD * h.Quantity)
+		sellQty := h.Quantity
+		sellValue := holdingValueRSD
+		if holdingValueRSD > remaining {
+			// Sell a partial chunk that covers the remaining shortfall.
+			sellQty = round2RSD(remaining / priceRSD)
+			if sellQty <= 0 {
+				continue
+			}
+			sellValue = round2RSD(priceRSD * sellQty)
+		}
+
+		order := &models.OrderRecord{
+			UserID:            fund.ID,
+			UserType:          models.PortfolioOwnerFund,
+			AssetID:           h.AssetID,
+			OrderType:         "market",
+			Direction:         "sell",
+			Quantity:          int64(math.Ceil(sellQty)),
+			ContractSize:      1,
+			PricePerUnit:      h.Asset.Bid,
+			Status:            "done",
+			IsDone:            true,
+			RemainingPortions: 0,
+			AccountID:         fund.AccountID,
+			LastModification:  now,
+			CreatedAt:         now,
+		}
+		if err := s.orderRepo.CreateOrder(order); err != nil {
+			return nil, fmt.Errorf("kreiranje likvidacionog ordera nije uspelo: %w", err)
+		}
+		txRec := &models.OrderTransactionRecord{
+			OrderID:      order.ID,
+			Quantity:     order.Quantity,
+			PricePerUnit: h.Asset.Bid,
+			ExecutedAt:   now,
+		}
+		if err := s.orderRepo.CreateOrderTransaction(txRec); err != nil {
+			return nil, fmt.Errorf("kreiranje likvidacione transakcije nije uspelo: %w", err)
+		}
+		// Reduce the fund's holding by the sold quantity.
+		if _, err := s.portfolioRepo.RecordSellFill(fund.ID, models.PortfolioOwnerFund, h.AssetID, sellQty, h.Asset.Bid); err != nil {
+			return nil, fmt.Errorf("azuriranje fondske pozicije nije uspelo: %w", err)
+		}
+		// Credit the fund's RSD account with the (RSD-converted) proceeds.
+		if err := s.fundRepo.CreditAccount(fund.AccountID, sellValue); err != nil {
+			return nil, err
+		}
+		liquidated = append(liquidated, LiquidatedItem{
+			AssetID:     h.AssetID,
+			Ticker:      h.Asset.Ticker,
+			Quantity:    sellQty,
+			PricePerRSD: priceRSD,
+			TotalRSD:    sellValue,
+		})
+		remaining -= sellValue
+	}
+
+	if remaining > 0.01 {
+		return liquidated, fmt.Errorf("nedovoljno hartija u fondu za pokrivanje povlacenja")
+	}
+	return liquidated, nil
+}
+
+// --- Positions / clients view ---
+
+func (s *FundService) ListClientFundPositions(clientID uint, clientType string) ([]FundPositionView, error) {
+	positions, err := s.fundRepo.ListPositionsForClient(clientID, clientType)
+	if err != nil {
+		return nil, err
+	}
+
+	views := make([]FundPositionView, 0, len(positions))
+	for _, pos := range positions {
+		fund, err := s.fundRepo.GetFundByID(pos.FundID)
+		if err != nil {
+			return nil, err
+		}
+		if fund == nil {
+			continue
+		}
+		summary, err := s.SummariseFund(fund)
+		if err != nil {
+			return nil, err
+		}
+		share := 0.0
+		currentValue := 0.0
+		if summary.TotalInvestedRSD > 0 {
+			share = pos.UkupanUlozeniIznos / summary.TotalInvestedRSD
+			currentValue = round2RSD(share * summary.FundValueRSD)
+		}
+		views = append(views, FundPositionView{
+			FundID:           fund.ID,
+			FundNaziv:        fund.Naziv,
+			UkupanUlozeniRSD: round2RSD(pos.UkupanUlozeniIznos),
+			UdeoProcenat:     round2RSD(share * 100),
+			TrenutnaVrednost: currentValue,
+			ProfitRSD:        round2RSD(currentValue - pos.UkupanUlozeniIznos),
+			FundValueRSD:     summary.FundValueRSD,
+		})
+	}
+	return views, nil
+}
+
+func (s *FundService) GetClientPosition(clientID uint, clientType string, fundID uint) (*FundPositionView, error) {
+	pos, err := s.fundRepo.GetPosition(clientID, clientType, fundID)
+	if err != nil {
+		return nil, err
+	}
+	if pos == nil {
+		return nil, ErrFundPositionNone
+	}
+	fund, err := s.GetFund(fundID)
+	if err != nil {
+		return nil, err
+	}
+	summary, err := s.SummariseFund(fund)
+	if err != nil {
+		return nil, err
+	}
+	share := 0.0
+	currentValue := 0.0
+	if summary.TotalInvestedRSD > 0 {
+		share = pos.UkupanUlozeniIznos / summary.TotalInvestedRSD
+		currentValue = round2RSD(share * summary.FundValueRSD)
+	}
+	return &FundPositionView{
+		FundID:           fund.ID,
+		FundNaziv:        fund.Naziv,
+		UkupanUlozeniRSD: round2RSD(pos.UkupanUlozeniIznos),
+		UdeoProcenat:     round2RSD(share * 100),
+		TrenutnaVrednost: currentValue,
+		ProfitRSD:        round2RSD(currentValue - pos.UkupanUlozeniIznos),
+		FundValueRSD:     summary.FundValueRSD,
+	}, nil
+}
+
+func (s *FundService) ListFundHoldings(fundID uint) ([]models.PortfolioHoldingRecord, error) {
+	return s.portfolioRepo.ListHoldingsForUser(fundID, models.PortfolioOwnerFund)
+}
+
+// --- Performance ---
+
+func (s *FundService) RecordDailyPerformance(referenceTime time.Time) error {
+	if referenceTime.IsZero() {
+		referenceTime = time.Now().UTC()
+	}
+	snapshotDate := time.Date(referenceTime.Year(), referenceTime.Month(), referenceTime.Day(), 0, 0, 0, 0, time.UTC)
+
+	funds, err := s.fundRepo.ListFunds()
+	if err != nil {
+		return err
+	}
+	for i := range funds {
+		summary, err := s.SummariseFund(&funds[i])
+		if err != nil {
+			return err
+		}
+		if err := s.fundRepo.SavePerformanceSnapshot(funds[i].ID, snapshotDate, summary.FundValueRSD); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *FundService) GetPerformance(fundID uint, granularity string) ([]models.FundPerformanceHistoryRecord, error) {
+	now := time.Now().UTC()
+	var from time.Time
+	switch strings.ToLower(granularity) {
+	case "monthly", "mesecno", "month", "":
+		from = now.AddDate(0, -1, 0)
+	case "quarterly", "kvartalno", "quarter":
+		from = now.AddDate(0, -3, 0)
+	case "yearly", "godisnje", "year":
+		from = now.AddDate(-1, 0, 0)
+	case "all":
+		from = time.Time{}
+	default:
+		return nil, fmt.Errorf("nepoznata granularnost: %s", granularity)
+	}
+	if from.IsZero() {
+		from = time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)
+	}
+	return s.fundRepo.ListPerformance(fundID, from, now)
+}
+
+// --- Manager reassignment ---
+
+// ReassignManagedFunds moves every fund managed by `oldManagerID` to be managed
+// by `newManagerID`. Returns the number of funds reassigned.
+func (s *FundService) ReassignManagedFunds(oldManagerID, newManagerID uint) (int64, error) {
+	if oldManagerID == 0 || newManagerID == 0 {
+		return 0, fmt.Errorf("oldManagerID i newManagerID su obavezni")
+	}
+	return s.fundRepo.ReassignFundsManager(oldManagerID, newManagerID)
+}
+
+// --- Buy-for-fund pre-flight ---
+
+// ValidateFundBuyOrder ensures that the supervisor `actorID` manages the fund
+// `fundID`, that the order's account is the fund's own account, and that the
+// fund's account currency matches the asset's currency. Called by the HTTP
+// handler before delegating to OrderService.CreateOrder.
+func (s *FundService) ValidateFundBuyOrder(fundID, actorID uint, accountID uint, assetCurrency string) (*models.InvestmentFundRecord, error) {
+	fund, err := s.GetFund(fundID)
+	if err != nil {
+		return nil, err
+	}
+	if fund.ManagerID != actorID {
+		return nil, fmt.Errorf("supervisor ne upravlja ovim fondom")
+	}
+	if accountID != fund.AccountID {
+		return nil, fmt.Errorf("buy order mora koristiti racun fonda")
+	}
+	account, err := s.fundRepo.GetAccountByID(fund.AccountID)
+	if err != nil || account == nil {
+		return nil, fmt.Errorf("racun fonda nije pronadjen")
+	}
+	if account.Status != "aktivan" {
+		return nil, fmt.Errorf("racun fonda nije aktivan")
+	}
+	return fund, nil
+}
+
+// --- Helpers ---
+
+func (s *FundService) holdingValueInRSD(h *models.PortfolioHoldingRecord) float64 {
+	priceRSD := s.assetPriceInRSD(&h.Asset)
+	return priceRSD * h.Quantity
+}
+
+func (s *FundService) assetPriceInRSD(asset *models.MarketListingRecord) float64 {
+	currency := asset.Exchange.Currency
+	if currency == "" || currency == "RSD" {
+		return asset.Price
+	}
+	rate, err := s.rateProvider.GetRate(currency, "RSD")
+	if err != nil || rate == 0 {
+		return asset.Price
+	}
+	return asset.Price * rate
+}
+
+func round2RSD(v float64) float64 {
+	return math.Round(v*100) / 100
+}
+

--- a/exchange-service/internal/service/order_service.go
+++ b/exchange-service/internal/service/order_service.go
@@ -190,6 +190,12 @@ func (s *OrderService) resolveStatus(input CreateOrderInput, totalPrice float64)
 	if input.UserType == "client" {
 		return "approved", false, nil
 	}
+	// Fund orders are placed by a supervisor on behalf of a fund and are
+	// always auto-approved — the supervisor has already passed the fund
+	// authorization checks before reaching here.
+	if input.UserType == "fund" {
+		return "approved", false, nil
+	}
 
 	// Bank orders: check the placing agent's actuary profile.
 	profile, err := s.orderRepo.GetActuaryProfile(input.ActorID)
@@ -377,11 +383,14 @@ func (s *OrderService) ListTransactionsForOrder(orderID uint) ([]models.OrderTra
 // --- Helpers ---
 
 func validateOrderInput(input CreateOrderInput) error {
-	if input.UserType != "client" && input.UserType != "bank" {
-		return fmt.Errorf("user type must be 'client' or 'bank'")
+	if input.UserType != "client" && input.UserType != "bank" && input.UserType != "fund" {
+		return fmt.Errorf("user type must be 'client', 'bank', or 'fund'")
 	}
 	if input.UserType == "client" && input.UserID == 0 {
 		return fmt.Errorf("user ID is required")
+	}
+	if input.UserType == "fund" && input.UserID == 0 {
+		return fmt.Errorf("fund ID is required")
 	}
 	if input.AssetTicker == "" {
 		return fmt.Errorf("asset ticker is required")


### PR DESCRIPTION
Adds investment-fund domain to exchange-service:
- Fund + transaction + position + performance-history GORM models
- FundRepository creates a bank-owned RSD account in the shared accounts table when a fund is created
- FundService: create (supervisor-only), invest, withdraw with auto liquidation of fund holdings at current market price, derived fund value / profit / share / position-value computations, daily performance snapshots
- HTTP routes under /api/v1/funds
- OrderService accepts UserType="fund" so supervisors can place buy-for-fund orders; order HTTP handler routes ownership through FundService.ValidateFundBuyOrder when fundId is supplied
- Daily 23:55 UTC cron records fund performance snapshots

Cross-service hook in employee-service:
- UpdateEmployeePermissions reassigns every fund managed by the demoted supervisor to the admin actor when employeeSupervisor is removed