### PR TITLE
feat(exchange): sprint 9 real TxProcessor for cross-bank OTC option receipt

### DIFF
--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -82,8 +82,12 @@ func main() {
 		"partner_count", len(ibRegistry.All()),
 	)
 	ibInboundRepo := repository.NewInterbankInboundRepository(db)
+	ibNegRepo := repository.NewInterbankOtcRepository(db)
+	ibPendingRepo := repository.NewInterbankPendingTxRepository(db)
+	ibOptionContractRepo := repository.NewInterbankOptionContractRepository(db)
 	ibClient := interbank.NewClient(ibRegistry)
-	ibServer := interbank.NewServer(ibRegistry, ibInboundRepo, interbank.NoopProcessor{})
+	ibTxProcessor := interbank.NewOtcTxProcessor(ibRegistry, ibNegRepo, ibPendingRepo, ibOptionContractRepo)
+	ibServer := interbank.NewServer(ibRegistry, ibInboundRepo, ibTxProcessor)
 	ibOtcH := interbank.NewOTCHandler(ibRegistry, portfolioRepo, interbank.StubDisplayNameResolver{})
 	_ = ibClient // outbound client is wired here, real callers land in a follow-up
 

--- a/exchange-service/internal/database/database.go
+++ b/exchange-service/internal/database/database.go
@@ -53,6 +53,8 @@ func Migrate(db *gorm.DB) error {
 		&models.FundPerformanceHistoryRecord{},
 		&models.InterbankInboundMessage{},
 		&models.InterbankOtcNegotiation{},
+		&models.InterbankPendingTx{},
+		&models.InterbankOptionContract{},
 	); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}

