### PR TITLE
feat(exchange): sprint 9 cross-bank OTC negotiation REST surface

### DIFF
--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -82,10 +82,11 @@ func main() {
 		"partner_count", len(ibRegistry.All()),
 	)
 	ibInboundRepo := repository.NewInterbankInboundRepository(db)
+	ibNegRepo := repository.NewInterbankOtcRepository(db)
 	ibClient := interbank.NewClient(ibRegistry)
 	ibServer := interbank.NewServer(ibRegistry, ibInboundRepo, interbank.NoopProcessor{})
 	ibOtcH := interbank.NewOTCHandler(ibRegistry, portfolioRepo, interbank.StubDisplayNameResolver{})
-	_ = ibClient // outbound client is wired here, real callers land in a follow-up
+	ibNegH := interbank.NewNegotiationsHandler(ibRegistry, ibNegRepo, ibClient)
 
 	cronScheduler := service.StartCronJobs(db, portfolioSvc, rateProvider, sagaRetryRunner, fundSvc)
 
@@ -165,6 +166,8 @@ func main() {
 	httpMux.Handle("/interbank", ibServer)
 	httpMux.Handle("/public-stock", interbank.AuthMiddleware(ibRegistry, http.HandlerFunc(ibOtcH.PublicStock)))
 	httpMux.Handle("/user/", interbank.AuthMiddleware(ibRegistry, http.HandlerFunc(ibOtcH.UserInfo)))
+	httpMux.Handle("/negotiations", interbank.AuthMiddleware(ibRegistry, http.HandlerFunc(ibNegH.Collection)))
+	httpMux.Handle("/negotiations/", interbank.AuthMiddleware(ibRegistry, http.HandlerFunc(ibNegH.Item)))
 	httpMux.Handle("/", middleware.CORS(gwMux))
 
 	httpServer := &http.Server{

--- a/exchange-service/internal/interbank/negotiations_accept.go
+++ b/exchange-service/internal/interbank/negotiations_accept.go
@@ -1,0 +1,180 @@
+package interbank
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+)
+
+// accept handles GET /negotiations/{routingNumber}/{id}/accept.
+// Per spec §3.6 this is a GET that mutates state — accepting an
+// open negotiation closes it and triggers an outbound NEW_TX from
+// the seller's bank to the buyer's bank carrying the four postings
+// that move the premium and create the option contract.
+//
+// Only the seller's bank can accept (this mirrors the existing
+// local OTC-5 rule). Both NEW_TX and a follow-up COMMIT_TX are
+// dispatched here; on a NO vote we send ROLLBACK_TX and reopen
+// the negotiation so the participants can keep haggling.
+func (h *NegotiationsHandler) accept(w http.ResponseWriter, r *http.Request, routing RoutingNumber, id string) {
+	partner := PartnerFromContext(r.Context())
+	if partner == nil {
+		writeProblemJSON(w, http.StatusUnauthorized, "no partner in context")
+		return
+	}
+
+	neg, err := h.repo.Get(int(routing), id)
+	if err != nil {
+		writeProblemJSON(w, http.StatusInternalServerError, fmt.Sprintf("loading negotiation: %v", err))
+		return
+	}
+	if neg == nil {
+		writeProblemJSON(w, http.StatusNotFound, "no such negotiation")
+		return
+	}
+	if !partnerMayAccess(neg, partner) {
+		writeProblemJSON(w, http.StatusForbidden, "this X-Api-Key is not a party to that negotiation")
+		return
+	}
+	if !neg.IsOngoing {
+		writeProblemJSON(w, http.StatusConflict, "negotiation is no longer ongoing")
+		return
+	}
+	if neg.LocalRole != models.InterbankNegotiationRoleSeller {
+		writeProblemJSON(w, http.StatusForbidden,
+			"only the seller's bank may accept — the buyer's bank cannot self-accept")
+		return
+	}
+
+	// Close locally first so a concurrent second accept can't double-spend.
+	if err := h.repo.MarkClosed(int(routing), id); err != nil {
+		writeProblemJSON(w, http.StatusInternalServerError, fmt.Sprintf("closing negotiation: %v", err))
+		return
+	}
+
+	tx := buildOptionAcceptanceTx(h.registry.OwnRoutingNumber(), neg)
+
+	txKey := h.client.NewIdempotenceKey()
+	buyerCode := RoutingNumber(neg.BuyerRoutingNumber)
+
+	vote, err := h.client.SendNewTx(r.Context(), buyerCode, txKey, &tx)
+	if err != nil {
+		// Network or partner error — reopen the negotiation so the
+		// seller can decide whether to retry from the UI.
+		slog.Error("interbank: NEW_TX dispatch failed during /accept",
+			"err", err, "negotiation", id, "buyer", buyerCode)
+		h.reopenAfterDispatchFailure(int(routing), id, neg.LastModifiedByRoutingNumber, neg.LastModifiedByID)
+		writeProblemJSON(w, http.StatusBadGateway, fmt.Sprintf("dispatching NEW_TX: %v", err))
+		return
+	}
+
+	if vote.Vote != VoteYes {
+		// Buyer's bank refused — the negotiation should reopen so the
+		// participants can keep going. We don't send ROLLBACK_TX
+		// because NEW_TX with vote=NO is itself the rollback; the
+		// buyer's bank holds no resources after a NO.
+		slog.Info("interbank: NEW_TX received NO vote during /accept",
+			"negotiation", id, "buyer", buyerCode, "reasons", vote.Reasons)
+		h.reopenAfterDispatchFailure(int(routing), id, neg.LastModifiedByRoutingNumber, neg.LastModifiedByID)
+		writeJSON(w, http.StatusConflict, vote)
+		return
+	}
+
+	// YES vote — commit. If COMMIT_TX itself fails after retries,
+	// we surface the error but leave the negotiation closed: the
+	// buyer's bank has already voted to hold the resources, so the
+	// resolution is operator-driven (CHECK_STATUS / replay), not
+	// reopening the negotiation.
+	commitKey := h.client.NewIdempotenceKey()
+	if err := h.client.SendCommitTx(r.Context(), buyerCode, commitKey, tx.TransactionID); err != nil {
+		slog.Error("interbank: COMMIT_TX dispatch failed after YES vote",
+			"err", err, "negotiation", id, "transaction", tx.TransactionID.ID, "buyer", buyerCode)
+		writeProblemJSON(w, http.StatusBadGateway,
+			fmt.Sprintf("buyer voted YES but COMMIT_TX failed; operator action required: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusOK, vote)
+}
+
+// buildOptionAcceptanceTx builds the protocol Transaction that
+// /accept dispatches: four postings expressing the premium transfer
+// (cash leg) and option-contract creation (option leg).
+//
+//	cash leg:    buyer -P   premium currency      → seller +P
+//	option leg:  seller -1  OPTION{neg, stock, …} → buyer  +1
+//
+// The TransactionID is owned by the seller's bank (= us) since
+// we initiated the NEW_TX. The buyer's bank stores it on receipt.
+func buildOptionAcceptanceTx(ownRouting RoutingNumber, neg *models.InterbankOtcNegotiation) Transaction {
+	buyer := TxAccount{
+		Type: TxAccountPerson,
+		ID: &ForeignBankId{
+			RoutingNumber: RoutingNumber(neg.BuyerRoutingNumber),
+			ID:            neg.BuyerID,
+		},
+	}
+	seller := TxAccount{
+		Type: TxAccountPerson,
+		ID: &ForeignBankId{
+			RoutingNumber: RoutingNumber(neg.SellerRoutingNumber),
+			ID:            neg.SellerID,
+		},
+	}
+
+	premiumAsset := Asset{
+		Type:  AssetMonas,
+		Monas: &MonetaryAsset{Currency: CurrencyCode(neg.PremiumCurrency)},
+	}
+
+	optionAsset := Asset{
+		Type: AssetOption,
+		Option: &OptionDescription{
+			NegotiationID: ForeignBankId{
+				RoutingNumber: RoutingNumber(neg.NegotiationRoutingNumber),
+				ID:            neg.NegotiationID,
+			},
+			Stock: StockDescription{Ticker: neg.StockTicker},
+			PricePerUnit: MonetaryValue{
+				Currency: CurrencyCode(neg.PricePerUnitCurrency),
+				Amount:   neg.PricePerUnitAmount,
+			},
+			SettlementDate: neg.SettlementDate,
+			Amount:         neg.Amount,
+		},
+	}
+
+	return Transaction{
+		Postings: []Posting{
+			{Account: buyer, Amount: -neg.PremiumAmount, Asset: premiumAsset},
+			{Account: seller, Amount: neg.PremiumAmount, Asset: premiumAsset},
+			{Account: seller, Amount: -1, Asset: optionAsset},
+			{Account: buyer, Amount: 1, Asset: optionAsset},
+		},
+		TransactionID: ForeignBankId{
+			RoutingNumber: ownRouting,
+			ID:            uuid.NewString(),
+		},
+		Message:        fmt.Sprintf("OTC option acceptance for negotiation %s", neg.NegotiationID),
+		PaymentCode:    "OTC",
+		PaymentPurpose: "OTC option contract premium + creation",
+	}
+}
+
+// reopenAfterDispatchFailure flips IsOngoing back to true so the
+// participants can resume the negotiation. We don't roll back to a
+// prior offer state — the most recent terms stay on record, just
+// re-marked open.
+func (h *NegotiationsHandler) reopenAfterDispatchFailure(routing int, id string, lastModRouting int, lastModID string) {
+	// Reuse UpdateTerms to bump updated_at; the LastModifiedBy lands back
+	// on whoever it was before so the wire copy looks unchanged from
+	// the participants' perspective.
+	if err := h.repo.MarkOngoing(routing, id, lastModRouting, lastModID); err != nil {
+		slog.Error("interbank: reopening negotiation after dispatch failure",
+			"err", err, "negotiation", id)
+	}
+}

--- a/exchange-service/internal/interbank/negotiations_handler.go
+++ b/exchange-service/internal/interbank/negotiations_handler.go
@@ -1,0 +1,356 @@
+package interbank
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// NegotiationsHandler hosts the cross-bank OTC negotiation REST surface
+// from spec §3 — POST /negotiations and the
+// /negotiations/{routingNumber}/{id} family. The handler assumes
+// AuthMiddleware has already attached a *PartnerBank to the request
+// context.
+//
+// /accept is a method on this handler too, but lives in
+// negotiations_accept.go because it owns the outbound NEW_TX dispatch
+// that the other verbs don't need.
+type NegotiationsHandler struct {
+	registry *Registry
+	repo     *repository.InterbankOtcRepository
+	client   *Client
+}
+
+// NewNegotiationsHandler wires up the negotiation routes.
+func NewNegotiationsHandler(registry *Registry, repo *repository.InterbankOtcRepository, client *Client) *NegotiationsHandler {
+	return &NegotiationsHandler{
+		registry: registry,
+		repo:     repo,
+		client:   client,
+	}
+}
+
+// Collection routes POST /negotiations — the create endpoint that a
+// buyer's bank calls on the seller's bank to start a negotiation.
+func (h *NegotiationsHandler) Collection(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	h.create(w, r)
+}
+
+// Item routes /negotiations/{routingNumber}/{id} and
+// /negotiations/{routingNumber}/{id}/accept. It dispatches on path
+// suffix + method.
+func (h *NegotiationsHandler) Item(w http.ResponseWriter, r *http.Request) {
+	rest, ok := stripPrefix(r.URL.Path, "/negotiations/")
+	if !ok {
+		writeProblemJSON(w, http.StatusNotFound, "unknown path")
+		return
+	}
+	parts := strings.Split(strings.TrimSuffix(rest, "/"), "/")
+
+	switch len(parts) {
+	case 2:
+		// /negotiations/{routingNumber}/{id}
+		routing, id, ok := parsePathKey(parts[0], parts[1])
+		if !ok {
+			writeProblemJSON(w, http.StatusBadRequest, "expected /negotiations/{routingNumber:int}/{id}")
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			h.read(w, r, routing, id)
+		case http.MethodPut:
+			h.update(w, r, routing, id)
+		case http.MethodDelete:
+			h.delete(w, r, routing, id)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	case 3:
+		// /negotiations/{routingNumber}/{id}/{verb}
+		if parts[2] != "accept" {
+			writeProblemJSON(w, http.StatusNotFound, fmt.Sprintf("unknown action %q", parts[2]))
+			return
+		}
+		routing, id, ok := parsePathKey(parts[0], parts[1])
+		if !ok {
+			writeProblemJSON(w, http.StatusBadRequest, "expected /negotiations/{routingNumber:int}/{id}/accept")
+			return
+		}
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.accept(w, r, routing, id)
+	default:
+		writeProblemJSON(w, http.StatusNotFound, "expected /negotiations/{routingNumber}/{id}[/accept]")
+	}
+}
+
+// create handles POST /negotiations. The body is an OtcOffer
+// representing the buyer's initial bid; we mint a fresh negotiation
+// id, persist our local copy with LocalRole=seller, and return the
+// ForeignBankId the buyer's bank should use for subsequent calls.
+func (h *NegotiationsHandler) create(w http.ResponseWriter, r *http.Request) {
+	partner := PartnerFromContext(r.Context())
+	if partner == nil {
+		writeProblemJSON(w, http.StatusUnauthorized, "no partner in context — AuthMiddleware not wired?")
+		return
+	}
+
+	var offer OtcOffer
+	if err := decodeJSONBody(r, &offer); err != nil {
+		writeProblemJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	own := h.registry.OwnRoutingNumber()
+	if offer.SellerID.RoutingNumber != own {
+		writeProblemJSON(w, http.StatusBadRequest,
+			fmt.Sprintf("offer.sellerId.routingNumber %d does not match this bank (%d) — POST to the seller's bank",
+				offer.SellerID.RoutingNumber, own))
+		return
+	}
+	if offer.BuyerID.RoutingNumber != partner.Code {
+		writeProblemJSON(w, http.StatusForbidden,
+			fmt.Sprintf("offer.buyerId.routingNumber %d does not match the X-Api-Key partner (%d)",
+				offer.BuyerID.RoutingNumber, partner.Code))
+		return
+	}
+	if offer.LastModifiedBy.RoutingNumber != partner.Code {
+		writeProblemJSON(w, http.StatusForbidden,
+			"offer.lastModifiedBy must belong to the calling bank on the initial offer")
+		return
+	}
+
+	negID := uuid.NewString()
+	neg := &models.InterbankOtcNegotiation{
+		NegotiationRoutingNumber: int(own),
+		NegotiationID:            negID,
+		LocalRole:                models.InterbankNegotiationRoleSeller,
+		CounterpartyRoutingNumber: int(partner.Code),
+
+		BuyerRoutingNumber:  int(offer.BuyerID.RoutingNumber),
+		BuyerID:             offer.BuyerID.ID,
+		SellerRoutingNumber: int(offer.SellerID.RoutingNumber),
+		SellerID:            offer.SellerID.ID,
+
+		StockTicker: offer.Stock.Ticker,
+		Amount:      offer.Amount,
+
+		PricePerUnitCurrency: string(offer.PricePerUnit.Currency),
+		PricePerUnitAmount:   offer.PricePerUnit.Amount,
+		PremiumCurrency:      string(offer.Premium.Currency),
+		PremiumAmount:        offer.Premium.Amount,
+
+		SettlementDate: offer.SettlementDate,
+
+		LastModifiedByRoutingNumber: int(offer.LastModifiedBy.RoutingNumber),
+		LastModifiedByID:            offer.LastModifiedBy.ID,
+		IsOngoing:                   true,
+	}
+
+	if err := h.repo.Create(neg); err != nil {
+		writeProblemJSON(w, http.StatusInternalServerError, fmt.Sprintf("persisting negotiation: %v", err))
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, ForeignBankId{
+		RoutingNumber: own,
+		ID:            negID,
+	})
+}
+
+// read handles GET /negotiations/{routingNumber}/{id}.
+func (h *NegotiationsHandler) read(w http.ResponseWriter, r *http.Request, routing RoutingNumber, id string) {
+	partner := PartnerFromContext(r.Context())
+	if partner == nil {
+		writeProblemJSON(w, http.StatusUnauthorized, "no partner in context")
+		return
+	}
+
+	neg, err := h.repo.Get(int(routing), id)
+	if err != nil {
+		writeProblemJSON(w, http.StatusInternalServerError, fmt.Sprintf("loading negotiation: %v", err))
+		return
+	}
+	if neg == nil {
+		writeProblemJSON(w, http.StatusNotFound, "no such negotiation")
+		return
+	}
+	if !partnerMayAccess(neg, partner) {
+		writeProblemJSON(w, http.StatusForbidden, "this X-Api-Key is not a party to that negotiation")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, negotiationToWire(neg))
+}
+
+// update handles PUT /negotiations/{routingNumber}/{id} — a counter-offer.
+// The body is an OtcOffer carrying the new terms; we trust the
+// LastModifiedBy field within it to identify who's countering, but we
+// re-check that it belongs to the calling partner.
+func (h *NegotiationsHandler) update(w http.ResponseWriter, r *http.Request, routing RoutingNumber, id string) {
+	partner := PartnerFromContext(r.Context())
+	if partner == nil {
+		writeProblemJSON(w, http.StatusUnauthorized, "no partner in context")
+		return
+	}
+
+	neg, err := h.repo.Get(int(routing), id)
+	if err != nil {
+		writeProblemJSON(w, http.StatusInternalServerError, fmt.Sprintf("loading negotiation: %v", err))
+		return
+	}
+	if neg == nil {
+		writeProblemJSON(w, http.StatusNotFound, "no such negotiation")
+		return
+	}
+	if !partnerMayAccess(neg, partner) {
+		writeProblemJSON(w, http.StatusForbidden, "this X-Api-Key is not a party to that negotiation")
+		return
+	}
+	if !neg.IsOngoing {
+		writeProblemJSON(w, http.StatusConflict, "negotiation is no longer ongoing")
+		return
+	}
+
+	var offer OtcOffer
+	if err := decodeJSONBody(r, &offer); err != nil {
+		writeProblemJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if offer.LastModifiedBy.RoutingNumber != partner.Code {
+		writeProblemJSON(w, http.StatusForbidden,
+			"offer.lastModifiedBy.routingNumber must match the calling bank")
+		return
+	}
+
+	if err := h.repo.UpdateTerms(
+		int(routing), id,
+		offer.Amount,
+		string(offer.PricePerUnit.Currency), offer.PricePerUnit.Amount,
+		string(offer.Premium.Currency), offer.Premium.Amount,
+		offer.SettlementDate,
+		int(offer.LastModifiedBy.RoutingNumber), offer.LastModifiedBy.ID,
+	); err != nil {
+		writeProblemJSON(w, http.StatusInternalServerError, fmt.Sprintf("updating negotiation: %v", err))
+		return
+	}
+
+	neg, err = h.repo.Get(int(routing), id)
+	if err != nil || neg == nil {
+		writeProblemJSON(w, http.StatusInternalServerError, "negotiation disappeared after update")
+		return
+	}
+	writeJSON(w, http.StatusOK, negotiationToWire(neg))
+}
+
+// delete handles DELETE /negotiations/{routingNumber}/{id}. Closes
+// the negotiation; idempotent on already-closed rows.
+func (h *NegotiationsHandler) delete(w http.ResponseWriter, r *http.Request, routing RoutingNumber, id string) {
+	partner := PartnerFromContext(r.Context())
+	if partner == nil {
+		writeProblemJSON(w, http.StatusUnauthorized, "no partner in context")
+		return
+	}
+
+	neg, err := h.repo.Get(int(routing), id)
+	if err != nil {
+		writeProblemJSON(w, http.StatusInternalServerError, fmt.Sprintf("loading negotiation: %v", err))
+		return
+	}
+	if neg == nil {
+		writeProblemJSON(w, http.StatusNotFound, "no such negotiation")
+		return
+	}
+	if !partnerMayAccess(neg, partner) {
+		writeProblemJSON(w, http.StatusForbidden, "this X-Api-Key is not a party to that negotiation")
+		return
+	}
+
+	if neg.IsOngoing {
+		if err := h.repo.MarkClosed(int(routing), id); err != nil {
+			writeProblemJSON(w, http.StatusInternalServerError, fmt.Sprintf("closing negotiation: %v", err))
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// negotiationToWire converts a model row to the protocol's
+// OtcNegotiation shape (= OtcOffer + isOngoing).
+func negotiationToWire(neg *models.InterbankOtcNegotiation) OtcNegotiation {
+	return OtcNegotiation{
+		OtcOffer: OtcOffer{
+			Stock:          StockDescription{Ticker: neg.StockTicker},
+			SettlementDate: neg.SettlementDate,
+			PricePerUnit: MonetaryValue{
+				Currency: CurrencyCode(neg.PricePerUnitCurrency),
+				Amount:   neg.PricePerUnitAmount,
+			},
+			Premium: MonetaryValue{
+				Currency: CurrencyCode(neg.PremiumCurrency),
+				Amount:   neg.PremiumAmount,
+			},
+			BuyerID:  ForeignBankId{RoutingNumber: RoutingNumber(neg.BuyerRoutingNumber), ID: neg.BuyerID},
+			SellerID: ForeignBankId{RoutingNumber: RoutingNumber(neg.SellerRoutingNumber), ID: neg.SellerID},
+			Amount:   neg.Amount,
+			LastModifiedBy: ForeignBankId{
+				RoutingNumber: RoutingNumber(neg.LastModifiedByRoutingNumber),
+				ID:            neg.LastModifiedByID,
+			},
+		},
+		IsOngoing: neg.IsOngoing,
+	}
+}
+
+// partnerMayAccess returns true when the calling X-Api-Key
+// corresponds to either of the negotiation's counterparties. Cross-
+// negotiation tampering is blocked here.
+func partnerMayAccess(neg *models.InterbankOtcNegotiation, partner *PartnerBank) bool {
+	code := int(partner.Code)
+	return neg.BuyerRoutingNumber == code || neg.SellerRoutingNumber == code
+}
+
+func decodeJSONBody(r *http.Request, dst any) error {
+	defer func() { _ = r.Body.Close() }()
+	body, err := io.ReadAll(http.MaxBytesReader(nil, r.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("reading body: %w", err)
+	}
+	if err := json.Unmarshal(body, dst); err != nil {
+		return fmt.Errorf("malformed JSON body: %w", err)
+	}
+	return nil
+}
+
+func stripPrefix(path, prefix string) (string, bool) {
+	if !strings.HasPrefix(path, prefix) {
+		return "", false
+	}
+	return strings.TrimPrefix(path, prefix), true
+}
+
+func parsePathKey(routingStr, id string) (RoutingNumber, string, bool) {
+	if routingStr == "" || id == "" {
+		return 0, "", false
+	}
+	n, err := strconv.Atoi(routingStr)
+	if err != nil {
+		return 0, "", false
+	}
+	return RoutingNumber(n), id, true
+}
+

--- a/exchange-service/internal/repository/interbank_otc_repository.go
+++ b/exchange-service/internal/repository/interbank_otc_repository.go
@@ -90,6 +90,22 @@ func (r *InterbankOtcRepository) MarkClosed(negotiationRoutingNumber int, negoti
 		}).Error
 }
 
+// MarkOngoing flips IsOngoing back to true. The accept handler calls
+// this when NEW_TX dispatch fails or the buyer's bank votes NO — the
+// negotiation reopens so the participants can keep haggling. The
+// LastModifiedBy fields are reset to whoever last touched the row so
+// the wire copy stays consistent with what the partner already saw.
+func (r *InterbankOtcRepository) MarkOngoing(negotiationRoutingNumber int, negotiationID string, lastModRouting int, lastModID string) error {
+	return r.db.Model(&models.InterbankOtcNegotiation{}).
+		Where("negotiation_routing_number = ? AND negotiation_id = ?", negotiationRoutingNumber, negotiationID).
+		Updates(map[string]interface{}{
+			"is_ongoing":                      true,
+			"last_modified_by_routing_number": lastModRouting,
+			"last_modified_by_id":             lastModID,
+			"updated_at":                      time.Now().UTC(),
+		}).Error
+}
+
 // ListByLocalParticipant returns the open negotiations where a given
 // local user is one of the two sides. role filters to "buyer" or
 // "seller"; pass "" for both.


### PR DESCRIPTION
## Summary

- Wires the `/negotiations` REST surface from protocol §3 on top of the Sprint 9 foundation (#196): `POST /negotiations` + `GET/PUT/DELETE /negotiations/{routingNumber}/{id}` + `GET /accept`
- `accept` is the side-effect endpoint — closes the negotiation locally first, dispatches `NEW_TX` with four postings (buyer/seller premium swap + option contract creation), and follows up with `COMMIT_TX` on YES. NO vote or dispatch failure reopens the negotiation via the new `MarkOngoing` repo method so participants can keep haggling
- `partnerMayAccess` gate blocks cross-negotiation tampering — only the buyer's bank or the seller's bank may touch a given row

Closes #198

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` green (no test files in `internal/interbank` yet, repository tests still pass)
- [ ] Manual smoke: `curl -X POST /negotiations` from a partner sandbox
- [ ] Manual smoke: `GET /accept` round-trip against a real partner once one is online (currently `NoopProcessor` votes NO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)