### PR TITLE
feat(exchange): sprint 9 local-seller accept for cross-bank OTC negotiations

### DIFF
--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -117,6 +117,8 @@ func main() {
 
 	fundH := handler.NewFundHTTPHandler(cfg, fundSvc)
 
+	ibOtcLocalH := handler.NewInterbankOtcHTTPHandler(cfg, ibRegistry, ibClient, ibNegRepo)
+
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
 			middleware.LoggingInterceptor(),
@@ -165,6 +167,7 @@ func main() {
 	httpMux.Handle("/api/v1/tax/", middleware.CORS(http.HandlerFunc(taxH.TaxRoutes)))
 	httpMux.Handle("/api/v1/funds", middleware.CORS(http.HandlerFunc(fundH.FundRoutes)))
 	httpMux.Handle("/api/v1/funds/", middleware.CORS(http.HandlerFunc(fundH.FundRoutes)))
+	httpMux.Handle("/api/v1/interbank-otc/", middleware.CORS(http.HandlerFunc(ibOtcLocalH.Routes)))
 	// Inter-bank wire endpoint — partner-bank traffic, no CORS, X-Api-Key auth.
 	httpMux.Handle("/interbank", ibServer)
 	httpMux.Handle("/public-stock", interbank.AuthMiddleware(ibRegistry, http.HandlerFunc(ibOtcH.PublicStock)))

--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -117,7 +117,7 @@ func main() {
 
 	fundH := handler.NewFundHTTPHandler(cfg, fundSvc)
 
-	ibOtcLocalH := handler.NewInterbankOtcHTTPHandler(cfg, ibRegistry, ibClient, ibNegRepo)
+	ibOtcLocalH := handler.NewInterbankOtcHTTPHandler(cfg, ibRegistry, ibClient, ibNegRepo, ibNegH)
 
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(

--- a/exchange-service/internal/handler/interbank_otc_http_handler.go
+++ b/exchange-service/internal/handler/interbank_otc_http_handler.go
@@ -1,0 +1,615 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/util"
+)
+
+// InterbankOtcHTTPHandler is the local-frontend entry point for the
+// cross-bank OTC negotiation flow. It sits in front of interbank.Client
+// (outbound /negotiations + /public-stock calls to partner banks) and
+// repository.InterbankOtcRepository (our local copy of every
+// negotiation we're a party to). The partner-facing wire surface lives
+// in package interbank; this handler is the JWT-authenticated face of
+// it for our own UI.
+type InterbankOtcHTTPHandler struct {
+	cfg      *config.Config
+	registry *interbank.Registry
+	client   *interbank.Client
+	negRepo  *repository.InterbankOtcRepository
+}
+
+func NewInterbankOtcHTTPHandler(
+	cfg *config.Config,
+	registry *interbank.Registry,
+	client *interbank.Client,
+	negRepo *repository.InterbankOtcRepository,
+) *InterbankOtcHTTPHandler {
+	return &InterbankOtcHTTPHandler{
+		cfg:      cfg,
+		registry: registry,
+		client:   client,
+		negRepo:  negRepo,
+	}
+}
+
+// Routes dispatches /api/v1/interbank-otc/* to the right method.
+func (h *InterbankOtcHTTPHandler) Routes(w http.ResponseWriter, r *http.Request) {
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/interbank-otc/"), "/")
+	if path == "" {
+		http.NotFound(w, r)
+		return
+	}
+	parts := strings.Split(path, "/")
+
+	switch {
+	case len(parts) == 1 && parts[0] == "public-stocks":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.listPublicStocks(w, r)
+	case len(parts) == 1 && parts[0] == "negotiations":
+		switch r.Method {
+		case http.MethodGet:
+			h.listNegotiations(w, r)
+		case http.MethodPost:
+			h.createNegotiation(w, r)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	case len(parts) == 3 && parts[0] == "negotiations":
+		routing, id, ok := parseRoutingAndID(parts[1], parts[2])
+		if !ok {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "expected /negotiations/{routingNumber}/{id}"})
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			h.getNegotiation(w, r, routing, id)
+		case http.MethodPut:
+			h.updateNegotiation(w, r, routing, id)
+		case http.MethodDelete:
+			h.closeNegotiation(w, r, routing, id)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// listPublicStocks aggregates the partner /public-stock responses into a
+// single payload the local frontend can render. Partner errors are
+// reported per-bank rather than failing the whole call — one slow
+// partner shouldn't block the catalogue.
+func (h *InterbankOtcHTTPHandler) listPublicStocks(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+
+	partners := h.registry.All()
+	type partnerResult struct {
+		code   interbank.RoutingNumber
+		stocks interbank.PublicStocksResponse
+		err    error
+	}
+	results := make([]partnerResult, len(partners))
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for i := range partners {
+		i := i
+		p := partners[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			stocks, err := h.client.FetchPublicStock(ctx, p.Code)
+			results[i] = partnerResult{code: p.Code, stocks: stocks, err: err}
+		}()
+	}
+	wg.Wait()
+
+	type stockResp struct {
+		Ticker  string `json:"ticker"`
+		Sellers []struct {
+			BankRoutingNumber int     `json:"bankRoutingNumber"`
+			BankDisplayName   string  `json:"bankDisplayName"`
+			SellerID          string  `json:"sellerId"`
+			Amount            float64 `json:"amount"`
+		} `json:"sellers"`
+	}
+	bankNames := map[interbank.RoutingNumber]string{}
+	for _, p := range partners {
+		bankNames[p.Code] = p.DisplayName
+	}
+	out := map[string]*stockResp{}
+	partnerErrors := map[string]string{}
+	for _, res := range results {
+		if res.err != nil {
+			partnerErrors[strconv.Itoa(int(res.code))] = res.err.Error()
+			slog.Warn("interbank-otc: partner /public-stock failed",
+				"partner", res.code, "error", res.err)
+			continue
+		}
+		for _, ps := range res.stocks {
+			entry, ok := out[ps.Stock.Ticker]
+			if !ok {
+				entry = &stockResp{Ticker: ps.Stock.Ticker}
+				out[ps.Stock.Ticker] = entry
+			}
+			for _, seller := range ps.Sellers {
+				entry.Sellers = append(entry.Sellers, struct {
+					BankRoutingNumber int     `json:"bankRoutingNumber"`
+					BankDisplayName   string  `json:"bankDisplayName"`
+					SellerID          string  `json:"sellerId"`
+					Amount            float64 `json:"amount"`
+				}{
+					BankRoutingNumber: int(seller.Seller.RoutingNumber),
+					BankDisplayName:   bankNames[seller.Seller.RoutingNumber],
+					SellerID:          seller.Seller.ID,
+					Amount:            seller.Amount,
+				})
+			}
+		}
+	}
+
+	stocks := make([]stockResp, 0, len(out))
+	for _, e := range out {
+		stocks = append(stocks, *e)
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"stocks":        stocks,
+		"count":         len(stocks),
+		"partnerErrors": partnerErrors,
+	})
+}
+
+// listNegotiations returns every cross-bank negotiation the caller is a
+// party to. `?role=buyer|seller` filters to one side; `?includeClosed=true`
+// includes negotiations whose isOngoing flag has flipped off.
+func (h *InterbankOtcHTTPHandler) listNegotiations(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+
+	localID, ok := localParticipantIDFromClaims(claims)
+	if !ok {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "only client tokens can list interbank negotiations"})
+		return
+	}
+
+	role := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("role")))
+	switch role {
+	case "buyer":
+		role = models.InterbankNegotiationRoleBuyer
+	case "seller":
+		role = models.InterbankNegotiationRoleSeller
+	case "":
+		// keep blank — repo treats blank as both sides
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "role must be buyer|seller"})
+		return
+	}
+	includeClosed := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("includeClosed")), "true")
+
+	rows, err := h.negRepo.ListByLocalParticipant(localID, role, includeClosed)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("listing negotiations: %v", err)})
+		return
+	}
+
+	items := make([]map[string]interface{}, 0, len(rows))
+	for i := range rows {
+		items = append(items, negotiationRowToResponse(&rows[i]))
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"negotiations": items,
+		"count":        len(items),
+	})
+}
+
+// createNegotiation forwards a new OtcOffer to the seller's bank and
+// persists the local copy with LocalRole=buyer. The caller's claims
+// resolve to the buyer identity; the request body only carries the
+// counterparty + terms.
+func (h *InterbankOtcHTTPHandler) createNegotiation(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+	localID, ok := localParticipantIDFromClaims(claims)
+	if !ok {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "only client tokens can start interbank negotiations"})
+		return
+	}
+
+	var body struct {
+		SellerID struct {
+			RoutingNumber int    `json:"routingNumber"`
+			ID            string `json:"id"`
+		} `json:"sellerId"`
+		Stock struct {
+			Ticker string `json:"ticker"`
+		} `json:"stock"`
+		SettlementDate string `json:"settlementDate"`
+		PricePerUnit   struct {
+			Currency string  `json:"currency"`
+			Amount   float64 `json:"amount"`
+		} `json:"pricePerUnit"`
+		Premium struct {
+			Currency string  `json:"currency"`
+			Amount   float64 `json:"amount"`
+		} `json:"premium"`
+		Amount float64 `json:"amount"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid request body"})
+		return
+	}
+
+	if body.SellerID.RoutingNumber == 0 || strings.TrimSpace(body.SellerID.ID) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "sellerId.routingNumber and sellerId.id are required"})
+		return
+	}
+	if body.SellerID.RoutingNumber == int(h.registry.OwnRoutingNumber()) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "sellerId.routingNumber must be a partner bank, not this bank — use /api/v1/otc for local negotiations"})
+		return
+	}
+	if h.registry.Lookup(interbank.RoutingNumber(body.SellerID.RoutingNumber)) == nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": fmt.Sprintf("no partner bank registered for routing number %d", body.SellerID.RoutingNumber)})
+		return
+	}
+	if strings.TrimSpace(body.Stock.Ticker) == "" || body.Amount <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "stock.ticker and a positive amount are required"})
+		return
+	}
+
+	own := h.registry.OwnRoutingNumber()
+	buyer := interbank.ForeignBankId{RoutingNumber: own, ID: localID}
+	seller := interbank.ForeignBankId{
+		RoutingNumber: interbank.RoutingNumber(body.SellerID.RoutingNumber),
+		ID:            body.SellerID.ID,
+	}
+
+	offer := interbank.OtcOffer{
+		Stock:          interbank.StockDescription{Ticker: body.Stock.Ticker},
+		SettlementDate: body.SettlementDate,
+		PricePerUnit: interbank.MonetaryValue{
+			Currency: interbank.CurrencyCode(body.PricePerUnit.Currency),
+			Amount:   body.PricePerUnit.Amount,
+		},
+		Premium: interbank.MonetaryValue{
+			Currency: interbank.CurrencyCode(body.Premium.Currency),
+			Amount:   body.Premium.Amount,
+		},
+		BuyerID:        buyer,
+		SellerID:       seller,
+		Amount:         body.Amount,
+		LastModifiedBy: buyer,
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+	defer cancel()
+	negID, err := h.client.CreateNegotiation(ctx, seller.RoutingNumber, offer)
+	if err != nil {
+		writeJSON(w, statusFromRemoteError(err), map[string]string{"message": fmt.Sprintf("partner POST /negotiations failed: %v", err)})
+		return
+	}
+
+	row := &models.InterbankOtcNegotiation{
+		NegotiationRoutingNumber:    int(negID.RoutingNumber),
+		NegotiationID:               negID.ID,
+		LocalRole:                   models.InterbankNegotiationRoleBuyer,
+		CounterpartyRoutingNumber:   int(seller.RoutingNumber),
+		BuyerRoutingNumber:          int(buyer.RoutingNumber),
+		BuyerID:                     buyer.ID,
+		SellerRoutingNumber:         int(seller.RoutingNumber),
+		SellerID:                    seller.ID,
+		StockTicker:                 body.Stock.Ticker,
+		Amount:                      body.Amount,
+		PricePerUnitCurrency:        body.PricePerUnit.Currency,
+		PricePerUnitAmount:          body.PricePerUnit.Amount,
+		PremiumCurrency:             body.Premium.Currency,
+		PremiumAmount:               body.Premium.Amount,
+		SettlementDate:              body.SettlementDate,
+		LastModifiedByRoutingNumber: int(buyer.RoutingNumber),
+		LastModifiedByID:            buyer.ID,
+		IsOngoing:                   true,
+	}
+	if err := h.negRepo.Create(row); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("persisting local negotiation: %v", err)})
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]interface{}{
+		"negotiation": negotiationRowToResponse(row),
+	})
+}
+
+// getNegotiation reads our local copy. We don't fan out to the partner
+// here — if the local row is stale the partner's inbound PUT/DELETE
+// will refresh it, and the frontend can poll.
+func (h *InterbankOtcHTTPHandler) getNegotiation(w http.ResponseWriter, r *http.Request, routing interbank.RoutingNumber, id string) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+	localID, ok := localParticipantIDFromClaims(claims)
+	if !ok {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "only client tokens can read interbank negotiations"})
+		return
+	}
+
+	row, err := h.negRepo.Get(int(routing), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("loading negotiation: %v", err)})
+		return
+	}
+	if row == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "no such negotiation"})
+		return
+	}
+	if !localUserIsParty(row, localID) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "you are not a party to that negotiation"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"negotiation": negotiationRowToResponse(row),
+	})
+}
+
+// updateNegotiation forwards a counter-offer to the partner, then
+// mirrors the new terms into the local row.
+func (h *InterbankOtcHTTPHandler) updateNegotiation(w http.ResponseWriter, r *http.Request, routing interbank.RoutingNumber, id string) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+	localID, ok := localParticipantIDFromClaims(claims)
+	if !ok {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "only client tokens can update interbank negotiations"})
+		return
+	}
+
+	row, err := h.negRepo.Get(int(routing), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("loading negotiation: %v", err)})
+		return
+	}
+	if row == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "no such negotiation"})
+		return
+	}
+	if !localUserIsParty(row, localID) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "you are not a party to that negotiation"})
+		return
+	}
+	if !row.IsOngoing {
+		writeJSON(w, http.StatusConflict, map[string]string{"message": "negotiation is no longer ongoing"})
+		return
+	}
+
+	var body struct {
+		SettlementDate string `json:"settlementDate"`
+		PricePerUnit   struct {
+			Currency string  `json:"currency"`
+			Amount   float64 `json:"amount"`
+		} `json:"pricePerUnit"`
+		Premium struct {
+			Currency string  `json:"currency"`
+			Amount   float64 `json:"amount"`
+		} `json:"premium"`
+		Amount float64 `json:"amount"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid request body"})
+		return
+	}
+	if body.Amount <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "amount must be positive"})
+		return
+	}
+
+	own := h.registry.OwnRoutingNumber()
+	caller := interbank.ForeignBankId{RoutingNumber: own, ID: localID}
+
+	offer := interbank.OtcOffer{
+		Stock:          interbank.StockDescription{Ticker: row.StockTicker},
+		SettlementDate: body.SettlementDate,
+		PricePerUnit: interbank.MonetaryValue{
+			Currency: interbank.CurrencyCode(body.PricePerUnit.Currency),
+			Amount:   body.PricePerUnit.Amount,
+		},
+		Premium: interbank.MonetaryValue{
+			Currency: interbank.CurrencyCode(body.Premium.Currency),
+			Amount:   body.Premium.Amount,
+		},
+		BuyerID:        interbank.ForeignBankId{RoutingNumber: interbank.RoutingNumber(row.BuyerRoutingNumber), ID: row.BuyerID},
+		SellerID:       interbank.ForeignBankId{RoutingNumber: interbank.RoutingNumber(row.SellerRoutingNumber), ID: row.SellerID},
+		Amount:         body.Amount,
+		LastModifiedBy: caller,
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+	defer cancel()
+	partnerCode := interbank.RoutingNumber(row.CounterpartyRoutingNumber)
+	if _, err := h.client.UpdateNegotiation(ctx, partnerCode, routing, id, offer); err != nil {
+		writeJSON(w, statusFromRemoteError(err), map[string]string{"message": fmt.Sprintf("partner PUT /negotiations failed: %v", err)})
+		return
+	}
+
+	if err := h.negRepo.UpdateTerms(
+		int(routing), id,
+		body.Amount,
+		body.PricePerUnit.Currency, body.PricePerUnit.Amount,
+		body.Premium.Currency, body.Premium.Amount,
+		body.SettlementDate,
+		int(caller.RoutingNumber), caller.ID,
+	); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("updating local negotiation: %v", err)})
+		return
+	}
+
+	row, err = h.negRepo.Get(int(routing), id)
+	if err != nil || row == nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "local negotiation disappeared after update"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"negotiation": negotiationRowToResponse(row),
+	})
+}
+
+// closeNegotiation tells the partner to close the negotiation, then
+// flips our local row to is_ongoing=false. Idempotent on already-closed
+// rows.
+func (h *InterbankOtcHTTPHandler) closeNegotiation(w http.ResponseWriter, r *http.Request, routing interbank.RoutingNumber, id string) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+	localID, ok := localParticipantIDFromClaims(claims)
+	if !ok {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "only client tokens can close interbank negotiations"})
+		return
+	}
+
+	row, err := h.negRepo.Get(int(routing), id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("loading negotiation: %v", err)})
+		return
+	}
+	if row == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "no such negotiation"})
+		return
+	}
+	if !localUserIsParty(row, localID) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "you are not a party to that negotiation"})
+		return
+	}
+
+	if row.IsOngoing {
+		ctx, cancel := context.WithTimeout(r.Context(), 20*time.Second)
+		defer cancel()
+		partnerCode := interbank.RoutingNumber(row.CounterpartyRoutingNumber)
+		if err := h.client.CloseNegotiation(ctx, partnerCode, routing, id); err != nil {
+			writeJSON(w, statusFromRemoteError(err), map[string]string{"message": fmt.Sprintf("partner DELETE /negotiations failed: %v", err)})
+			return
+		}
+		if err := h.negRepo.MarkClosed(int(routing), id); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("closing local negotiation: %v", err)})
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func negotiationRowToResponse(row *models.InterbankOtcNegotiation) map[string]interface{} {
+	return map[string]interface{}{
+		"negotiationRoutingNumber": row.NegotiationRoutingNumber,
+		"negotiationId":            row.NegotiationID,
+		"localRole":                row.LocalRole,
+		"counterpartyRoutingNumber": row.CounterpartyRoutingNumber,
+		"buyerId":                  map[string]interface{}{"routingNumber": row.BuyerRoutingNumber, "id": row.BuyerID},
+		"sellerId":                 map[string]interface{}{"routingNumber": row.SellerRoutingNumber, "id": row.SellerID},
+		"stock":                    map[string]string{"ticker": row.StockTicker},
+		"amount":                   row.Amount,
+		"pricePerUnit":             map[string]interface{}{"currency": row.PricePerUnitCurrency, "amount": row.PricePerUnitAmount},
+		"premium":                  map[string]interface{}{"currency": row.PremiumCurrency, "amount": row.PremiumAmount},
+		"settlementDate":           row.SettlementDate,
+		"lastModifiedBy":           map[string]interface{}{"routingNumber": row.LastModifiedByRoutingNumber, "id": row.LastModifiedByID},
+		"isOngoing":                row.IsOngoing,
+		"createdAt":                row.CreatedAt,
+		"updatedAt":                row.UpdatedAt,
+	}
+}
+
+// localParticipantIDFromClaims returns the local participant id we
+// encode into ForeignBankId.ID for a JWT-authenticated client caller.
+// Employee/bank tokens are rejected at this entry point — interbank
+// OTC is a client-initiated flow.
+func localParticipantIDFromClaims(claims *util.Claims) (string, bool) {
+	if claims.TokenSource != "client" || claims.ClientID == 0 {
+		return "", false
+	}
+	return interbank.EncodeLocalParticipantID(interbank.LocalParticipantClient, claims.ClientID), true
+}
+
+// localUserIsParty returns true if the encoded local id is the buyer
+// or seller on the local side of the negotiation row. The remote side
+// would carry the partner's opaque id and won't match.
+func localUserIsParty(row *models.InterbankOtcNegotiation, localID string) bool {
+	switch row.LocalRole {
+	case models.InterbankNegotiationRoleBuyer:
+		return row.BuyerID == localID
+	case models.InterbankNegotiationRoleSeller:
+		return row.SellerID == localID
+	default:
+		return false
+	}
+}
+
+func parseRoutingAndID(routingStr, id string) (interbank.RoutingNumber, string, bool) {
+	if strings.TrimSpace(routingStr) == "" || strings.TrimSpace(id) == "" {
+		return 0, "", false
+	}
+	n, err := strconv.Atoi(routingStr)
+	if err != nil {
+		return 0, "", false
+	}
+	return interbank.RoutingNumber(n), id, true
+}
+
+// statusFromRemoteError maps an interbank.RemoteError onto the
+// appropriate HTTP status code to bubble out to our frontend. We
+// preserve 4xx codes (partner is telling us our request was malformed
+// or unauthorized in their view) and collapse 5xx to 502 Bad Gateway.
+// Any non-RemoteError error becomes 502 too — that covers timeouts,
+// connection failures, etc.
+func statusFromRemoteError(err error) int {
+	var rerr *interbank.RemoteError
+	if errors.As(err, &rerr) {
+		if rerr.StatusCode >= 400 && rerr.StatusCode < 500 {
+			return rerr.StatusCode
+		}
+	}
+	return http.StatusBadGateway
+}