--- a/exchange-service/internal/interbank/tx_processor.go
+++ b/exchange-service/internal/interbank/tx_processor.go
@@ -1,0 +1,502 @@
+package interbank
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// OtcTxProcessor is the real TxProcessor — the one that replaces
+// NoopProcessor once the OTC option acceptance flow is wired
+// end-to-end. It only recognises the four-posting NEW_TX shape that
+// /negotiations/{...}/accept produces (cash leg + option leg with
+// PERSON accounts and MONAS+OPTION assets). Any other shape gets
+// VoteNo with an appropriate reason.
+//
+// Scope note: cash reservation against our local user's balance is
+// NOT yet enforced — that requires calling bank-service across the
+// service boundary, which is a follow-up. Until then we persist the
+// reservation snapshot in InterbankPendingTx so it can be honoured
+// retroactively once the bank-service shim lands.
+type OtcTxProcessor struct {
+	registry     *Registry
+	negRepo      *repository.InterbankOtcRepository
+	pendingRepo  *repository.InterbankPendingTxRepository
+	contractRepo *repository.InterbankOptionContractRepository
+}
+
+// NewOtcTxProcessor wires up the real TxProcessor implementation.
+func NewOtcTxProcessor(
+	registry *Registry,
+	negRepo *repository.InterbankOtcRepository,
+	pendingRepo *repository.InterbankPendingTxRepository,
+	contractRepo *repository.InterbankOptionContractRepository,
+) *OtcTxProcessor {
+	return &OtcTxProcessor{
+		registry:     registry,
+		negRepo:      negRepo,
+		pendingRepo:  pendingRepo,
+		contractRepo: contractRepo,
+	}
+}
+
+// OnNewTx implements TxProcessor.OnNewTx. Validates the 4-posting OTC
+// option acceptance shape against a stored InterbankOtcNegotiation row
+// and votes YES on a match. Anything else gets VoteNo + a reason code.
+func (p *OtcTxProcessor) OnNewTx(_ context.Context, partner *PartnerBank, tx *Transaction) (*TransactionVote, error) {
+	// Tx must be balanced — this also guards against malformed shapes
+	// that happen to have 4 postings but skew amounts.
+	if reason := checkBalanced(tx); reason != nil {
+		return voteNo(*reason), nil
+	}
+
+	parsed, reason := parseOtcAcceptance(tx)
+	if reason != nil {
+		return voteNo(*reason), nil
+	}
+
+	// Look up the negotiation by the OPTION asset's NegotiationID. The
+	// negotiation row is keyed by (NegotiationRoutingNumber, NegotiationID)
+	// = the seller's bank's coordinates.
+	neg, err := p.negRepo.Get(
+		int(parsed.option.NegotiationID.RoutingNumber),
+		parsed.option.NegotiationID.ID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("looking up negotiation: %w", err)
+	}
+	if neg == nil {
+		return voteNo(NoVoteReason{
+			Reason:  ReasonOptionNegotiationNotFound,
+			Posting: parsed.optionLegBuyerPosting,
+		}), nil
+	}
+
+	// The partner that POSTed this NEW_TX must be the seller's bank
+	// (the initiator). Anything else is either a spoofed message or
+	// a misrouted relay.
+	if int(partner.Code) != neg.SellerRoutingNumber {
+		slog.Warn("interbank: NEW_TX partner does not match negotiation seller",
+			"partner", partner.Code,
+			"negotiation_seller_routing", neg.SellerRoutingNumber,
+			"negotiation_id", neg.NegotiationID,
+		)
+		return voteNo(NoVoteReason{Reason: ReasonOptionNegotiationNotFound}), nil
+	}
+
+	// We must be the buyer's bank to receive this NEW_TX. If we're the
+	// seller's bank we wouldn't have dispatched against ourselves; if
+	// we're neither, the partner shouldn't have sent it.
+	ownRouting := int(p.registry.OwnRoutingNumber())
+	if neg.BuyerRoutingNumber != ownRouting {
+		return voteNo(NoVoteReason{Reason: ReasonNoSuchAccount, Posting: parsed.optionLegBuyerPosting}), nil
+	}
+
+	// Validate posting terms match the stored negotiation.
+	if reason := matchAcceptanceTerms(parsed, neg); reason != nil {
+		return voteNo(*reason), nil
+	}
+
+	// Negotiation must still be ongoing for accept to make sense; a
+	// partner trying to settle a closed/declined negotiation gets a
+	// soft NO so the flow can be retried after re-opening.
+	if !neg.IsOngoing {
+		return voteNo(NoVoteReason{Reason: ReasonOptionUsedOrExpired, Posting: parsed.optionLegBuyerPosting}), nil
+	}
+
+	// Persist the pending row so COMMIT_TX/ROLLBACK_TX can find back
+	// what we promised. If an identical row already exists (NEW_TX
+	// replay sneaking past the idempotence layer) treat as a no-op
+	// success.
+	existing, err := p.pendingRepo.GetByTxID(
+		int(tx.TransactionID.RoutingNumber),
+		tx.TransactionID.ID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("looking up pending tx: %w", err)
+	}
+	if existing == nil {
+		row := &models.InterbankPendingTx{
+			TxRoutingNumber:          int(tx.TransactionID.RoutingNumber),
+			TxID:                     tx.TransactionID.ID,
+			PartnerRoutingNumber:     int(partner.Code),
+			NegotiationRoutingNumber: neg.NegotiationRoutingNumber,
+			NegotiationID:            neg.NegotiationID,
+
+			ReservedFromLocalID: neg.BuyerID,
+			ReservedCurrency:    neg.PremiumCurrency,
+			ReservedAmount:      neg.PremiumAmount,
+
+			StockTicker:          neg.StockTicker,
+			OptionAmount:         neg.Amount,
+			PricePerUnitCurrency: neg.PricePerUnitCurrency,
+			PricePerUnitAmount:   neg.PricePerUnitAmount,
+			SettlementDate:       neg.SettlementDate,
+
+			BuyerRoutingNumber:  neg.BuyerRoutingNumber,
+			BuyerID:             neg.BuyerID,
+			SellerRoutingNumber: neg.SellerRoutingNumber,
+			SellerID:            neg.SellerID,
+
+			Status: models.InterbankPendingTxStatusPending,
+		}
+		if err := p.pendingRepo.Create(row); err != nil {
+			return nil, fmt.Errorf("persisting pending tx: %w", err)
+		}
+	}
+
+	// TODO(interbank-balance): once bank-service exposes a "reserve"
+	// shim, call it here for ReservedAmount of ReservedCurrency on
+	// the local buyer; on failure return ReasonInsufficientAsset. For
+	// now we record the intent and trust the partner.
+	slog.Info("interbank: OTC option NEW_TX accepted (cash reservation deferred)",
+		"tx_routing", tx.TransactionID.RoutingNumber,
+		"tx_id", tx.TransactionID.ID,
+		"buyer_local_id", neg.BuyerID,
+		"reserve_currency", neg.PremiumCurrency,
+		"reserve_amount", neg.PremiumAmount,
+	)
+
+	return &TransactionVote{Vote: VoteYes}, nil
+}
+
+// OnCommitTx implements TxProcessor.OnCommitTx. On the first commit for
+// a given TransactionID we create the local option-contract row and
+// flip the negotiation closed; subsequent invocations are no-ops by
+// design (the protocol mandates byte-identical replay).
+func (p *OtcTxProcessor) OnCommitTx(_ context.Context, _ *PartnerBank, txID ForeignBankId) error {
+	pending, err := p.pendingRepo.GetByTxID(int(txID.RoutingNumber), txID.ID)
+	if err != nil {
+		return fmt.Errorf("loading pending tx: %w", err)
+	}
+	if pending == nil {
+		// COMMIT_TX without a corresponding NEW_TX is a protocol
+		// violation. We surface it so the partner sees a 500 and
+		// can investigate; we don't fabricate state.
+		return fmt.Errorf("COMMIT_TX for unknown transaction %d/%s", txID.RoutingNumber, txID.ID)
+	}
+
+	switch pending.Status {
+	case models.InterbankPendingTxStatusCommitted:
+		return nil // idempotent replay
+	case models.InterbankPendingTxStatusRolledBack:
+		return fmt.Errorf("COMMIT_TX for already-rolled-back transaction %d/%s", txID.RoutingNumber, txID.ID)
+	case models.InterbankPendingTxStatusPending:
+		// fall through to apply the commit
+	default:
+		return fmt.Errorf("pending tx %d/%s is in unknown status %q",
+			txID.RoutingNumber, txID.ID, pending.Status)
+	}
+
+	// Create the local option-contract row (idempotent on the
+	// negotiation key — if a row already exists, skip).
+	existingContract, err := p.contractRepo.Get(pending.NegotiationRoutingNumber, pending.NegotiationID)
+	if err != nil {
+		return fmt.Errorf("loading option contract: %w", err)
+	}
+	if existingContract == nil {
+		contract := &models.InterbankOptionContract{
+			NegotiationRoutingNumber: pending.NegotiationRoutingNumber,
+			NegotiationID:            pending.NegotiationID,
+			BuyerLocalID:             pending.BuyerID,
+			SellerRoutingNumber:      pending.SellerRoutingNumber,
+			SellerID:                 pending.SellerID,
+			StockTicker:              pending.StockTicker,
+			Amount:                   pending.OptionAmount,
+			PricePerUnitCurrency:     pending.PricePerUnitCurrency,
+			PricePerUnitAmount:       pending.PricePerUnitAmount,
+			PremiumCurrency:          pending.ReservedCurrency,
+			PremiumAmount:            pending.ReservedAmount,
+			SettlementDate:           pending.SettlementDate,
+			Status:                   models.InterbankOptionContractStatusValid,
+		}
+		if err := p.contractRepo.Create(contract); err != nil {
+			return fmt.Errorf("creating option contract: %w", err)
+		}
+	}
+
+	if err := p.negRepo.MarkClosed(pending.NegotiationRoutingNumber, pending.NegotiationID); err != nil {
+		return fmt.Errorf("closing negotiation on commit: %w", err)
+	}
+
+	// TODO(interbank-balance): on commit we owe the bank-service shim
+	// a "deduct reserved" call so the premium actually leaves the
+	// buyer's wallet. Today we just mark the pending row committed.
+	if err := p.pendingRepo.MarkCommitted(int(txID.RoutingNumber), txID.ID); err != nil {
+		return fmt.Errorf("marking pending tx committed: %w", err)
+	}
+
+	slog.Info("interbank: OTC option COMMIT_TX applied",
+		"tx_routing", txID.RoutingNumber,
+		"tx_id", txID.ID,
+		"negotiation_id", pending.NegotiationID,
+	)
+	return nil
+}
+
+// OnRollbackTx implements TxProcessor.OnRollbackTx. Releases the
+// reservation snapshot (logged TODO until bank-service is wired) and
+// flips the pending row to rolled_back. Idempotent: replays after the
+// first rollback are no-ops.
+func (p *OtcTxProcessor) OnRollbackTx(_ context.Context, _ *PartnerBank, txID ForeignBankId) error {
+	pending, err := p.pendingRepo.GetByTxID(int(txID.RoutingNumber), txID.ID)
+	if err != nil {
+		return fmt.Errorf("loading pending tx: %w", err)
+	}
+	if pending == nil {
+		// No record means we never voted YES (or the row was already
+		// cleaned up). The protocol's "MUST return identical response"
+		// is satisfied by the upstream idempotence cache; here we
+		// just succeed.
+		return nil
+	}
+
+	switch pending.Status {
+	case models.InterbankPendingTxStatusRolledBack:
+		return nil // idempotent
+	case models.InterbankPendingTxStatusCommitted:
+		return fmt.Errorf("ROLLBACK_TX for already-committed transaction %d/%s", txID.RoutingNumber, txID.ID)
+	case models.InterbankPendingTxStatusPending:
+		// proceed
+	default:
+		return fmt.Errorf("pending tx %d/%s is in unknown status %q",
+			txID.RoutingNumber, txID.ID, pending.Status)
+	}
+
+	// TODO(interbank-balance): release the reservation in bank-service.
+	if err := p.pendingRepo.MarkRolledBack(int(txID.RoutingNumber), txID.ID); err != nil {
+		return fmt.Errorf("marking pending tx rolled back: %w", err)
+	}
+
+	slog.Info("interbank: OTC option ROLLBACK_TX applied",
+		"tx_routing", txID.RoutingNumber,
+		"tx_id", txID.ID,
+		"negotiation_id", pending.NegotiationID,
+	)
+	return nil
+}
+
+// otcAcceptanceTx is a parsed view of a 4-posting OTC option acceptance
+// NEW_TX. The four postings are: cash buyer (-P), cash seller (+P),
+// option seller (-1), option buyer (+1).
+type otcAcceptanceTx struct {
+	cashLegBuyerPosting  *Posting
+	cashLegSellerPosting *Posting
+	optionLegSellerPosting *Posting
+	optionLegBuyerPosting  *Posting
+
+	premium     MonetaryAsset
+	premiumAmt  float64
+	option      *OptionDescription
+	buyer       ForeignBankId
+	seller      ForeignBankId
+}
+
+// parseOtcAcceptance classifies the four postings of an OTC acceptance
+// NEW_TX. Returns a NoVoteReason if the shape doesn't match.
+func parseOtcAcceptance(tx *Transaction) (*otcAcceptanceTx, *NoVoteReason) {
+	if len(tx.Postings) != 4 {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset}
+	}
+
+	parsed := &otcAcceptanceTx{}
+	for i := range tx.Postings {
+		ptg := &tx.Postings[i]
+
+		// All four postings must reference PERSON accounts (the OTC
+		// acceptance shape; ACCOUNT-typed postings here would be a
+		// different transaction kind we don't yet support).
+		if ptg.Account.Type != TxAccountPerson || ptg.Account.ID == nil {
+			return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+		}
+
+		switch ptg.Asset.Type {
+		case AssetMonas:
+			if ptg.Asset.Monas == nil {
+				return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+			}
+			if ptg.Amount < 0 {
+				if parsed.cashLegBuyerPosting != nil {
+					return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+				}
+				parsed.cashLegBuyerPosting = ptg
+				parsed.buyer = *ptg.Account.ID
+				parsed.premium = *ptg.Asset.Monas
+				parsed.premiumAmt = -ptg.Amount
+			} else {
+				if parsed.cashLegSellerPosting != nil {
+					return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+				}
+				parsed.cashLegSellerPosting = ptg
+				parsed.seller = *ptg.Account.ID
+			}
+		case AssetOption:
+			if ptg.Asset.Option == nil {
+				return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+			}
+			if ptg.Amount < 0 {
+				if parsed.optionLegSellerPosting != nil {
+					return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+				}
+				parsed.optionLegSellerPosting = ptg
+				parsed.option = ptg.Asset.Option
+			} else {
+				if parsed.optionLegBuyerPosting != nil {
+					return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+				}
+				parsed.optionLegBuyerPosting = ptg
+			}
+		default:
+			return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+		}
+	}
+
+	if parsed.cashLegBuyerPosting == nil ||
+		parsed.cashLegSellerPosting == nil ||
+		parsed.optionLegSellerPosting == nil ||
+		parsed.optionLegBuyerPosting == nil {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset}
+	}
+
+	// Option-leg amounts must be exactly +/-1: an option contract is a
+	// single indivisible unit (Amount inside OptionDescription holds the
+	// underlying stock count).
+	if !nearlyEqual(parsed.optionLegSellerPosting.Amount, -1) || !nearlyEqual(parsed.optionLegBuyerPosting.Amount, 1) {
+		return nil, &NoVoteReason{Reason: ReasonOptionAmountIncorrect, Posting: parsed.optionLegBuyerPosting}
+	}
+
+	// Cash leg amounts must offset.
+	if !nearlyEqual(parsed.cashLegBuyerPosting.Amount, -parsed.cashLegSellerPosting.Amount) {
+		return nil, &NoVoteReason{Reason: ReasonUnbalancedTx}
+	}
+
+	// Both option-leg postings must describe the same option.
+	if !sameOption(parsed.option, parsed.optionLegBuyerPosting.Asset.Option) {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.optionLegBuyerPosting}
+	}
+
+	// The buyer of the cash leg must equal the buyer of the option leg
+	// (and similarly for the seller). Otherwise the postings would not
+	// describe a coherent option acceptance.
+	if !sameForeignBankId(parsed.buyer, *parsed.optionLegBuyerPosting.Account.ID) {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.optionLegBuyerPosting}
+	}
+	if !sameForeignBankId(parsed.seller, *parsed.optionLegSellerPosting.Account.ID) {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.optionLegSellerPosting}
+	}
+
+	return parsed, nil
+}
+
+// matchAcceptanceTerms checks that the parsed transaction's terms match
+// the stored negotiation row exactly. Returns a NoVoteReason on
+// mismatch.
+func matchAcceptanceTerms(parsed *otcAcceptanceTx, neg *models.InterbankOtcNegotiation) *NoVoteReason {
+	if int(parsed.buyer.RoutingNumber) != neg.BuyerRoutingNumber || parsed.buyer.ID != neg.BuyerID {
+		return &NoVoteReason{Reason: ReasonNoSuchAccount, Posting: parsed.cashLegBuyerPosting}
+	}
+	if int(parsed.seller.RoutingNumber) != neg.SellerRoutingNumber || parsed.seller.ID != neg.SellerID {
+		return &NoVoteReason{Reason: ReasonNoSuchAccount, Posting: parsed.cashLegSellerPosting}
+	}
+	if string(parsed.premium.Currency) != neg.PremiumCurrency {
+		return &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.cashLegBuyerPosting}
+	}
+	if !nearlyEqual(parsed.premiumAmt, neg.PremiumAmount) {
+		return &NoVoteReason{Reason: ReasonInsufficientAsset, Posting: parsed.cashLegBuyerPosting}
+	}
+	if parsed.option.Stock.Ticker != neg.StockTicker {
+		return &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.optionLegBuyerPosting}
+	}
+	if string(parsed.option.PricePerUnit.Currency) != neg.PricePerUnitCurrency ||
+		!nearlyEqual(parsed.option.PricePerUnit.Amount, neg.PricePerUnitAmount) {
+		return &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.optionLegBuyerPosting}
+	}
+	if parsed.option.SettlementDate != neg.SettlementDate {
+		return &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.optionLegBuyerPosting}
+	}
+	if !nearlyEqual(parsed.option.Amount, neg.Amount) {
+		return &NoVoteReason{Reason: ReasonOptionAmountIncorrect, Posting: parsed.optionLegBuyerPosting}
+	}
+	if int(parsed.option.NegotiationID.RoutingNumber) != neg.NegotiationRoutingNumber ||
+		parsed.option.NegotiationID.ID != neg.NegotiationID {
+		return &NoVoteReason{Reason: ReasonOptionNegotiationNotFound, Posting: parsed.optionLegBuyerPosting}
+	}
+	return nil
+}
+
+// checkBalanced verifies that for every (account, asset) pair the
+// posting amounts sum to zero. This is the §2.8.6 balance check.
+//
+// Implementation note: we group by asset type only (not account) since
+// the spec says "regardless of account, all credited and debited
+// amounts add up to zero" for a transaction to be balanced.
+func checkBalanced(tx *Transaction) *NoVoteReason {
+	sums := map[string]float64{}
+	for i := range tx.Postings {
+		key := assetGroupKey(&tx.Postings[i].Asset)
+		sums[key] += tx.Postings[i].Amount
+	}
+	for _, v := range sums {
+		if !nearlyEqual(v, 0) {
+			return &NoVoteReason{Reason: ReasonUnbalancedTx}
+		}
+	}
+	return nil
+}
+
+// assetGroupKey returns a key that uniquely identifies "the same
+// asset" across postings. Two MONAS postings with the same currency
+// are the same asset; two OPTION postings with the same negotiation id
+// are the same asset; STOCK postings group by ticker.
+func assetGroupKey(a *Asset) string {
+	switch a.Type {
+	case AssetMonas:
+		if a.Monas == nil {
+			return "monas:?"
+		}
+		return "monas:" + string(a.Monas.Currency)
+	case AssetStock:
+		if a.Stock == nil {
+			return "stock:?"
+		}
+		return "stock:" + a.Stock.Ticker
+	case AssetOption:
+		if a.Option == nil {
+			return "option:?"
+		}
+		return fmt.Sprintf("option:%d/%s",
+			a.Option.NegotiationID.RoutingNumber,
+			a.Option.NegotiationID.ID)
+	default:
+		return "?"
+	}
+}
+
+func sameOption(a, b *OptionDescription) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	return a.NegotiationID.RoutingNumber == b.NegotiationID.RoutingNumber &&
+		a.NegotiationID.ID == b.NegotiationID.ID &&
+		a.Stock.Ticker == b.Stock.Ticker &&
+		a.PricePerUnit.Currency == b.PricePerUnit.Currency &&
+		nearlyEqual(a.PricePerUnit.Amount, b.PricePerUnit.Amount) &&
+		a.SettlementDate == b.SettlementDate &&
+		nearlyEqual(a.Amount, b.Amount)
+}
+
+func sameForeignBankId(a, b ForeignBankId) bool {
+	return a.RoutingNumber == b.RoutingNumber && a.ID == b.ID
+}
+
+func nearlyEqual(a, b float64) bool {
+	return math.Abs(a-b) < 1e-9
+}
+
+func voteNo(reason NoVoteReason) *TransactionVote {
+	return &TransactionVote{Vote: VoteNo, Reasons: []NoVoteReason{reason}}
+}