--- a/exchange-service/internal/handler/interbank_otc_http_handler.go
+++ b/exchange-service/internal/handler/interbank_otc_http_handler.go
@@ -27,10 +27,11 @@ import (
 // in package interbank; this handler is the JWT-authenticated face of
 // it for our own UI.
 type InterbankOtcHTTPHandler struct {
-	cfg      *config.Config
-	registry *interbank.Registry
-	client   *interbank.Client
-	negRepo  *repository.InterbankOtcRepository
+	cfg         *config.Config
+	registry    *interbank.Registry
+	client      *interbank.Client
+	negRepo     *repository.InterbankOtcRepository
+	negsHandler *interbank.NegotiationsHandler
 }
 
 func NewInterbankOtcHTTPHandler(
@@ -38,12 +39,14 @@ func NewInterbankOtcHTTPHandler(
 	registry *interbank.Registry,
 	client *interbank.Client,
 	negRepo *repository.InterbankOtcRepository,
+	negsHandler *interbank.NegotiationsHandler,
 ) *InterbankOtcHTTPHandler {
 	return &InterbankOtcHTTPHandler{
-		cfg:      cfg,
-		registry: registry,
-		client:   client,
-		negRepo:  negRepo,
+		cfg:         cfg,
+		registry:    registry,
+		client:      client,
+		negRepo:     negRepo,
+		negsHandler: negsHandler,
 	}
 }
 
@@ -88,6 +91,17 @@ func (h *InterbankOtcHTTPHandler) Routes(w http.ResponseWriter, r *http.Request)
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
+	case len(parts) == 4 && parts[0] == "negotiations" && parts[3] == "accept":
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		routing, id, ok := parseRoutingAndID(parts[1], parts[2])
+		if !ok {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "expected /negotiations/{routingNumber}/{id}/accept"})
+			return
+		}
+		h.acceptNegotiation(w, r, routing, id)
 	default:
 		http.NotFound(w, r)
 	}