--- a/exchange-service/internal/models/interbank.go
+++ b/exchange-service/internal/models/interbank.go
@@ -13,6 +13,19 @@ const (
 	InterbankNegotiationRoleSeller = "seller"
 )
 
+const (
+	InterbankPendingTxStatusPending     = "pending"
+	InterbankPendingTxStatusCommitted   = "committed"
+	InterbankPendingTxStatusRolledBack  = "rolled_back"
+	InterbankPendingTxStatusRejected    = "rejected"
+)
+
+const (
+	InterbankOptionContractStatusValid     = "valid"
+	InterbankOptionContractStatusExercised = "exercised"
+	InterbankOptionContractStatusExpired   = "expired"
+)
+
 // InterbankInboundMessage is the audit + idempotence log for every
 // /interbank request we accept from a partner bank. The composite
 // (routing_number, locally_generated_key) is the protocol-defined
@@ -90,3 +103,105 @@ type InterbankOtcNegotiation struct {
 }
 
 func (InterbankOtcNegotiation) TableName() string { return "interbank_otc_negotiations" }
+
+// InterbankPendingTx is the per-TransactionID state machine row for an
+// inbound NEW_TX that we voted YES on but haven't yet seen a
+// COMMIT_TX/ROLLBACK_TX for. The protocol allows arbitrary delay between
+// the vote and the resolution, so we persist what we reserved + what
+// posting effect should fire on commit. Idempotence is enforced at the
+// /interbank handler layer by InterbankInboundMessage; this table is
+// the BUSINESS-layer record of "we promised to do X at commit time".
+//
+// The composite (TxRoutingNumber, TxID) is the protocol's
+// transactionId.routingNumber + transactionId.id — i.e. the
+// initiating bank's coordinates, which the protocol guarantees are
+// globally unique.
+type InterbankPendingTx struct {
+	ID uint `gorm:"primaryKey"`
+
+	TxRoutingNumber int    `gorm:"column:tx_routing_number;not null;uniqueIndex:idx_interbank_pending_tx_key,priority:1"`
+	TxID            string `gorm:"column:tx_id;type:varchar(64);not null;uniqueIndex:idx_interbank_pending_tx_key,priority:2"`
+
+	// PartnerRoutingNumber is the partner that POSTed the NEW_TX to us;
+	// it's almost always equal to TxRoutingNumber (the initiator is
+	// also the sender) but we record it separately to catch a
+	// hypothetical relay-through-third-party case during audit.
+	PartnerRoutingNumber int `gorm:"column:partner_routing_number;not null;index"`
+
+	// NegotiationRoutingNumber + NegotiationID let us find back the
+	// InterbankOtcNegotiation row that this NEW_TX is settling, so
+	// COMMIT_TX can flip it closed + write the option contract.
+	NegotiationRoutingNumber int    `gorm:"column:negotiation_routing_number;not null;index"`
+	NegotiationID            string `gorm:"column:negotiation_id;type:varchar(64);not null"`
+
+	// Resource-reservation snapshot. We persist what was reserved on
+	// NEW_TX so we can release it on ROLLBACK_TX even if the original
+	// envelope can't be replayed.
+	ReservedFromLocalID  string  `gorm:"column:reserved_from_local_id;type:varchar(64);not null"`
+	ReservedCurrency     string  `gorm:"column:reserved_currency;not null"`
+	ReservedAmount       float64 `gorm:"column:reserved_amount;not null"`
+
+	// Snapshot of the option contract terms — applied on COMMIT_TX to
+	// create the InterbankOptionContract row.
+	StockTicker          string  `gorm:"column:stock_ticker;not null"`
+	OptionAmount         float64 `gorm:"column:option_amount;not null"`
+	PricePerUnitCurrency string  `gorm:"column:price_per_unit_currency;not null"`
+	PricePerUnitAmount   float64 `gorm:"column:price_per_unit_amount;not null"`
+	SettlementDate       string  `gorm:"column:settlement_date;not null"`
+
+	// Identities of the two sides; the local side is our customer.
+	BuyerRoutingNumber  int    `gorm:"column:buyer_routing_number;not null"`
+	BuyerID             string `gorm:"column:buyer_id;type:varchar(64);not null"`
+	SellerRoutingNumber int    `gorm:"column:seller_routing_number;not null"`
+	SellerID            string `gorm:"column:seller_id;type:varchar(64);not null"`
+
+	Status string `gorm:"not null;default:'pending';index"`
+
+	CreatedAt   time.Time  `gorm:"not null"`
+	ResolvedAt  *time.Time `gorm:"column:resolved_at"`
+}
+
+func (InterbankPendingTx) TableName() string { return "interbank_pending_txs" }
+
+// InterbankOptionContract is our local record of an option contract
+// formed with a partner bank. We always sit on the BUYER side of these
+// rows — when we're the seller, the contract is just the negotiation
+// we've already closed plus a corresponding reservation in our local
+// portfolio.
+//
+// The contract's global identity is the negotiation's identity
+// (NegotiationRoutingNumber, NegotiationID) per spec §3.6.1 ("Set the
+// OTC option contract negotiationId to the ID of the negotiation that
+// lead to its creation. This ensures that the option pseudo-account is
+// always in the bank of the seller").
+type InterbankOptionContract struct {
+	ID uint `gorm:"primaryKey"`
+
+	NegotiationRoutingNumber int    `gorm:"column:negotiation_routing_number;not null;uniqueIndex:idx_interbank_option_contract_key,priority:1"`
+	NegotiationID            string `gorm:"column:negotiation_id;type:varchar(64);not null;uniqueIndex:idx_interbank_option_contract_key,priority:2"`
+
+	// The local user holding the option (always our side; this table
+	// is only written when WE are the buyer's bank). For the
+	// symmetric "we are the seller's bank" case the local-side
+	// effect lives in the existing portfolio holding reservation, not
+	// in this table.
+	BuyerLocalID string `gorm:"column:buyer_local_id;type:varchar(64);not null;index"`
+
+	SellerRoutingNumber int    `gorm:"column:seller_routing_number;not null"`
+	SellerID            string `gorm:"column:seller_id;type:varchar(64);not null"`
+
+	StockTicker          string  `gorm:"column:stock_ticker;not null;index"`
+	Amount               float64 `gorm:"not null"`
+	PricePerUnitCurrency string  `gorm:"column:price_per_unit_currency;not null"`
+	PricePerUnitAmount   float64 `gorm:"column:price_per_unit_amount;not null"`
+	PremiumCurrency      string  `gorm:"column:premium_currency;not null"`
+	PremiumAmount        float64 `gorm:"column:premium_amount;not null"`
+	SettlementDate       string  `gorm:"column:settlement_date;not null"`
+
+	Status string `gorm:"not null;default:'valid';index"`
+
+	CreatedAt time.Time `gorm:"not null"`
+	UpdatedAt time.Time `gorm:"not null"`
+}
+
+func (InterbankOptionContract) TableName() string { return "interbank_option_contracts" }