@@ -540,6 +554,57 @@ func (h *InterbankOtcHTTPHandler) closeNegotiation(w http.ResponseWriter, r *htt
 		}
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// acceptNegotiation is the local-seller analogue of the partner-triggered
+// GET /negotiations/{r}/{id}/accept in package interbank. It validates
+// that the caller's local id matches the seller on the negotiation,
+// then asks NegotiationsHandler to run the same dispatch (close
+// locally, send NEW_TX, follow with COMMIT_TX on YES). The HTTP
+// response carries the buyer-bank's vote on success or a structured
+// error on dispatch / commit failure.
+func (h *InterbankOtcHTTPHandler) acceptNegotiation(w http.ResponseWriter, r *http.Request, routing interbank.RoutingNumber, id string) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+	localID, ok := localParticipantIDFromClaims(claims)
+	if !ok {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "only client tokens can accept interbank negotiations"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	outcome, statusCode, errMsg := h.negsHandler.AcceptForLocalSeller(ctx, routing, id, localID)
+	if statusCode != 0 {
+		writeJSON(w, statusCode, map[string]string{"message": errMsg})
+		return
+	}
+
+	switch {
+	case outcome.DispatchErr != nil:
+		writeJSON(w, http.StatusBadGateway, map[string]string{
+			"message": fmt.Sprintf("dispatching NEW_TX to buyer's bank failed: %v", outcome.DispatchErr),
+		})
+	case outcome.Vote != nil && outcome.Vote.Vote != interbank.VoteYes:
+		writeJSON(w, http.StatusConflict, map[string]interface{}{
+			"message": "buyer's bank refused the acceptance — negotiation has been reopened",
+			"vote":    outcome.Vote,
+		})
+	case outcome.CommitErr != nil:
+		writeJSON(w, http.StatusBadGateway, map[string]interface{}{
+			"message": fmt.Sprintf("buyer voted YES but COMMIT_TX failed; operator action required: %v", outcome.CommitErr),
+			"vote":    outcome.Vote,
+		})
+	default:
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"vote": outcome.Vote,
+		})
+	}
 }
 
 func negotiationRowToResponse(row *models.InterbankOtcNegotiation) map[string]interface{} {

--- a/exchange-service/internal/interbank/client.go
+++ b/exchange-service/internal/interbank/client.go
@@ -154,6 +154,119 @@ func (c *Client) SendRollbackTx(ctx context.Context, partnerCode RoutingNumber, 
 	return err
 }
 
+// FetchPublicStock GETs the partner's /public-stock list — the catalogue
+// of OTC sellers the partner is willing to expose to peer banks. Spec §3.4.
+func (c *Client) FetchPublicStock(ctx context.Context, partnerCode RoutingNumber) (PublicStocksResponse, error) {
+	var out PublicStocksResponse
+	if err := c.doJSON(ctx, partnerCode, http.MethodGet, "/public-stock", nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// CreateNegotiation POSTs an OtcOffer to the seller's bank /negotiations
+// and returns the seller-minted ForeignBankId for the new negotiation.
+// Spec §3.2 — buyer's bank initiates by POSTing here.
+func (c *Client) CreateNegotiation(ctx context.Context, partnerCode RoutingNumber, offer OtcOffer) (ForeignBankId, error) {
+	var out ForeignBankId
+	if err := c.doJSON(ctx, partnerCode, http.MethodPost, "/negotiations", offer, &out); err != nil {
+		return ForeignBankId{}, err
+	}
+	return out, nil
+}
+
+// GetNegotiation reads the partner's authoritative copy of a negotiation
+// at /negotiations/{routingNumber}/{id}. Spec §3.3.
+func (c *Client) GetNegotiation(ctx context.Context, partnerCode RoutingNumber, routing RoutingNumber, id string) (*OtcNegotiation, error) {
+	var out OtcNegotiation
+	path := fmt.Sprintf("/negotiations/%d/%s", int(routing), id)
+	if err := c.doJSON(ctx, partnerCode, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpdateNegotiation PUTs a counter-offer to the partner's
+// /negotiations/{routingNumber}/{id} and returns the partner's updated
+// view of the negotiation. Spec §3.3.
+func (c *Client) UpdateNegotiation(ctx context.Context, partnerCode RoutingNumber, routing RoutingNumber, id string, offer OtcOffer) (*OtcNegotiation, error) {
+	var out OtcNegotiation
+	path := fmt.Sprintf("/negotiations/%d/%s", int(routing), id)
+	if err := c.doJSON(ctx, partnerCode, http.MethodPut, path, offer, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CloseNegotiation DELETEs /negotiations/{routingNumber}/{id} on the
+// partner. The partner is expected to flip is_ongoing → false; we send
+// the same DELETE for both buyer-side and seller-side closes. Spec §3.3.
+func (c *Client) CloseNegotiation(ctx context.Context, partnerCode RoutingNumber, routing RoutingNumber, id string) error {
+	path := fmt.Sprintf("/negotiations/%d/%s", int(routing), id)
+	return c.doJSON(ctx, partnerCode, http.MethodDelete, path, nil, nil)
+}
+
+// doJSON is the plain-HTTP analogue of sendEnvelope used by the §3 OTC
+// REST surface. It does NOT poll 202 Accepted — those replies are only
+// defined for the /interbank envelope endpoint. 204 No Content is
+// accepted as a successful empty response.
+func (c *Client) doJSON(ctx context.Context, partnerCode RoutingNumber, method, path string, in any, out any) error {
+	partner := c.registry.Lookup(partnerCode)
+	if partner == nil {
+		return fmt.Errorf("%w: %d", ErrNoSuchPartner, partnerCode)
+	}
+
+	var bodyReader io.Reader
+	if in != nil {
+		raw, err := json.Marshal(in)
+		if err != nil {
+			return fmt.Errorf("interbank: marshalling %s %s body: %w", method, path, err)
+		}
+		bodyReader = bytes.NewReader(raw)
+	}
+
+	endpoint := partner.BaseURL + path
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bodyReader)
+	if err != nil {
+		return fmt.Errorf("interbank: building %s %s request: %w", method, endpoint, err)
+	}
+	if in != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set(HeaderAPIKey, partner.OutboundKey)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("interbank: %s %s: %w", method, endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return fmt.Errorf("interbank: reading response body from %s %s: %w", method, endpoint, readErr)
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusNoContent:
+		return nil
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		if out == nil || len(respBody) == 0 {
+			return nil
+		}
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("interbank: decoding %s %s response: %w", method, endpoint, err)
+		}
+		return nil
+	default:
+		return &RemoteError{
+			StatusCode: resp.StatusCode,
+			Status:     resp.Status,
+			Body:       respBody,
+		}
+	}
+}
+
 // sendEnvelope is the workhorse: serialises the envelope, POSTs to
 // {partner.BaseURL}/interbank with the partner's OutboundKey, and
 // retries the SAME request (same idempotence key, same body) while the

--- a/exchange-service/internal/interbank/negotiations_accept.go
+++ b/exchange-service/internal/interbank/negotiations_accept.go
@@ -1,6 +1,7 @@
 package interbank
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -10,16 +11,37 @@ import (
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
 )
 
-// accept handles GET /negotiations/{routingNumber}/{id}/accept.
-// Per spec §3.6 this is a GET that mutates state — accepting an
-// open negotiation closes it and triggers an outbound NEW_TX from
-// the seller's bank to the buyer's bank carrying the four postings
-// that move the premium and create the option contract.
+// AcceptOutcome is the structured result of a runAcceptDispatch call.
+// It lets the two HTTP entry points (partner-triggered /accept and the
+// local-frontend POST /api/v1/interbank-otc/.../accept) translate the
+// same dispatch outcome into their own response conventions.
+type AcceptOutcome struct {
+	// Vote is the buyer-bank's response to NEW_TX, or nil if NEW_TX
+	// never got a reply (transport failure). On Vote=NO and on
+	// transport failure the negotiation has been reopened.
+	Vote *TransactionVote
+
+	// DispatchErr is non-nil when NEW_TX itself failed (network, 5xx,
+	// 202-poll timeout). The negotiation has been reopened.
+	DispatchErr error
+
+	// CommitErr is non-nil when NEW_TX returned YES but the follow-up
+	// COMMIT_TX failed. The negotiation stays closed — operator
+	// action is required (the buyer's bank has already promised to
+	// hold the resources for our YES vote).
+	CommitErr error
+}
+
+// accept handles GET /negotiations/{routingNumber}/{id}/accept (the
+// partner-triggered entry point). Per spec §3.6 this is a GET that
+// mutates state — accepting an open negotiation closes it and triggers
+// an outbound NEW_TX from the seller's bank to the buyer's bank
+// carrying the four postings that move the premium and create the
+// option contract.
 //
-// Only the seller's bank can accept (this mirrors the existing
-// local OTC-5 rule). Both NEW_TX and a follow-up COMMIT_TX are
-// dispatched here; on a NO vote we send ROLLBACK_TX and reopen
-// the negotiation so the participants can keep haggling.
+// Only the seller's bank can accept (mirrors the local OTC-5 rule).
+// Authz here checks the calling partner; the actual dispatch logic
+// is shared with AcceptForLocalSeller via runAcceptDispatch.
 func (h *NegotiationsHandler) accept(w http.ResponseWriter, r *http.Request, routing RoutingNumber, id string) {
 	partner := PartnerFromContext(r.Context())
 	if partner == nil {
@@ -50,55 +72,110 @@ func (h *NegotiationsHandler) accept(w http.ResponseWriter, r *http.Request, rou
 		return
 	}
 
-	// Close locally first so a concurrent second accept can't double-spend.
-	if err := h.repo.MarkClosed(int(routing), id); err != nil {
-		writeProblemJSON(w, http.StatusInternalServerError, fmt.Sprintf("closing negotiation: %v", err))
-		return
+	outcome := h.runAcceptDispatch(r.Context(), neg)
+	switch {
+	case outcome.DispatchErr != nil:
+		writeProblemJSON(w, http.StatusBadGateway, fmt.Sprintf("dispatching NEW_TX: %v", outcome.DispatchErr))
+	case outcome.Vote != nil && outcome.Vote.Vote != VoteYes:
+		writeJSON(w, http.StatusConflict, outcome.Vote)
+	case outcome.CommitErr != nil:
+		writeProblemJSON(w, http.StatusBadGateway,
+			fmt.Sprintf("buyer voted YES but COMMIT_TX failed; operator action required: %v", outcome.CommitErr))
+	default:
+		writeJSON(w, http.StatusOK, outcome.Vote)
+	}
+}
+
+// AcceptForLocalSeller is the local-frontend analogue of accept(). It
+// validates that the caller's local seller id matches the negotiation
+// and that the negotiation is in a state to be accepted, then runs the
+// same dispatch as the partner-triggered path.
+//
+// statusCode > 0 means a precondition failed and the dispatch was not
+// run; the caller should return that status with errMsg as the body.
+// statusCode == 0 means dispatch ran and outcome carries the result.
+func (h *NegotiationsHandler) AcceptForLocalSeller(
+	ctx context.Context,
+	routing RoutingNumber,
+	id string,
+	localSellerID string,
+) (outcome AcceptOutcome, statusCode int, errMsg string) {
+	neg, err := h.repo.Get(int(routing), id)
+	if err != nil {
+		return AcceptOutcome{}, http.StatusInternalServerError, fmt.Sprintf("loading negotiation: %v", err)
+	}
+	if neg == nil {
+		return AcceptOutcome{}, http.StatusNotFound, "no such negotiation"
+	}
+	if neg.LocalRole != models.InterbankNegotiationRoleSeller {
+		return AcceptOutcome{}, http.StatusForbidden,
+			"only the local seller may accept — for buyer-side acceptance, the seller's bank must trigger the accept"
+	}
+	if neg.SellerID != localSellerID {
+		return AcceptOutcome{}, http.StatusForbidden, "you are not the seller on that negotiation"
+	}
+	if !neg.IsOngoing {
+		return AcceptOutcome{}, http.StatusConflict, "negotiation is no longer ongoing"
+	}
+
+	return h.runAcceptDispatch(ctx, neg), 0, ""
+}
+
+// runAcceptDispatch performs the close-and-dispatch sequence shared by
+// the two accept entry points. Preconditions checked by the caller:
+//   - neg loaded and IsOngoing == true
+//   - neg.LocalRole == seller
+//   - operator (partner or local user) is authorised to accept
+//
+// On NEW_TX transport failure or a NO vote, the negotiation is
+// reopened so participants can resume haggling. On a YES vote followed
+// by a COMMIT_TX failure the negotiation stays closed — the buyer's
+// bank has already promised to hold the resources for our YES vote,
+// so reopening would risk double-spend.
+func (h *NegotiationsHandler) runAcceptDispatch(ctx context.Context, neg *models.InterbankOtcNegotiation) AcceptOutcome {
+	// Close locally first so a concurrent second accept can't
+	// double-dispatch.
+	if err := h.repo.MarkClosed(neg.NegotiationRoutingNumber, neg.NegotiationID); err != nil {
+		return AcceptOutcome{DispatchErr: fmt.Errorf("closing negotiation: %w", err)}
 	}
 
 	tx := buildOptionAcceptanceTx(h.registry.OwnRoutingNumber(), neg)
-
 	txKey := h.client.NewIdempotenceKey()
 	buyerCode := RoutingNumber(neg.BuyerRoutingNumber)
 
-	vote, err := h.client.SendNewTx(r.Context(), buyerCode, txKey, &tx)
+	vote, err := h.client.SendNewTx(ctx, buyerCode, txKey, &tx)
 	if err != nil {
-		// Network or partner error — reopen the negotiation so the
-		// seller can decide whether to retry from the UI.
-		slog.Error("interbank: NEW_TX dispatch failed during /accept",
-			"err", err, "negotiation", id, "buyer", buyerCode)
-		h.reopenAfterDispatchFailure(int(routing), id, neg.LastModifiedByRoutingNumber, neg.LastModifiedByID)
-		writeProblemJSON(w, http.StatusBadGateway, fmt.Sprintf("dispatching NEW_TX: %v", err))
-		return
+		slog.Error("interbank: NEW_TX dispatch failed during accept",
+			"err", err, "negotiation", neg.NegotiationID, "buyer", buyerCode)
+		h.reopenAfterDispatchFailure(neg.NegotiationRoutingNumber, neg.NegotiationID,
+			neg.LastModifiedByRoutingNumber, neg.LastModifiedByID)
+		return AcceptOutcome{DispatchErr: err}
 	}
 
 	if vote.Vote != VoteYes {
-		// Buyer's bank refused — the negotiation should reopen so the
-		// participants can keep going. We don't send ROLLBACK_TX
-		// because NEW_TX with vote=NO is itself the rollback; the
-		// buyer's bank holds no resources after a NO.
-		slog.Info("interbank: NEW_TX received NO vote during /accept",
-			"negotiation", id, "buyer", buyerCode, "reasons", vote.Reasons)
-		h.reopenAfterDispatchFailure(int(routing), id, neg.LastModifiedByRoutingNumber, neg.LastModifiedByID)
-		writeJSON(w, http.StatusConflict, vote)
-		return
+		// Buyer's bank refused — we don't send ROLLBACK_TX because
+		// NEW_TX with vote=NO is itself the rollback; the buyer's
+		// bank holds no resources after a NO. Reopen so participants
+		// can keep going.
+		slog.Info("interbank: NEW_TX received NO vote during accept",
+			"negotiation", neg.NegotiationID, "buyer", buyerCode, "reasons", vote.Reasons)
+		h.reopenAfterDispatchFailure(neg.NegotiationRoutingNumber, neg.NegotiationID,
+			neg.LastModifiedByRoutingNumber, neg.LastModifiedByID)
+		return AcceptOutcome{Vote: vote}
 	}
 
-	// YES vote — commit. If COMMIT_TX itself fails after retries,
-	// we surface the error but leave the negotiation closed: the
-	// buyer's bank has already voted to hold the resources, so the
-	// resolution is operator-driven (CHECK_STATUS / replay), not
-	// reopening the negotiation.
+	// YES vote — commit. If COMMIT_TX itself fails after retries we
+	// leave the negotiation closed; the buyer's bank has already
+	// voted to hold the resources, so resolution is operator-driven
+	// (CHECK_STATUS / replay), not reopening the negotiation.
 	commitKey := h.client.NewIdempotenceKey()
-	if err := h.client.SendCommitTx(r.Context(), buyerCode, commitKey, tx.TransactionID); err != nil {
+	if err := h.client.SendCommitTx(ctx, buyerCode, commitKey, tx.TransactionID); err != nil {
 		slog.Error("interbank: COMMIT_TX dispatch failed after YES vote",
-			"err", err, "negotiation", id, "transaction", tx.TransactionID.ID, "buyer", buyerCode)
-		writeProblemJSON(w, http.StatusBadGateway,
-			fmt.Sprintf("buyer voted YES but COMMIT_TX failed; operator action required: %v", err))
-		return
+			"err", err, "negotiation", neg.NegotiationID, "transaction", tx.TransactionID.ID, "buyer", buyerCode)
+		return AcceptOutcome{Vote: vote, CommitErr: err}
 	}
 
-	writeJSON(w, http.StatusOK, vote)
+	return AcceptOutcome{Vote: vote}
 }
 
 // buildOptionAcceptanceTx builds the protocol Transaction that
@@ -170,9 +247,6 @@ func buildOptionAcceptanceTx(ownRouting RoutingNumber, neg *models.InterbankOtcN
 // prior offer state — the most recent terms stay on record, just
 // re-marked open.
 func (h *NegotiationsHandler) reopenAfterDispatchFailure(routing int, id string, lastModRouting int, lastModID string) {
-	// Reuse UpdateTerms to bump updated_at; the LastModifiedBy lands back
-	// on whoever it was before so the wire copy looks unchanged from
-	// the participants' perspective.
 	if err := h.repo.MarkOngoing(routing, id, lastModRouting, lastModID); err != nil {
 		slog.Error("interbank: reopening negotiation after dispatch failure",
 			"err", err, "negotiation", id)


### PR DESCRIPTION
Closes #204. **Stacks on #203** — merge #203 first to make this diff collapse to just the new commit.

## Summary

- Refactor `internal/interbank/negotiations_accept.go`: extract the close-and-dispatch sequence into `runAcceptDispatch` + `AcceptOutcome`. Partner-triggered `accept()` HTTP handler keeps identical wire behavior.
- Add `AcceptForLocalSeller(ctx, routing, id, localSellerID)` exported method on `*interbank.NegotiationsHandler` — validates local-seller authz and runs the shared dispatch.
- Add `POST /api/v1/interbank-otc/negotiations/{routing}/{id}/accept` to `InterbankOtcHTTPHandler`.

## Wire semantics (mirrors partner-triggered /accept)

| Outcome | HTTP status | Negotiation state |
|---|---|---|
| YES vote → COMMIT_TX OK | 200 OK | Closed |
| NO vote | 409 Conflict | Reopened |
| NEW_TX transport failure | 502 Bad Gateway | Reopened |
| YES vote → COMMIT_TX failure | 502 Bad Gateway | Stays closed (operator action) |
| Precondition failure (not found / not ongoing / not the seller) | 403/404/409 | Unchanged |

## Test plan

- [ ] `go build ./...` clean (verified locally).
- [ ] Local seller user POSTs `.../accept` on a negotiation a partner pushed to us → partner gets NEW_TX → on YES, local row flips to closed, partner stores the option.
- [ ] Partner-triggered GET `/negotiations/.../accept` still works identically (no regressions).
- [ ] Non-seller calling the local accept route gets 403.
- [ ] Already-closed negotiation returns 409.

## Out of scope (still deferred)

- Buyer-wallet cash reservation.
- Cross-bank option exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)