--- a/exchange-service/internal/repository/interbank_tx_repository.go
+++ b/exchange-service/internal/repository/interbank_tx_repository.go
@@ -1,0 +1,116 @@
+package repository
+
+import (
+	"errors"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"gorm.io/gorm"
+)
+
+// InterbankPendingTxRepository persists the per-TransactionID state we
+// hold between voting YES on a NEW_TX and seeing the matching
+// COMMIT_TX / ROLLBACK_TX. The /interbank handler dedupes by
+// idempotence key already; this repo is the business-layer record of
+// "what we promised to do on commit".
+type InterbankPendingTxRepository struct {
+	db *gorm.DB
+}
+
+func NewInterbankPendingTxRepository(db *gorm.DB) *InterbankPendingTxRepository {
+	return &InterbankPendingTxRepository{db: db}
+}
+
+// Create writes a new pending-tx row in status "pending". Timestamps
+// are set here so callers don't have to remember.
+func (r *InterbankPendingTxRepository) Create(p *models.InterbankPendingTx) error {
+	p.CreatedAt = time.Now().UTC()
+	if p.Status == "" {
+		p.Status = models.InterbankPendingTxStatusPending
+	}
+	return r.db.Create(p).Error
+}
+
+// GetByTxID fetches a pending tx by the protocol transaction identity.
+// Returns (nil, nil) when there's no row — used to detect duplicate
+// COMMIT/ROLLBACK that arrived before NEW_TX (shouldn't happen in
+// practice but the handler must be defensive).
+func (r *InterbankPendingTxRepository) GetByTxID(txRoutingNumber int, txID string) (*models.InterbankPendingTx, error) {
+	var row models.InterbankPendingTx
+	err := r.db.
+		Where("tx_routing_number = ? AND tx_id = ?", txRoutingNumber, txID).
+		First(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &row, nil
+}
+
+// MarkCommitted flips status → committed and stamps resolved_at. Safe
+// to call on an already-committed row (no-op).
+func (r *InterbankPendingTxRepository) MarkCommitted(txRoutingNumber int, txID string) error {
+	now := time.Now().UTC()
+	return r.db.Model(&models.InterbankPendingTx{}).
+		Where("tx_routing_number = ? AND tx_id = ? AND status = ?",
+			txRoutingNumber, txID, models.InterbankPendingTxStatusPending).
+		Updates(map[string]interface{}{
+			"status":      models.InterbankPendingTxStatusCommitted,
+			"resolved_at": now,
+		}).Error
+}
+
+// MarkRolledBack flips status → rolled_back and stamps resolved_at.
+// Safe to call on an already-rolled-back row (no-op).
+func (r *InterbankPendingTxRepository) MarkRolledBack(txRoutingNumber int, txID string) error {
+	now := time.Now().UTC()
+	return r.db.Model(&models.InterbankPendingTx{}).
+		Where("tx_routing_number = ? AND tx_id = ? AND status = ?",
+			txRoutingNumber, txID, models.InterbankPendingTxStatusPending).
+		Updates(map[string]interface{}{
+			"status":      models.InterbankPendingTxStatusRolledBack,
+			"resolved_at": now,
+		}).Error
+}
+
+// InterbankOptionContractRepository persists local option-contract rows
+// formed via cross-bank OTC negotiations. We only write to this table
+// when WE are the buyer's bank; when we're the seller, the local-side
+// effect lives in the regular portfolio holding reservation.
+type InterbankOptionContractRepository struct {
+	db *gorm.DB
+}
+
+func NewInterbankOptionContractRepository(db *gorm.DB) *InterbankOptionContractRepository {
+	return &InterbankOptionContractRepository{db: db}
+}
+
+// Create writes a new contract row. Timestamps are set here.
+func (r *InterbankOptionContractRepository) Create(c *models.InterbankOptionContract) error {
+	now := time.Now().UTC()
+	c.CreatedAt = now
+	c.UpdatedAt = now
+	if c.Status == "" {
+		c.Status = models.InterbankOptionContractStatusValid
+	}
+	return r.db.Create(c).Error
+}
+
+// Get fetches a contract by the negotiation identity (= the contract's
+// global identity per spec §3.6.1). Returns (nil, nil) when no row
+// exists.
+func (r *InterbankOptionContractRepository) Get(negotiationRoutingNumber int, negotiationID string) (*models.InterbankOptionContract, error) {
+	var row models.InterbankOptionContract
+	err := r.db.
+		Where("negotiation_routing_number = ? AND negotiation_id = ?", negotiationRoutingNumber, negotiationID).
+		First(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &row, nil
+}


### PR DESCRIPTION
## Summary

- Replaces `NoopProcessor` with `OtcTxProcessor` — the buyer's-bank side of protocol §3.6. Validates the 4-posting NEW_TX shape against a stored `InterbankOtcNegotiation`, persists per-TxID state, and applies option-contract creation on COMMIT_TX
- Anything that isn't a recognised OTC-option NEW_TX gets `VoteNo` with a spec-aligned reason (`UNBALANCED_TX`, `UNACCEPTABLE_ASSET`, `NO_SUCH_ACCOUNT`, etc.)
- Idempotent on replay: COMMIT_TX and ROLLBACK_TX both no-op if the pending row is already resolved
- Cash reservation against the local buyer is deferred (logged TODO) — we record what we WOULD reserve in `InterbankPendingTx`; plugging into bank-service is the next ticket

Closes #200

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` green
- [ ] Manual smoke: dispatch NEW_TX from a partner sandbox and verify YES vote + option contract row after COMMIT_TX
- [ ] Manual smoke: replay COMMIT_TX and ROLLBACK_TX to confirm idempotence

🤖 Generated with [Claude Code](https://claude.com/claude-code)