### PR TITLE
feat(exchange): sprint 9 cross-bank payments, reconciliation, public-…

### DIFF
--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -86,13 +86,23 @@ func main() {
 	ibPendingRepo := repository.NewInterbankPendingTxRepository(db)
 	ibOptionContractRepo := repository.NewInterbankOptionContractRepository(db)
 	ibWalletRepo := repository.NewInterbankWalletRepository(db)
+	ibPaymentRepo := repository.NewInterbankPaymentRepository(db)
+	ibPaymentWalletRepo := repository.NewInterbankPaymentWalletRepository(db)
 	ibClient := interbank.NewClient(ibRegistry)
-	ibTxProcessor := interbank.NewOtcTxProcessor(db, ibRegistry, ibNegRepo, ibPendingRepo, ibOptionContractRepo, ibWalletRepo)
-	ibServer := interbank.NewServer(ibRegistry, ibInboundRepo, ibTxProcessor)
+	ibExerciseRepo := repository.NewInterbankExerciseRepository(db)
+	ibOtcProcessor := interbank.NewOtcTxProcessor(db, ibRegistry, ibNegRepo, ibPendingRepo, ibOptionContractRepo, ibWalletRepo)
+	ibPaymentProcessor := interbank.NewPaymentTxProcessor(db, ibRegistry, ibPaymentRepo, ibPaymentWalletRepo)
+	ibExerciseProcessor := interbank.NewExerciseTxProcessor(db, ibRegistry, ibNegRepo, ibExerciseRepo, portfolioRepo, marketRepo, ibWalletRepo)
+	ibDispatchProcessor := interbank.NewDispatchTxProcessor(ibOtcProcessor, ibPaymentProcessor, ibExerciseProcessor, ibPaymentRepo, ibPendingRepo, ibExerciseRepo)
+	ibServer := interbank.NewServer(ibRegistry, ibInboundRepo, ibDispatchProcessor)
 	ibOtcH := interbank.NewOTCHandler(ibRegistry, portfolioRepo, interbank.StubDisplayNameResolver{})
 	ibNegH := interbank.NewNegotiationsHandler(ibRegistry, ibNegRepo, ibClient, db, ibWalletRepo)
 
-	cronScheduler := service.StartCronJobs(db, portfolioSvc, rateProvider, sagaRetryRunner, fundSvc)
+	ibReconcile := service.NewInterbankReconcileRunner(db, ibRegistry, ibClient, ibPaymentRepo, ibPaymentWalletRepo)
+	ibPublicStockRepo := repository.NewRemotePublicStockRepository(db)
+	ibPublicStockCache := service.NewPublicStockCacheRunner(ibRegistry, ibClient, ibPublicStockRepo)
+
+	cronScheduler := service.StartCronJobs(db, portfolioSvc, rateProvider, sagaRetryRunner, fundSvc, ibReconcile, ibPublicStockCache)
 
 	go func() {
 		slog.Info("Running market data seed in background...")
@@ -118,7 +128,11 @@ func main() {
 
 	fundH := handler.NewFundHTTPHandler(cfg, fundSvc)
 
-	ibOtcLocalH := handler.NewInterbankOtcHTTPHandler(cfg, ibRegistry, ibClient, ibNegRepo, ibNegH)
+	ibOtcLocalH := handler.NewInterbankOtcHTTPHandler(
+		cfg, ibRegistry, ibClient, ibNegRepo, ibNegH, ibPublicStockRepo,
+		ibOptionContractRepo, ibExerciseRepo, ibWalletRepo, portfolioRepo, marketRepo, db,
+	)
+	ibPaymentLocalH := handler.NewInterbankPaymentHTTPHandler(cfg, ibRegistry, ibClient, ibPaymentRepo, ibPaymentWalletRepo, db)
 
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
@@ -169,6 +183,8 @@ func main() {
 	httpMux.Handle("/api/v1/funds", middleware.CORS(http.HandlerFunc(fundH.FundRoutes)))
 	httpMux.Handle("/api/v1/funds/", middleware.CORS(http.HandlerFunc(fundH.FundRoutes)))
 	httpMux.Handle("/api/v1/interbank-otc/", middleware.CORS(http.HandlerFunc(ibOtcLocalH.Routes)))
+	httpMux.Handle("/api/v1/payments/cross-bank", middleware.CORS(http.HandlerFunc(ibPaymentLocalH.Routes)))
+	httpMux.Handle("/api/v1/payments/cross-bank/", middleware.CORS(http.HandlerFunc(ibPaymentLocalH.Routes)))
 	// Inter-bank wire endpoint — partner-bank traffic, no CORS, X-Api-Key auth.
 	httpMux.Handle("/interbank", ibServer)
 	httpMux.Handle("/public-stock", interbank.AuthMiddleware(ibRegistry, http.HandlerFunc(ibOtcH.PublicStock)))

--- a/exchange-service/internal/database/database.go
+++ b/exchange-service/internal/database/database.go
@@ -55,6 +55,9 @@ func Migrate(db *gorm.DB) error {
 		&models.InterbankOtcNegotiation{},
 		&models.InterbankPendingTx{},
 		&models.InterbankOptionContract{},
+		&models.InterbankPayment{},
+		&models.RemotePublicStockSnapshot{},
+		&models.InterbankPendingExercise{},
 	); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}

--- a/exchange-service/internal/handler/interbank_exercise_http_handler.go
+++ b/exchange-service/internal/handler/interbank_exercise_http_handler.go
@@ -1,0 +1,498 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// listOptionContracts returns the caller's cross-bank option contracts.
+// We only persist InterbankOptionContract rows on the BUYER side (the
+// seller has the underlying portfolio holding instead), so this list
+// is implicitly "options I bought from a partner bank".
+func (h *InterbankOtcHTTPHandler) listOptionContracts(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+	localID, ok := localParticipantIDFromClaims(claims)
+	if !ok {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "only client tokens can list interbank option contracts"})
+		return
+	}
+	rows, err := h.contractRepo.ListByBuyerLocalID(localID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("listing option contracts: %v", err)})
+		return
+	}
+	items := make([]map[string]interface{}, 0, len(rows))
+	for i := range rows {
+		items = append(items, optionContractRowToResponse(&rows[i]))
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"contracts": items,
+		"count":     len(items),
+	})
+}
+
+func (h *InterbankOtcHTTPHandler) getOptionContract(w http.ResponseWriter, r *http.Request, id uint) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+	localID, ok := localParticipantIDFromClaims(claims)
+	if !ok {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "only client tokens can read interbank option contracts"})
+		return
+	}
+	row, err := h.contractRepo.GetByID(id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("loading contract: %v", err)})
+		return
+	}
+	if row == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "no such contract"})
+		return
+	}
+	if row.BuyerLocalID != localID {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "you do not own that contract"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"contract": optionContractRowToResponse(row),
+	})
+}
+
+// exerciseOptionContract is the buyer-side initiator for cross-bank
+// option exercise (protocol §2.7.2). The flow:
+//
+//  1. Load the local InterbankOptionContract, verify ownership, status,
+//     and that the settlement window hasn't passed (mirror of the
+//     buyer-bank validation that the partner will also enforce).
+//  2. Build the 4-posting NEW_TX (OPTION pseudo + PERSON buyer; MONAS +
+//     STOCK assets). The OPTION pseudo lives at the seller's bank.
+//  3. In a single DB tx: reserve the buyer's strike-price cash and
+//     persist InterbankPendingExercise (direction=outbound).
+//  4. Send NEW_TX to the seller's bank. Apply the response:
+//     YES → debit cash, add stock holding, mark contract exercised,
+//     mark pending row committed; then send COMMIT_TX.
+//     NO  → release cash, mark pending rejected.
+//     err → release cash, mark pending failed; best-effort ROLLBACK_TX.
+func (h *InterbankOtcHTTPHandler) exerciseOptionContract(w http.ResponseWriter, r *http.Request, contractID uint) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+	localID, ok := localParticipantIDFromClaims(claims)
+	if !ok {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "only client tokens can exercise interbank option contracts"})
+		return
+	}
+
+	contract, err := h.contractRepo.GetByID(contractID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("loading contract: %v", err)})
+		return
+	}
+	if contract == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "no such contract"})
+		return
+	}
+	if contract.BuyerLocalID != localID {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "you do not own that contract"})
+		return
+	}
+	if contract.Status != models.InterbankOptionContractStatusValid {
+		writeJSON(w, http.StatusConflict, map[string]string{"message": fmt.Sprintf("contract status %q, cannot exercise", contract.Status)})
+		return
+	}
+	if exp, parsed := parseContractSettlement(contract.SettlementDate); parsed {
+		if time.Now().UTC().After(exp.Add(24 * time.Hour)) {
+			writeJSON(w, http.StatusConflict, map[string]string{"message": "contract settlement window has passed"})
+			return
+		}
+	}
+
+	// Look up the asset by ticker. Required for the buyer-side
+	// portfolio holding upsert on COMMIT.
+	listing, err := h.marketRepo.GetListingRecordByTicker(contract.StockTicker)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": fmt.Sprintf("unknown asset ticker %q: %v", contract.StockTicker, err)})
+		return
+	}
+
+	cashAmount := contract.PricePerUnitAmount * contract.Amount
+
+	ownRouting := h.registry.OwnRoutingNumber()
+	txID := interbank.ForeignBankId{RoutingNumber: ownRouting, ID: uuid.NewString()}
+	sellerRouting := interbank.RoutingNumber(contract.SellerRoutingNumber)
+
+	// Phase 1: reserve cash locally + persist outbound pending row.
+	var (
+		pendingRow     *models.InterbankPendingExercise
+		buyerAccountID uint
+	)
+	prepareErr := h.db.Transaction(func(dbtx *gorm.DB) error {
+		accID, lookupErr := h.walletRepo.LookupClientAccountID(dbtx, localID, contract.PricePerUnitCurrency)
+		if errors.Is(lookupErr, repository.ErrInterbankWalletInsufficient) {
+			return preparePaymentErr{
+				status: http.StatusUnprocessableEntity,
+				msg:    fmt.Sprintf("no active %s account on your profile to debit the strike price from", contract.PricePerUnitCurrency),
+			}
+		}
+		if lookupErr != nil {
+			return lookupErr
+		}
+		if err := h.walletRepo.Reserve(dbtx, localID, contract.PricePerUnitCurrency, cashAmount); err != nil {
+			if errors.Is(err, repository.ErrInterbankWalletInsufficient) {
+				return preparePaymentErr{
+					status: http.StatusUnprocessableEntity,
+					msg:    fmt.Sprintf("insufficient available balance to cover strike price %.2f %s", cashAmount, contract.PricePerUnitCurrency),
+				}
+			}
+			return err
+		}
+		buyerAccountID = accID
+		clientID := claims.ClientID
+		ctrID := contract.ID
+		row := &models.InterbankPendingExercise{
+			TxRoutingNumber:          int(txID.RoutingNumber),
+			TxID:                     txID.ID,
+			Direction:                models.InterbankExerciseDirectionOutbound,
+			PartnerRoutingNumber:     int(sellerRouting),
+			NegotiationRoutingNumber: contract.NegotiationRoutingNumber,
+			NegotiationID:            contract.NegotiationID,
+			StockTicker:              contract.StockTicker,
+			StockAmount:              contract.Amount,
+			PricePerUnitCurrency:     contract.PricePerUnitCurrency,
+			PricePerUnitAmount:       contract.PricePerUnitAmount,
+			CashAmount:               cashAmount,
+			BuyerRoutingNumber:       int(ownRouting),
+			BuyerID:                  localID,
+			SellerRoutingNumber:      contract.SellerRoutingNumber,
+			SellerID:                 contract.SellerID,
+			BuyerLocalAccountID:      &buyerAccountID,
+			BuyerLocalClientID:       &clientID,
+			OptionContractID:         &ctrID,
+			Status:                   models.InterbankExerciseStatusPending,
+			CreatedAt:                time.Now().UTC(),
+		}
+		if err := h.exerciseRepo.CreateTx(dbtx, row); err != nil {
+			return err
+		}
+		pendingRow = row
+		return nil
+	})
+	if prepareErr != nil {
+		var pe preparePaymentErr
+		if errors.As(prepareErr, &pe) {
+			writeJSON(w, pe.status, map[string]string{"message": pe.msg})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("preparing exercise: %v", prepareErr)})
+		return
+	}
+
+	// Phase 2 — NEW_TX outbound.
+	tx := buildExerciseTx(txID, contract, ownRouting, cashAmount)
+	idemKey := h.client.NewIdempotenceKey()
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+
+	vote, dispatchErr := h.client.SendNewTx(ctx, sellerRouting, idemKey, &tx)
+	if dispatchErr != nil {
+		h.finaliseExerciseTransportFailure(pendingRow, contract, sellerRouting, dispatchErr)
+		writeJSON(w, http.StatusBadGateway, map[string]interface{}{
+			"message":    fmt.Sprintf("dispatching NEW_TX to seller's bank failed: %v", dispatchErr),
+			"exerciseId": pendingRow.ID,
+			"status":     models.InterbankExerciseStatusFailed,
+		})
+		return
+	}
+	if vote.Vote != interbank.VoteYes {
+		reason := summariseNoVote(vote)
+		if err := h.finaliseExerciseRejected(pendingRow, contract, reason); err != nil {
+			slog.Error("interbank: exercise rejection finalise failed",
+				"err", err, "exercise_id", pendingRow.ID)
+		}
+		writeJSON(w, http.StatusConflict, map[string]interface{}{
+			"message":    "seller's bank refused the exercise",
+			"exerciseId": pendingRow.ID,
+			"status":     models.InterbankExerciseStatusRejected,
+			"vote":       vote,
+		})
+		return
+	}
+
+	// YES — apply local commit: debit cash, add stock holding, mark
+	// contract exercised, CAS pending row committed. Then send
+	// COMMIT_TX. A local commit failure leaves the row in pending
+	// for the reconciliation cron to retry (future work).
+	if err := h.finaliseExerciseCommit(pendingRow, contract, listing.ID, buyerAccountID, claims.ClientID); err != nil {
+		slog.Error("interbank: exercise local commit failed after YES vote",
+			"err", err, "exercise_id", pendingRow.ID)
+		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+			"message":    fmt.Sprintf("seller's bank voted YES but local commit failed: %v", err),
+			"exerciseId": pendingRow.ID,
+		})
+		return
+	}
+
+	commitKey := h.client.NewIdempotenceKey()
+	if err := h.client.SendCommitTx(ctx, sellerRouting, commitKey, txID); err != nil {
+		slog.Warn("interbank: exercise COMMIT_TX dispatch failed after local commit",
+			"err", err, "exercise_id", pendingRow.ID, "tx_id", txID.ID)
+		writeJSON(w, http.StatusAccepted, map[string]interface{}{
+			"message":    fmt.Sprintf("local commit succeeded but COMMIT_TX dispatch failed; partner will reconcile: %v", err),
+			"exerciseId": pendingRow.ID,
+			"status":     models.InterbankExerciseStatusCommitted,
+		})
+		return
+	}
+	h.markExerciseCommitDispatched(pendingRow)
+
+	writeJSON(w, http.StatusCreated, map[string]interface{}{
+		"exerciseId": pendingRow.ID,
+		"status":     models.InterbankExerciseStatusCommitted,
+		"contract":   optionContractRowToResponse(contract),
+	})
+}
+
+// finaliseExerciseCommit applies the buyer-side local effects after a
+// YES vote: cash debit, portfolio holding upsert, contract status flip,
+// pending row CAS. All four land in one DB transaction.
+func (h *InterbankOtcHTTPHandler) finaliseExerciseCommit(
+	row *models.InterbankPendingExercise,
+	contract *models.InterbankOptionContract,
+	assetID, buyerAccountID, clientID uint,
+) error {
+	err := h.db.Transaction(func(dbtx *gorm.DB) error {
+		rows, err := h.exerciseRepo.MarkCommittedCAS(dbtx, row.TxRoutingNumber, row.TxID)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return nil
+		}
+
+		// Debit the strike-price cash.
+		if err := h.walletRepo.Debit(dbtx, row.BuyerID, row.PricePerUnitCurrency, row.CashAmount); err != nil {
+			return fmt.Errorf("debiting buyer cash: %w", err)
+		}
+
+		// Add the stocks to the buyer's portfolio. RecordBuyFill
+		// handles weighted-average update if a holding already
+		// exists for this asset.
+		if err := upsertBuyerStockHolding(dbtx, clientID, assetID, buyerAccountID, row.StockAmount, row.PricePerUnitAmount); err != nil {
+			return fmt.Errorf("recording stock fill: %w", err)
+		}
+
+		// Flip the contract to exercised.
+		if _, err := h.contractRepo.MarkExercisedCAS(dbtx, contract.ID); err != nil {
+			return fmt.Errorf("marking contract exercised: %w", err)
+		}
+		row.Status = models.InterbankExerciseStatusCommitted
+		contract.Status = models.InterbankOptionContractStatusExercised
+		return nil
+	})
+	return err
+}
+
+// finaliseExerciseRejected releases the cash reservation, marks the
+// row rejected, and stamps partner_finalised_at (no terminal partner
+// message owed — partner voted NO and holds no resources).
+func (h *InterbankOtcHTTPHandler) finaliseExerciseRejected(row *models.InterbankPendingExercise, _ *models.InterbankOptionContract, reason string) error {
+	return h.db.Transaction(func(dbtx *gorm.DB) error {
+		rows, err := h.exerciseRepo.MarkRejectedCAS(dbtx, row.TxRoutingNumber, row.TxID, reason)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return nil
+		}
+		if _, err := h.exerciseRepo.MarkPartnerFinalised(dbtx, row.TxRoutingNumber, row.TxID); err != nil {
+			return err
+		}
+		row.Status = models.InterbankExerciseStatusRejected
+		row.LastError = reason
+		return h.walletRepo.Release(dbtx, row.BuyerID, row.PricePerUnitCurrency, row.CashAmount)
+	})
+}
+
+// finaliseExerciseTransportFailure releases the cash reservation and
+// marks failed, then best-effort sends ROLLBACK_TX so the partner can
+// drop any partial state.
+func (h *InterbankOtcHTTPHandler) finaliseExerciseTransportFailure(row *models.InterbankPendingExercise, _ *models.InterbankOptionContract, sellerRouting interbank.RoutingNumber, dispatchErr error) {
+	txErr := h.db.Transaction(func(dbtx *gorm.DB) error {
+		rows, err := h.exerciseRepo.MarkFailedCAS(dbtx, row.TxRoutingNumber, row.TxID, dispatchErr.Error())
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return nil
+		}
+		row.Status = models.InterbankExerciseStatusFailed
+		row.LastError = dispatchErr.Error()
+		return h.walletRepo.Release(dbtx, row.BuyerID, row.PricePerUnitCurrency, row.CashAmount)
+	})
+	if txErr != nil {
+		slog.Error("interbank: exercise transport-failure finalise failed",
+			"err", txErr, "exercise_id", row.ID)
+		return
+	}
+
+	rollbackCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	rbKey := h.client.NewIdempotenceKey()
+	txID := interbank.ForeignBankId{
+		RoutingNumber: interbank.RoutingNumber(row.TxRoutingNumber),
+		ID:            row.TxID,
+	}
+	if err := h.client.SendRollbackTx(rollbackCtx, sellerRouting, rbKey, txID); err != nil {
+		slog.Warn("interbank: best-effort ROLLBACK_TX failed after exercise transport failure",
+			"err", err, "exercise_id", row.ID)
+		return
+	}
+	if err := h.db.Transaction(func(dbtx *gorm.DB) error {
+		_, mErr := h.exerciseRepo.MarkPartnerFinalised(dbtx, row.TxRoutingNumber, row.TxID)
+		return mErr
+	}); err != nil {
+		slog.Warn("interbank: failed to stamp exercise partner_finalised_at after ROLLBACK_TX",
+			"err", err, "exercise_id", row.ID)
+	}
+}
+
+func (h *InterbankOtcHTTPHandler) markExerciseCommitDispatched(row *models.InterbankPendingExercise) {
+	if err := h.db.Transaction(func(dbtx *gorm.DB) error {
+		_, mErr := h.exerciseRepo.MarkPartnerFinalised(dbtx, row.TxRoutingNumber, row.TxID)
+		return mErr
+	}); err != nil {
+		slog.Warn("interbank: failed to stamp exercise partner_finalised_at after COMMIT_TX",
+			"err", err, "exercise_id", row.ID)
+	}
+}
+
+// upsertBuyerStockHolding adds the buyer's newly-acquired stocks to
+// their local portfolio at the strike price. Delegates to the existing
+// portfolio repo's tx-aware helper so the buy-fill update lands inside
+// the caller's transaction.
+func upsertBuyerStockHolding(tx *gorm.DB, clientID, assetID, accountID uint, qty, price float64) error {
+	now := time.Now().UTC()
+	var h models.PortfolioHoldingRecord
+	err := tx.Where("user_id = ? AND user_type = ? AND asset_id = ?", clientID, "client", assetID).
+		First(&h).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		h = models.PortfolioHoldingRecord{
+			UserID:      clientID,
+			UserType:    "client",
+			AssetID:     assetID,
+			AccountID:   accountID,
+			Quantity:    qty,
+			AvgBuyPrice: price,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		return tx.Create(&h).Error
+	}
+	if err != nil {
+		return err
+	}
+	newQty := h.Quantity + qty
+	newAvg := (h.Quantity*h.AvgBuyPrice + qty*price) / newQty
+	return tx.Model(&h).Updates(map[string]interface{}{
+		"quantity":      newQty,
+		"avg_buy_price": newAvg,
+		"updated_at":    now,
+	}).Error
+}
+
+// buildExerciseTx assembles the 4-posting OPTION-execution NEW_TX per
+// protocol §2.7.2. The OPTION pseudo-account is at the seller's bank;
+// the PERSON account is the buyer in our bank.
+func buildExerciseTx(txID interbank.ForeignBankId, contract *models.InterbankOptionContract, ownRouting interbank.RoutingNumber, cashAmount float64) interbank.Transaction {
+	monas := interbank.Asset{
+		Type:  interbank.AssetMonas,
+		Monas: &interbank.MonetaryAsset{Currency: interbank.CurrencyCode(contract.PricePerUnitCurrency)},
+	}
+	stock := interbank.Asset{
+		Type:  interbank.AssetStock,
+		Stock: &interbank.StockDescription{Ticker: contract.StockTicker},
+	}
+	optionAcc := interbank.TxAccount{
+		Type: interbank.TxAccountOption,
+		ID: &interbank.ForeignBankId{
+			RoutingNumber: interbank.RoutingNumber(contract.NegotiationRoutingNumber),
+			ID:            contract.NegotiationID,
+		},
+	}
+	buyerAcc := interbank.TxAccount{
+		Type: interbank.TxAccountPerson,
+		ID: &interbank.ForeignBankId{
+			RoutingNumber: ownRouting,
+			ID:            contract.BuyerLocalID,
+		},
+	}
+	return interbank.Transaction{
+		TransactionID:  txID,
+		Message:        fmt.Sprintf("OTC option exercise for negotiation %s", contract.NegotiationID),
+		PaymentCode:    "OTC",
+		PaymentPurpose: "OTC option exercise — cash for stocks",
+		Postings: []interbank.Posting{
+			{Account: optionAcc, Amount: cashAmount, Asset: monas},   // option debited cash (+π·k)
+			{Account: buyerAcc, Amount: -cashAmount, Asset: monas},   // buyer credited cash (-π·k)
+			{Account: optionAcc, Amount: -contract.Amount, Asset: stock}, // option credited stocks (-k)
+			{Account: buyerAcc, Amount: contract.Amount, Asset: stock},   // buyer debited stocks (+k)
+		},
+	}
+}
+
+// parseContractSettlement is a lenient ISO8601 parse for the
+// contract.SettlementDate string. Mirrors the parser in the seller-side
+// exercise processor so both ends apply the same expiry rule.
+func parseContractSettlement(s string) (time.Time, bool) {
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+func optionContractRowToResponse(c *models.InterbankOptionContract) map[string]interface{} {
+	return map[string]interface{}{
+		"id":                       c.ID,
+		"negotiationRoutingNumber": c.NegotiationRoutingNumber,
+		"negotiationId":            c.NegotiationID,
+		"buyerLocalId":             c.BuyerLocalID,
+		"sellerRoutingNumber":      c.SellerRoutingNumber,
+		"sellerId":                 c.SellerID,
+		"stockTicker":              c.StockTicker,
+		"amount":                   c.Amount,
+		"pricePerUnit":             map[string]interface{}{"currency": c.PricePerUnitCurrency, "amount": c.PricePerUnitAmount},
+		"premium":                  map[string]interface{}{"currency": c.PremiumCurrency, "amount": c.PremiumAmount},
+		"settlementDate":           c.SettlementDate,
+		"status":                   c.Status,
+		"createdAt":                c.CreatedAt,
+		"updatedAt":                c.UpdatedAt,
+	}
+}

--- a/exchange-service/internal/handler/interbank_otc_http_handler.go
+++ b/exchange-service/internal/handler/interbank_otc_http_handler.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"gorm.io/gorm"
+
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
@@ -26,12 +28,24 @@ import (
 // negotiation we're a party to). The partner-facing wire surface lives
 // in package interbank; this handler is the JWT-authenticated face of
 // it for our own UI.
+//
+// The buyer-side option-exercise routes (option-contracts list/get/
+// exercise) live on this handler too — they share the
+// /api/v1/interbank-otc/* prefix and the same client + JWT context.
+// The exercise implementation lives in interbank_exercise_http_handler.go.
 type InterbankOtcHTTPHandler struct {
-	cfg         *config.Config
-	registry    *interbank.Registry
-	client      *interbank.Client
-	negRepo     *repository.InterbankOtcRepository
-	negsHandler *interbank.NegotiationsHandler
+	cfg              *config.Config
+	registry         *interbank.Registry
+	client           *interbank.Client
+	negRepo          *repository.InterbankOtcRepository
+	negsHandler      *interbank.NegotiationsHandler
+	stockCacheRepo   *repository.RemotePublicStockRepository
+	contractRepo     *repository.InterbankOptionContractRepository
+	exerciseRepo     *repository.InterbankExerciseRepository
+	walletRepo       *repository.InterbankWalletRepository
+	portfolioRepo    *repository.PortfolioRepository
+	marketRepo       *repository.MarketRepository
+	db               *gorm.DB
 }
 
 func NewInterbankOtcHTTPHandler(
@@ -40,14 +54,44 @@ func NewInterbankOtcHTTPHandler(
 	client *interbank.Client,
 	negRepo *repository.InterbankOtcRepository,
 	negsHandler *interbank.NegotiationsHandler,
+	stockCacheRepo *repository.RemotePublicStockRepository,
+	contractRepo *repository.InterbankOptionContractRepository,
+	exerciseRepo *repository.InterbankExerciseRepository,
+	walletRepo *repository.InterbankWalletRepository,
+	portfolioRepo *repository.PortfolioRepository,
+	marketRepo *repository.MarketRepository,
+	db *gorm.DB,
 ) *InterbankOtcHTTPHandler {
 	return &InterbankOtcHTTPHandler{
-		cfg:         cfg,
-		registry:    registry,
-		client:      client,
-		negRepo:     negRepo,
-		negsHandler: negsHandler,
+		cfg:            cfg,
+		registry:       registry,
+		client:         client,
+		negRepo:        negRepo,
+		negsHandler:    negsHandler,
+		stockCacheRepo: stockCacheRepo,
+		contractRepo:   contractRepo,
+		exerciseRepo:   exerciseRepo,
+		walletRepo:     walletRepo,
+		portfolioRepo:  portfolioRepo,
+		marketRepo:     marketRepo,
+		db:             db,
 	}
+}
+
+// publicStockStaleness is the cutoff beyond which a cached snapshot is
+// marked `stale=true` in the response. The cron refreshes @every 5m, so
+// 12m gives a comfortable two-tick window before stale flags appear.
+const publicStockStaleness = 12 * time.Minute
+
+// partnerStockResult is the per-partner intermediate for listPublicStocks.
+// Used by both fanOutLive (live fan-out) and readCached (cache reads) so
+// the merging loop in listPublicStocks doesn't care which source produced
+// the data.
+type partnerStockResult struct {
+	code   interbank.RoutingNumber
+	stocks interbank.PublicStocksResponse
+	err    error
+	stale  bool
 }
 
 // Routes dispatches /api/v1/interbank-otc/* to the right method.
@@ -102,15 +146,50 @@ func (h *InterbankOtcHTTPHandler) Routes(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		h.acceptNegotiation(w, r, routing, id)
+	case len(parts) == 1 && parts[0] == "option-contracts":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.listOptionContracts(w, r)
+	case len(parts) == 2 && parts[0] == "option-contracts":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		id, err := strconv.ParseUint(parts[1], 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "contract id must be numeric"})
+			return
+		}
+		h.getOptionContract(w, r, uint(id))
+	case len(parts) == 3 && parts[0] == "option-contracts" && parts[2] == "exercise":
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		id, err := strconv.ParseUint(parts[1], 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "contract id must be numeric"})
+			return
+		}
+		h.exerciseOptionContract(w, r, uint(id))
 	default:
 		http.NotFound(w, r)
 	}
 }
 
-// listPublicStocks aggregates the partner /public-stock responses into a
-// single payload the local frontend can render. Partner errors are
-// reported per-bank rather than failing the whole call — one slow
-// partner shouldn't block the catalogue.
+// listPublicStocks aggregates partner /public-stock data into a single
+// payload the local frontend can render. By default the data comes
+// from the remote_public_stock_snapshots cache (refreshed by the
+// PublicStockCacheRunner cron). Passing ?live=true bypasses the cache
+// and does a parallel fan-out for callers that need fresh data right
+// now (e.g. an explicit "refresh" button).
+//
+// Per-partner errors are reported per-bank rather than failing the
+// whole call — one slow or down partner shouldn't blank the catalogue.
+// Cached responses include a `stale=true` flag when the snapshot is
+// older than publicStockStaleness.
 func (h *InterbankOtcHTTPHandler) listPublicStocks(w http.ResponseWriter, r *http.Request) {
 	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
 	if !ok {
@@ -120,29 +199,28 @@ func (h *InterbankOtcHTTPHandler) listPublicStocks(w http.ResponseWriter, r *htt
 		return
 	}
 
+	live := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("live")), "true")
+
 	partners := h.registry.All()
-	type partnerResult struct {
-		code   interbank.RoutingNumber
-		stocks interbank.PublicStocksResponse
-		err    error
+	bankNames := map[interbank.RoutingNumber]string{}
+	for _, p := range partners {
+		bankNames[p.Code] = p.DisplayName
 	}
-	results := make([]partnerResult, len(partners))
 
-	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
-	defer cancel()
-
-	var wg sync.WaitGroup
-	for i := range partners {
-		i := i
-		p := partners[i]
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			stocks, err := h.client.FetchPublicStock(ctx, p.Code)
-			results[i] = partnerResult{code: p.Code, stocks: stocks, err: err}
-		}()
+	var results []partnerStockResult
+	if live || h.stockCacheRepo == nil {
+		results = h.fanOutLive(r.Context(), partners)
+	} else {
+		liveResults, fellBack := h.readCached(partners)
+		if fellBack {
+			// No cache row exists at all — first run, no cron has
+			// fired yet. Fan out live so the caller doesn't see an
+			// empty list on cold start.
+			results = h.fanOutLive(r.Context(), partners)
+		} else {
+			results = liveResults
+		}
 	}
-	wg.Wait()
 
 	type stockResp struct {
 		Ticker  string `json:"ticker"`
@@ -153,18 +231,19 @@ func (h *InterbankOtcHTTPHandler) listPublicStocks(w http.ResponseWriter, r *htt
 			Amount            float64 `json:"amount"`
 		} `json:"sellers"`
 	}
-	bankNames := map[interbank.RoutingNumber]string{}
-	for _, p := range partners {
-		bankNames[p.Code] = p.DisplayName
-	}
 	out := map[string]*stockResp{}
 	partnerErrors := map[string]string{}
+	partnerStale := map[string]bool{}
 	for _, res := range results {
+		key := strconv.Itoa(int(res.code))
 		if res.err != nil {
-			partnerErrors[strconv.Itoa(int(res.code))] = res.err.Error()
+			partnerErrors[key] = res.err.Error()
 			slog.Warn("interbank-otc: partner /public-stock failed",
 				"partner", res.code, "error", res.err)
 			continue
+		}
+		if res.stale {
+			partnerStale[key] = true
 		}
 		for _, ps := range res.stocks {
 			entry, ok := out[ps.Stock.Ticker]
@@ -192,11 +271,98 @@ func (h *InterbankOtcHTTPHandler) listPublicStocks(w http.ResponseWriter, r *htt
 	for _, e := range out {
 		stocks = append(stocks, *e)
 	}
+
+	source := "cache"
+	if live || h.stockCacheRepo == nil {
+		source = "live"
+	}
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"stocks":        stocks,
 		"count":         len(stocks),
 		"partnerErrors": partnerErrors,
+		"partnerStale":  partnerStale,
+		"source":        source,
 	})
+}
+
+// fanOutLive runs the original parallel /public-stock fan-out. Used
+// for ?live=true and as a cold-start fallback when the cache is empty.
+func (h *InterbankOtcHTTPHandler) fanOutLive(reqCtx context.Context, partners []interbank.PartnerBank) []partnerStockResult {
+	ctx, cancel := context.WithTimeout(reqCtx, 15*time.Second)
+	defer cancel()
+
+	results := make([]partnerStockResult, len(partners))
+	var wg sync.WaitGroup
+	for i := range partners {
+		i := i
+		p := partners[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			stocks, err := h.client.FetchPublicStock(ctx, p.Code)
+			results[i] = partnerStockResult{code: p.Code, stocks: stocks, err: err}
+		}()
+	}
+	wg.Wait()
+	return results
+}
+
+// readCached returns per-partner cached snapshots. Marks a result
+// stale when the snapshot is older than publicStockStaleness. Returns
+// fellBack=true when zero snapshots exist at all (cold start) — the
+// caller falls back to a live fan-out in that case so the first user
+// after process start doesn't see an empty catalogue.
+func (h *InterbankOtcHTTPHandler) readCached(partners []interbank.PartnerBank) ([]partnerStockResult, bool) {
+	rows, err := h.stockCacheRepo.List()
+	if err != nil {
+		slog.Error("interbank-otc: reading public-stock cache failed", "err", err)
+		return nil, true
+	}
+	if len(rows) == 0 {
+		return nil, true
+	}
+	byPartner := map[int]*models.RemotePublicStockSnapshot{}
+	for i := range rows {
+		byPartner[rows[i].PartnerRoutingNumber] = &rows[i]
+	}
+	now := time.Now().UTC()
+	results := make([]partnerStockResult, 0, len(partners))
+	for _, p := range partners {
+		row := byPartner[int(p.Code)]
+		if row == nil {
+			results = append(results, partnerStockResult{
+				code: p.Code,
+				err:  fmt.Errorf("no cached snapshot yet"),
+			})
+			continue
+		}
+		stale := now.Sub(row.FetchedAt) > publicStockStaleness
+		if row.LastError != "" && row.PayloadJSON == "" {
+			results = append(results, partnerStockResult{
+				code:  p.Code,
+				err:   fmt.Errorf("partner cache error: %s", row.LastError),
+				stale: stale,
+			})
+			continue
+		}
+		var stocks interbank.PublicStocksResponse
+		if row.PayloadJSON != "" {
+			if err := json.Unmarshal([]byte(row.PayloadJSON), &stocks); err != nil {
+				results = append(results, partnerStockResult{
+					code:  p.Code,
+					err:   fmt.Errorf("decoding cached snapshot: %w", err),
+					stale: stale,
+				})
+				continue
+			}
+		}
+		results = append(results, partnerStockResult{
+			code:   p.Code,
+			stocks: stocks,
+			stale:  stale,
+		})
+	}
+	return results, false
 }
 
 // listNegotiations returns every cross-bank negotiation the caller is a

--- a/exchange-service/internal/handler/interbank_payment_http_handler.go
+++ b/exchange-service/internal/handler/interbank_payment_http_handler.go
@@ -1,0 +1,557 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// InterbankPaymentHTTPHandler exposes the sender-side cross-bank
+// payment flow to our own JWT-authenticated frontend. It owns the
+// "user clicks Send → 2PC over /interbank → status visible to user"
+// path; the recipient-side ledger effects live in
+// interbank.PaymentTxProcessor.
+type InterbankPaymentHTTPHandler struct {
+	cfg         *config.Config
+	registry    *interbank.Registry
+	client      *interbank.Client
+	paymentRepo *repository.InterbankPaymentRepository
+	walletRepo  *repository.InterbankPaymentWalletRepository
+	db          *gorm.DB
+}
+
+func NewInterbankPaymentHTTPHandler(
+	cfg *config.Config,
+	registry *interbank.Registry,
+	client *interbank.Client,
+	paymentRepo *repository.InterbankPaymentRepository,
+	walletRepo *repository.InterbankPaymentWalletRepository,
+	db *gorm.DB,
+) *InterbankPaymentHTTPHandler {
+	return &InterbankPaymentHTTPHandler{
+		cfg:         cfg,
+		registry:    registry,
+		client:      client,
+		paymentRepo: paymentRepo,
+		walletRepo:  walletRepo,
+		db:          db,
+	}
+}
+
+// Routes dispatches /api/v1/payments/cross-bank/* paths. Three endpoints:
+//
+//	POST /api/v1/payments/cross-bank         — initiate a new payment
+//	GET  /api/v1/payments/cross-bank         — list caller's outbound payments
+//	GET  /api/v1/payments/cross-bank/{id}    — fetch one payment's status (FE polling)
+func (h *InterbankPaymentHTTPHandler) Routes(w http.ResponseWriter, r *http.Request) {
+	path := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/v1/payments/cross-bank"), "/")
+	if path == "" {
+		switch r.Method {
+		case http.MethodPost:
+			h.createPayment(w, r)
+		case http.MethodGet:
+			h.listPayments(w, r)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+		return
+	}
+
+	parts := strings.Split(path, "/")
+	if len(parts) == 1 {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		id, err := strconv.ParseUint(parts[0], 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "payment id must be numeric"})
+			return
+		}
+		h.getPayment(w, r, uint(id))
+		return
+	}
+	http.NotFound(w, r)
+}
+
+// createPayment is the sender-side initiator. The flow is:
+//
+//  1. Authenticate as a client.
+//  2. Validate body + resolve recipient routing. Must point at a registered
+//     partner bank; local recipients are rejected (use the local transfer
+//     flow instead).
+//  3. In a single DB tx: lock the sender's account by broj_racuna, verify
+//     ownership + status + currency + available balance, reserve the funds
+//     by decrementing raspolozivo_stanje, and persist an InterbankPayment
+//     row in pending state.
+//  4. Outside the tx: POST NEW_TX to the partner.
+//  5. Apply the partner's response under a fresh DB tx:
+//     YES → debit stanje, mark committed, then send COMMIT_TX.
+//     NO  → release raspolozivo, mark rejected (with the partner's
+//     reasons). No ROLLBACK_TX needed — the partner never reserved.
+//     err → release raspolozivo, mark failed. Best-effort ROLLBACK_TX so
+//     the partner can drop any half-applied state.
+func (h *InterbankPaymentHTTPHandler) createPayment(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if claims.TokenSource != "client" || claims.ClientID == 0 {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "only client tokens can initiate cross-bank payments"})
+		return
+	}
+
+	var body struct {
+		SenderAccountNumber    string  `json:"senderAccountNumber"`
+		RecipientAccountNumber string  `json:"recipientAccountNumber"`
+		Currency               string  `json:"currency"`
+		Amount                 float64 `json:"amount"`
+		Message                string  `json:"message"`
+		PaymentCode            string  `json:"paymentCode"`
+		PaymentPurpose         string  `json:"paymentPurpose"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid request body"})
+		return
+	}
+
+	body.SenderAccountNumber = strings.TrimSpace(body.SenderAccountNumber)
+	body.RecipientAccountNumber = strings.TrimSpace(body.RecipientAccountNumber)
+	body.Currency = strings.TrimSpace(strings.ToUpper(body.Currency))
+
+	if body.SenderAccountNumber == "" || body.RecipientAccountNumber == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "senderAccountNumber and recipientAccountNumber are required"})
+		return
+	}
+	if body.Currency == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "currency is required"})
+		return
+	}
+	if !interbank.IsKnownCurrency(interbank.CurrencyCode(body.Currency)) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": fmt.Sprintf("unknown currency %q", body.Currency)})
+		return
+	}
+	if body.Amount <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "amount must be positive"})
+		return
+	}
+	if body.SenderAccountNumber == body.RecipientAccountNumber {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "sender and recipient accounts must differ"})
+		return
+	}
+
+	ownRouting := h.registry.OwnRoutingNumber()
+	senderRouting, _, isLocalSender, err := h.registry.ResolveBankFromAccount(body.SenderAccountNumber)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": fmt.Sprintf("resolving sender account routing: %v", err)})
+		return
+	}
+	if !isLocalSender {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": fmt.Sprintf("sender account routing %d is not this bank — initiate the payment from the partner bank's frontend instead", senderRouting)})
+		return
+	}
+
+	recipientRouting, _, isLocalRecipient, err := h.registry.ResolveBankFromAccount(body.RecipientAccountNumber)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": fmt.Sprintf("resolving recipient account routing: %v", err)})
+		return
+	}
+	if isLocalRecipient {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "recipient is on this bank — use the local transfer flow instead"})
+		return
+	}
+	if h.registry.Lookup(recipientRouting) == nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": fmt.Sprintf("no partner bank registered for routing number %d", recipientRouting)})
+		return
+	}
+
+	// Phase 1 — local prepare: lock sender, validate ownership, reserve
+	// funds, persist pending row. Single DB tx so the reservation and
+	// the audit row land together.
+	clientID := claims.ClientID
+	txID := interbank.ForeignBankId{
+		RoutingNumber: ownRouting,
+		ID:            uuid.NewString(),
+	}
+	var paymentRow *models.InterbankPayment
+	prepareErr := h.db.Transaction(func(dbtx *gorm.DB) error {
+		snap, lockErr := h.walletRepo.LockByNumber(dbtx, body.SenderAccountNumber, body.Currency)
+		switch {
+		case errors.Is(lockErr, repository.ErrInterbankPaymentNoSuchAccount):
+			return preparePaymentErr{status: http.StatusNotFound, msg: "sender account not found"}
+		case errors.Is(lockErr, repository.ErrInterbankPaymentAccountInactive):
+			return preparePaymentErr{status: http.StatusConflict, msg: "sender account is not active"}
+		case errors.Is(lockErr, repository.ErrInterbankPaymentCurrencyMismatch):
+			return preparePaymentErr{status: http.StatusBadRequest, msg: "currency does not match sender account's currency"}
+		case lockErr != nil:
+			return lockErr
+		}
+		if snap.ClientID == nil || *snap.ClientID != clientID {
+			return preparePaymentErr{status: http.StatusForbidden, msg: "you do not own that sender account"}
+		}
+		if err := h.walletRepo.Reserve(dbtx, snap.ID, body.Amount); err != nil {
+			if errors.Is(err, repository.ErrInterbankPaymentInsufficientFunds) {
+				return preparePaymentErr{status: http.StatusUnprocessableEntity, msg: "insufficient available balance on sender account"}
+			}
+			return err
+		}
+		accountID := snap.ID
+		clID := clientID
+		row := &models.InterbankPayment{
+			TxRoutingNumber:        int(txID.RoutingNumber),
+			TxID:                   txID.ID,
+			Direction:              models.InterbankPaymentDirectionOutbound,
+			PartnerRoutingNumber:   int(recipientRouting),
+			SenderAccountNumber:    body.SenderAccountNumber,
+			RecipientAccountNumber: body.RecipientAccountNumber,
+			Currency:               body.Currency,
+			Amount:                 body.Amount,
+			LocalAccountID:         &accountID,
+			LocalClientID:          &clID,
+			Message:                body.Message,
+			PaymentCode:            body.PaymentCode,
+			PaymentPurpose:         body.PaymentPurpose,
+			Status:                 models.InterbankPaymentStatusPending,
+			CreatedAt:              time.Now().UTC(),
+		}
+		if err := h.paymentRepo.CreateTx(dbtx, row); err != nil {
+			return err
+		}
+		paymentRow = row
+		return nil
+	})
+	if prepareErr != nil {
+		var pe preparePaymentErr
+		if errors.As(prepareErr, &pe) {
+			writeJSON(w, pe.status, map[string]string{"message": pe.msg})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("preparing payment: %v", prepareErr)})
+		return
+	}
+
+	// Phase 2 — send NEW_TX to the partner. This is the only network
+	// hop in the happy path; the partner's 202-poll loop is handled
+	// inside interbank.Client.SendNewTx.
+	tx := interbank.BuildPaymentTx(txID, body.SenderAccountNumber, body.RecipientAccountNumber,
+		body.Currency, body.Amount, body.Message, body.PaymentCode, body.PaymentPurpose)
+	idemKey := h.client.NewIdempotenceKey()
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	vote, dispatchErr := h.client.SendNewTx(ctx, recipientRouting, idemKey, &tx)
+	if dispatchErr != nil {
+		h.finaliseTransportFailure(paymentRow, recipientRouting, idemKey, dispatchErr)
+		writeJSON(w, http.StatusBadGateway, map[string]interface{}{
+			"message":   fmt.Sprintf("dispatching NEW_TX to partner failed: %v", dispatchErr),
+			"paymentId": paymentRow.ID,
+			"status":    models.InterbankPaymentStatusFailed,
+		})
+		return
+	}
+	if vote.Vote != interbank.VoteYes {
+		reason := summariseNoVote(vote)
+		if err := h.finaliseRejected(paymentRow, reason); err != nil {
+			slog.Error("interbank: payment rejection finalise failed",
+				"err", err, "payment_id", paymentRow.ID)
+		}
+		writeJSON(w, http.StatusConflict, map[string]interface{}{
+			"message":   "partner refused the payment",
+			"paymentId": paymentRow.ID,
+			"status":    models.InterbankPaymentStatusRejected,
+			"vote":      vote,
+		})
+		return
+	}
+
+	// Partner voted YES — apply local commit and notify partner.
+	if err := h.finaliseCommit(paymentRow); err != nil {
+		// Local commit failed AFTER the partner voted YES — operator
+		// action required. We do not roll back; the partner is
+		// holding nothing on its side until COMMIT_TX arrives, but
+		// our books haven't been debited either. The retry loop
+		// (later milestone — BANKA-BE-8) is where reconciliation
+		// belongs.
+		slog.Error("interbank: payment local commit failed after YES vote",
+			"err", err, "payment_id", paymentRow.ID, "tx_id", txID.ID)
+		writeJSON(w, http.StatusInternalServerError, map[string]interface{}{
+			"message":   fmt.Sprintf("partner voted YES but local commit failed: %v", err),
+			"paymentId": paymentRow.ID,
+			"status":    paymentRow.Status,
+		})
+		return
+	}
+
+	commitKey := h.client.NewIdempotenceKey()
+	if err := h.client.SendCommitTx(ctx, recipientRouting, commitKey, txID); err != nil {
+		// COMMIT_TX failed after we already debited locally. The
+		// reconciliation cron will resend it on the next tick; the
+		// payment row stays committed locally. Surface as 202-style
+		// success-with-warning so the frontend can show "in progress".
+		slog.Warn("interbank: payment COMMIT_TX dispatch failed after local commit",
+			"err", err, "payment_id", paymentRow.ID, "tx_id", txID.ID)
+		writeJSON(w, http.StatusAccepted, map[string]interface{}{
+			"message":   fmt.Sprintf("local commit succeeded but COMMIT_TX dispatch failed; partner will reconcile: %v", err),
+			"paymentId": paymentRow.ID,
+			"status":    models.InterbankPaymentStatusCommitted,
+		})
+		return
+	}
+	h.markCommitDispatched(paymentRow)
+
+	writeJSON(w, http.StatusCreated, map[string]interface{}{
+		"paymentId": paymentRow.ID,
+		"status":    models.InterbankPaymentStatusCommitted,
+		"payment":   paymentRowToResponse(paymentRow),
+	})
+}
+
+// listPayments returns the caller's recent outbound cross-bank payments,
+// newest first. Inbound payments live on the partner's customer rows,
+// not ours.
+func (h *InterbankPaymentHTTPHandler) listPayments(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if claims.TokenSource != "client" || claims.ClientID == 0 {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "only client tokens can list cross-bank payments"})
+		return
+	}
+
+	limit := 50
+	if s := strings.TrimSpace(r.URL.Query().Get("limit")); s != "" {
+		if v, err := strconv.Atoi(s); err == nil && v > 0 {
+			limit = v
+		}
+	}
+
+	rows, err := h.paymentRepo.ListOutboundForClient(claims.ClientID, limit)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("listing payments: %v", err)})
+		return
+	}
+
+	items := make([]map[string]interface{}, 0, len(rows))
+	for i := range rows {
+		items = append(items, paymentRowToResponse(&rows[i]))
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"payments": items,
+		"count":    len(items),
+	})
+}
+
+// getPayment is the polling endpoint for the FE. Returns the current
+// state of a payment owned by the caller.
+func (h *InterbankPaymentHTTPHandler) getPayment(w http.ResponseWriter, r *http.Request, id uint) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if claims.TokenSource != "client" || claims.ClientID == 0 {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "only client tokens can read cross-bank payments"})
+		return
+	}
+
+	row, err := h.paymentRepo.GetByID(id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": fmt.Sprintf("loading payment: %v", err)})
+		return
+	}
+	if row == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "no such payment"})
+		return
+	}
+	if row.Direction != models.InterbankPaymentDirectionOutbound || row.LocalClientID == nil || *row.LocalClientID != claims.ClientID {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "you do not own that payment"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"payment": paymentRowToResponse(row),
+	})
+}
+
+// finaliseCommit applies the local commit: debit stanje on the sender
+// account and CAS-mark the payment row committed.
+func (h *InterbankPaymentHTTPHandler) finaliseCommit(row *models.InterbankPayment) error {
+	if row.LocalAccountID == nil {
+		return fmt.Errorf("payment row missing local_account_id")
+	}
+	err := h.db.Transaction(func(dbtx *gorm.DB) error {
+		rows, err := h.paymentRepo.MarkCommittedCAS(dbtx, row.TxRoutingNumber, row.TxID)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			// Already resolved by a concurrent caller — leave alone.
+			return nil
+		}
+		if err := h.walletRepo.Debit(dbtx, *row.LocalAccountID, row.Amount); err != nil {
+			return err
+		}
+		row.Status = models.InterbankPaymentStatusCommitted
+		return nil
+	})
+	return err
+}
+
+// finaliseRejected applies the partner-voted-NO finalise: release the
+// reservation, CAS-mark the payment rejected, and stamp
+// partner_finalised_at — the partner voted NO so it never reserved
+// anything and no terminal message is owed.
+func (h *InterbankPaymentHTTPHandler) finaliseRejected(row *models.InterbankPayment, reason string) error {
+	if row.LocalAccountID == nil {
+		return fmt.Errorf("payment row missing local_account_id")
+	}
+	return h.db.Transaction(func(dbtx *gorm.DB) error {
+		rows, err := h.paymentRepo.MarkRejectedCAS(dbtx, row.TxRoutingNumber, row.TxID, reason)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return nil
+		}
+		row.Status = models.InterbankPaymentStatusRejected
+		row.LastError = reason
+		if _, err := h.paymentRepo.MarkPartnerFinalised(dbtx, row.TxRoutingNumber, row.TxID); err != nil {
+			return err
+		}
+		return h.walletRepo.Release(dbtx, *row.LocalAccountID, row.Amount)
+	})
+}
+
+// markCommitDispatched stamps PartnerFinalisedAt after SendCommitTx
+// succeeds, so the reconciliation cron stops re-sending it. Best-effort
+// — a failure here just means the cron will resend COMMIT_TX, which is
+// idempotent on the partner side.
+func (h *InterbankPaymentHTTPHandler) markCommitDispatched(row *models.InterbankPayment) {
+	err := h.db.Transaction(func(dbtx *gorm.DB) error {
+		_, mErr := h.paymentRepo.MarkPartnerFinalised(dbtx, row.TxRoutingNumber, row.TxID)
+		return mErr
+	})
+	if err != nil {
+		slog.Warn("interbank: failed to stamp payment partner_finalised_at after COMMIT_TX",
+			"err", err, "payment_id", row.ID)
+	}
+}
+
+// finaliseTransportFailure releases the reservation and CAS-marks the
+// payment as failed when NEW_TX itself returned a transport-level
+// error (timeout, connection refused, 5xx, 202-poll budget exhausted).
+// Then best-effort sends ROLLBACK_TX so the partner can drop any
+// half-applied state.
+func (h *InterbankPaymentHTTPHandler) finaliseTransportFailure(row *models.InterbankPayment, recipientRouting interbank.RoutingNumber, _ interbank.IdempotenceKey, dispatchErr error) {
+	if row.LocalAccountID == nil {
+		slog.Error("interbank: cannot release failed payment — missing local_account_id",
+			"payment_id", row.ID)
+		return
+	}
+	txErr := h.db.Transaction(func(dbtx *gorm.DB) error {
+		rows, err := h.paymentRepo.MarkFailedCAS(dbtx, row.TxRoutingNumber, row.TxID, dispatchErr.Error())
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return nil
+		}
+		row.Status = models.InterbankPaymentStatusFailed
+		row.LastError = dispatchErr.Error()
+		return h.walletRepo.Release(dbtx, *row.LocalAccountID, row.Amount)
+	})
+	if txErr != nil {
+		slog.Error("interbank: failed to release payment after transport failure",
+			"err", txErr, "payment_id", row.ID)
+		return
+	}
+
+	// Best-effort ROLLBACK_TX so the partner clears any partial state.
+	// The partner may have never seen NEW_TX (timeout BEFORE delivery)
+	// — in that case the partner's idempotence cache will treat
+	// ROLLBACK_TX as a no-op (no pending row to flip). Either way the
+	// partner is left in a consistent state.
+	rollbackCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	rbKey := h.client.NewIdempotenceKey()
+	txID := interbank.ForeignBankId{
+		RoutingNumber: interbank.RoutingNumber(row.TxRoutingNumber),
+		ID:            row.TxID,
+	}
+	if err := h.client.SendRollbackTx(rollbackCtx, recipientRouting, rbKey, txID); err != nil {
+		slog.Warn("interbank: best-effort ROLLBACK_TX failed",
+			"err", err, "payment_id", row.ID, "tx_id", row.TxID)
+		return
+	}
+	if dbErr := h.db.Transaction(func(dbtx *gorm.DB) error {
+		_, mErr := h.paymentRepo.MarkPartnerFinalised(dbtx, row.TxRoutingNumber, row.TxID)
+		return mErr
+	}); dbErr != nil {
+		slog.Warn("interbank: failed to stamp payment partner_finalised_at after ROLLBACK_TX",
+			"err", dbErr, "payment_id", row.ID)
+	}
+}
+
+// preparePaymentErr carries a status code + user-facing message out of
+// the prepare DB transaction without leaking a 500 for predictable
+// validation failures (insufficient funds, no such account, etc.).
+type preparePaymentErr struct {
+	status int
+	msg    string
+}
+
+func (e preparePaymentErr) Error() string { return e.msg }
+
+// summariseNoVote turns the partner's reason list into a short string
+// for storage in InterbankPayment.last_error and for surfacing to the
+// FE. Keeps the structured vote on the wire but renders something the
+// user can read.
+func summariseNoVote(vote *interbank.TransactionVote) string {
+	if vote == nil || len(vote.Reasons) == 0 {
+		return "partner voted NO without reason"
+	}
+	parts := make([]string, 0, len(vote.Reasons))
+	for _, r := range vote.Reasons {
+		parts = append(parts, string(r.Reason))
+	}
+	return "partner voted NO: " + strings.Join(parts, ", ")
+}
+
+// paymentRowToResponse shapes a payment row for the FE.
+func paymentRowToResponse(row *models.InterbankPayment) map[string]interface{} {
+	out := map[string]interface{}{
+		"id":                     row.ID,
+		"transactionId":          map[string]interface{}{"routingNumber": row.TxRoutingNumber, "id": row.TxID},
+		"direction":              row.Direction,
+		"partnerRoutingNumber":   row.PartnerRoutingNumber,
+		"senderAccountNumber":    row.SenderAccountNumber,
+		"recipientAccountNumber": row.RecipientAccountNumber,
+		"currency":               row.Currency,
+		"amount":                 row.Amount,
+		"message":                row.Message,
+		"paymentCode":            row.PaymentCode,
+		"paymentPurpose":         row.PaymentPurpose,
+		"status":                 row.Status,
+		"lastError":              row.LastError,
+		"createdAt":              row.CreatedAt,
+		"updatedAt":              row.UpdatedAt,
+	}
+	if row.ResolvedAt != nil {
+		out["resolvedAt"] = row.ResolvedAt
+	}
+	return out
+}

--- a/exchange-service/internal/interbank/dispatch_tx_processor.go
+++ b/exchange-service/internal/interbank/dispatch_tx_processor.go
@@ -1,0 +1,170 @@
+package interbank
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// DispatchTxProcessor multiplexes inbound /interbank messages across
+// the three flows we support: OTC option acceptance (4 postings with
+// PERSON accounts and an OPTION asset), direct cross-bank payments (2
+// postings with ACCOUNT accounts and only MONAS assets), and OTC
+// option exercise (4 postings with one OPTION account and MONAS+STOCK
+// assets).
+//
+// For NEW_TX, classification is by posting shape. For COMMIT_TX and
+// ROLLBACK_TX, the inbound message carries only a TransactionID, so
+// classification is by looking up which processor previously persisted
+// a pending row for that TransactionID. The protocol guarantees
+// TransactionIDs are globally unique, so the lookup yields at most one
+// match across all flows.
+type DispatchTxProcessor struct {
+	otc          *OtcTxProcessor
+	payment      *PaymentTxProcessor
+	exercise     *ExerciseTxProcessor
+	paymentRepo  *repository.InterbankPaymentRepository
+	pendingRepo  *repository.InterbankPendingTxRepository
+	exerciseRepo *repository.InterbankExerciseRepository
+}
+
+// NewDispatchTxProcessor wires the multiplexer. Any inner processor
+// may be nil (e.g. in tests that exercise only one flow); we treat a
+// nil inner as "vote NO with UNACCEPTABLE_ASSET" for that shape.
+func NewDispatchTxProcessor(
+	otc *OtcTxProcessor,
+	payment *PaymentTxProcessor,
+	exercise *ExerciseTxProcessor,
+	paymentRepo *repository.InterbankPaymentRepository,
+	pendingRepo *repository.InterbankPendingTxRepository,
+	exerciseRepo *repository.InterbankExerciseRepository,
+) *DispatchTxProcessor {
+	return &DispatchTxProcessor{
+		otc:          otc,
+		payment:      payment,
+		exercise:     exercise,
+		paymentRepo:  paymentRepo,
+		pendingRepo:  pendingRepo,
+		exerciseRepo: exerciseRepo,
+	}
+}
+
+// OnNewTx classifies by posting shape and forwards to the right
+// processor. The order matters: exercise has OPTION-typed accounts
+// (unique among the three flows), payment has all-ACCOUNT all-MONAS
+// (also unique), and OTC acceptance is the catch-all for the
+// 4-posting PERSON shape. Bodies that match no shape get UNACCEPTABLE
+// _ASSET so the partner can correct its envelope.
+func (d *DispatchTxProcessor) OnNewTx(ctx context.Context, partner *PartnerBank, tx *Transaction) (*TransactionVote, error) {
+	if IsExerciseShape(tx) {
+		if d.exercise == nil {
+			return voteNo(NoVoteReason{Reason: ReasonUnacceptableAsset}), nil
+		}
+		return d.exercise.OnNewTx(ctx, partner, tx)
+	}
+	if IsPaymentShape(tx) {
+		if d.payment == nil {
+			return voteNo(NoVoteReason{Reason: ReasonUnacceptableAsset}), nil
+		}
+		return d.payment.OnNewTx(ctx, partner, tx)
+	}
+	if d.otc == nil {
+		return voteNo(NoVoteReason{Reason: ReasonUnacceptableAsset}), nil
+	}
+	return d.otc.OnNewTx(ctx, partner, tx)
+}
+
+// OnCommitTx looks up the TransactionID in both pending-row tables.
+// Whichever processor persisted the pending row owns the commit. If
+// neither did, surface a 5xx so the partner sees that COMMIT_TX
+// preceded NEW_TX (a protocol violation).
+func (d *DispatchTxProcessor) OnCommitTx(ctx context.Context, partner *PartnerBank, txID ForeignBankId) error {
+	target, err := d.classifyByTxID(txID)
+	if err != nil {
+		return err
+	}
+	switch target {
+	case dispatchTargetPayment:
+		return d.payment.OnCommitTx(ctx, partner, txID)
+	case dispatchTargetExercise:
+		return d.exercise.OnCommitTx(ctx, partner, txID)
+	case dispatchTargetOtc:
+		return d.otc.OnCommitTx(ctx, partner, txID)
+	default:
+		return fmt.Errorf("COMMIT_TX for unknown transaction %d/%s (no pending row in any flow)",
+			txID.RoutingNumber, txID.ID)
+	}
+}
+
+// OnRollbackTx mirrors OnCommitTx. A ROLLBACK_TX for an unknown
+// TransactionID is treated as success — it means we voted NO (or never
+// received NEW_TX), and the initiator's "notify all participants" rule
+// allows the partner to send ROLLBACK_TX anyway.
+func (d *DispatchTxProcessor) OnRollbackTx(ctx context.Context, partner *PartnerBank, txID ForeignBankId) error {
+	target, err := d.classifyByTxID(txID)
+	if err != nil {
+		return err
+	}
+	switch target {
+	case dispatchTargetPayment:
+		return d.payment.OnRollbackTx(ctx, partner, txID)
+	case dispatchTargetExercise:
+		return d.exercise.OnRollbackTx(ctx, partner, txID)
+	case dispatchTargetOtc:
+		return d.otc.OnRollbackTx(ctx, partner, txID)
+	default:
+		// No row exists → we never voted YES on this TransactionID,
+		// so there's nothing to roll back. Per protocol, return
+		// success and let the inbound idempotence cache serve future
+		// replays.
+		return nil
+	}
+}
+
+type dispatchTarget int
+
+const (
+	dispatchTargetNone dispatchTarget = iota
+	dispatchTargetPayment
+	dispatchTargetOtc
+	dispatchTargetExercise
+)
+
+// classifyByTxID looks up which flow owns a given TransactionID. The
+// protocol guarantees TransactionIDs are globally unique, so at most
+// one repo will return a match — order of checks doesn't affect
+// correctness, only the cheapest-first heuristic.
+func (d *DispatchTxProcessor) classifyByTxID(txID ForeignBankId) (dispatchTarget, error) {
+	if d.paymentRepo != nil {
+		row, err := d.paymentRepo.GetByTxID(int(txID.RoutingNumber), txID.ID)
+		if err != nil {
+			return dispatchTargetNone, fmt.Errorf("classifying tx %d/%s by payment repo: %w",
+				txID.RoutingNumber, txID.ID, err)
+		}
+		if row != nil {
+			return dispatchTargetPayment, nil
+		}
+	}
+	if d.exerciseRepo != nil {
+		row, err := d.exerciseRepo.GetByTxID(int(txID.RoutingNumber), txID.ID)
+		if err != nil {
+			return dispatchTargetNone, fmt.Errorf("classifying tx %d/%s by exercise repo: %w",
+				txID.RoutingNumber, txID.ID, err)
+		}
+		if row != nil {
+			return dispatchTargetExercise, nil
+		}
+	}
+	if d.pendingRepo != nil {
+		row, err := d.pendingRepo.GetByTxID(int(txID.RoutingNumber), txID.ID)
+		if err != nil {
+			return dispatchTargetNone, fmt.Errorf("classifying tx %d/%s by OTC pending repo: %w",
+				txID.RoutingNumber, txID.ID, err)
+		}
+		if row != nil {
+			return dispatchTargetOtc, nil
+		}
+	}
+	return dispatchTargetNone, nil
+}

--- a/exchange-service/internal/interbank/exercise_tx_processor.go
+++ b/exchange-service/internal/interbank/exercise_tx_processor.go
@@ -1,0 +1,473 @@
+package interbank
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// ExerciseTxProcessor handles the 4-posting OPTION-execution shape
+// described in protocol §2.7.2:
+//
+//	OPTION{neg_id}      Amount=+π·k   Asset=MONAS{premium currency}
+//	PERSON{buyer_bank}  Amount=-π·k   Asset=MONAS{premium currency}
+//	OPTION{neg_id}      Amount=-k     Asset=STOCK{ticker}
+//	PERSON{buyer_bank}  Amount=+k     Asset=STOCK{ticker}
+//
+// Per spec, the OPTION pseudo-account always lives in the seller's
+// bank (its id is the negotiation id, which the seller's bank minted).
+// So we only see this processor's OnNewTx when we ARE the seller's
+// bank. The buyer's bank is the initiator — see ExerciseForLocalBuyer
+// in interbank_otc_http_handler.go for that side.
+//
+// COMMIT_TX effects on the seller's side:
+//
+//	1. Mark the local OTC negotiation as exercised (we reuse the
+//	   negotiation row's lifecycle since we don't separately track
+//	   seller-side option contracts yet — see "Known gap" below).
+//	2. Decrement the seller's stock holding by StockAmount, releasing
+//	   the reservation that the acceptance flow took. Realised profit
+//	   is computed via RecordSellFillTx.
+//	3. Credit the seller's account by CashAmount in the strike currency.
+//
+// Known gap: cross-bank OTC acceptance does not currently reserve the
+// seller's local stock holding (see Additions.md §3.2). If the seller
+// has disposed of the stocks between acceptance and exercise, the
+// RecordSellFill call will fail and the COMMIT_TX will return 5xx —
+// the partner's reconciliation will keep retrying until an operator
+// intervenes. Closing that gap is tracked separately.
+type ExerciseTxProcessor struct {
+	db            *gorm.DB
+	registry      *Registry
+	negRepo       *repository.InterbankOtcRepository
+	exerciseRepo  *repository.InterbankExerciseRepository
+	portfolioRepo *repository.PortfolioRepository
+	marketRepo    *repository.MarketRepository
+	walletRepo    *repository.InterbankWalletRepository
+}
+
+// NewExerciseTxProcessor wires the seller-side processor.
+func NewExerciseTxProcessor(
+	db *gorm.DB,
+	registry *Registry,
+	negRepo *repository.InterbankOtcRepository,
+	exerciseRepo *repository.InterbankExerciseRepository,
+	portfolioRepo *repository.PortfolioRepository,
+	marketRepo *repository.MarketRepository,
+	walletRepo *repository.InterbankWalletRepository,
+) *ExerciseTxProcessor {
+	return &ExerciseTxProcessor{
+		db:            db,
+		registry:      registry,
+		negRepo:       negRepo,
+		exerciseRepo:  exerciseRepo,
+		portfolioRepo: portfolioRepo,
+		marketRepo:    marketRepo,
+		walletRepo:    walletRepo,
+	}
+}
+
+// OnNewTx validates the exercise shape against the stored negotiation,
+// persists the pending exercise row, and votes YES. No local effects
+// are applied here — the seller's accounting moves on COMMIT_TX.
+func (p *ExerciseTxProcessor) OnNewTx(_ context.Context, partner *PartnerBank, tx *Transaction) (*TransactionVote, error) {
+	if reason := checkBalanced(tx); reason != nil {
+		return voteNo(*reason), nil
+	}
+	parsed, reason := parseExerciseTx(tx)
+	if reason != nil {
+		return voteNo(*reason), nil
+	}
+
+	// The OPTION pseudo-account routing must be our own.
+	ownRouting := p.registry.OwnRoutingNumber()
+	if parsed.optionRouting != ownRouting {
+		return voteNo(NoVoteReason{Reason: ReasonOptionNegotiationNotFound, Posting: parsed.optionCashLeg}), nil
+	}
+	// The partner that POSTed this NEW_TX must be the buyer's bank.
+	if parsed.buyerRouting != partner.Code {
+		return voteNo(NoVoteReason{Reason: ReasonNoSuchAccount, Posting: parsed.buyerCashLeg}), nil
+	}
+
+	neg, err := p.negRepo.Get(int(parsed.optionNegRouting), parsed.optionNegID)
+	if err != nil {
+		return nil, fmt.Errorf("loading negotiation: %w", err)
+	}
+	if neg == nil {
+		return voteNo(NoVoteReason{Reason: ReasonOptionNegotiationNotFound, Posting: parsed.optionCashLeg}), nil
+	}
+
+	// Validate terms against the stored negotiation.
+	if int(parsed.buyerRouting) != neg.BuyerRoutingNumber || parsed.buyerID != neg.BuyerID {
+		return voteNo(NoVoteReason{Reason: ReasonNoSuchAccount, Posting: parsed.buyerCashLeg}), nil
+	}
+	if parsed.stockTicker != neg.StockTicker {
+		return voteNo(NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.buyerStockLeg}), nil
+	}
+	if !nearlyEqual(parsed.stockAmount, neg.Amount) {
+		return voteNo(NoVoteReason{Reason: ReasonOptionAmountIncorrect, Posting: parsed.buyerStockLeg}), nil
+	}
+	if parsed.cashCurrency != neg.PricePerUnitCurrency {
+		return voteNo(NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.buyerCashLeg}), nil
+	}
+	expectedCash := neg.PricePerUnitAmount * neg.Amount
+	if !nearlyEqual(parsed.cashAmount, expectedCash) {
+		return voteNo(NoVoteReason{Reason: ReasonOptionAmountIncorrect, Posting: parsed.buyerCashLeg}), nil
+	}
+
+	// Has the option already been exercised? The negotiation's
+	// IsOngoing was flipped off at acceptance time, so it doesn't tell
+	// us — instead, check the exercise log for a committed row tied to
+	// this negotiation.
+	already, err := p.exerciseRepo.HasCommittedForNegotiation(neg.NegotiationRoutingNumber, neg.NegotiationID)
+	if err != nil {
+		return nil, fmt.Errorf("checking exercise history: %w", err)
+	}
+	if already {
+		return voteNo(NoVoteReason{Reason: ReasonOptionUsedOrExpired, Posting: parsed.optionCashLeg}), nil
+	}
+	// Settlement-date check: per spec §2.7.2 last paragraph, an option
+	// whose settlementDate has passed should not execute. We parse
+	// loosely — if the stored format is malformed, we accept rather
+	// than reject (better to let the partner test pass).
+	if exp, ok := parseSettlement(neg.SettlementDate); ok {
+		if time.Now().UTC().After(exp.Add(24 * time.Hour)) {
+			return voteNo(NoVoteReason{Reason: ReasonOptionUsedOrExpired, Posting: parsed.optionCashLeg}), nil
+		}
+	}
+
+	// Idempotent replay: pending row already exists for this txID.
+	if existing, err := p.exerciseRepo.GetByTxID(int(tx.TransactionID.RoutingNumber), tx.TransactionID.ID); err != nil {
+		return nil, fmt.Errorf("looking up pending exercise: %w", err)
+	} else if existing != nil {
+		return &TransactionVote{Vote: VoteYes}, nil
+	}
+
+	row := &models.InterbankPendingExercise{
+		TxRoutingNumber: int(tx.TransactionID.RoutingNumber),
+		TxID:            tx.TransactionID.ID,
+		Direction:       models.InterbankExerciseDirectionInbound,
+
+		PartnerRoutingNumber: int(partner.Code),
+
+		NegotiationRoutingNumber: neg.NegotiationRoutingNumber,
+		NegotiationID:            neg.NegotiationID,
+
+		StockTicker:          neg.StockTicker,
+		StockAmount:          neg.Amount,
+		PricePerUnitCurrency: neg.PricePerUnitCurrency,
+		PricePerUnitAmount:   neg.PricePerUnitAmount,
+		CashAmount:           expectedCash,
+
+		BuyerRoutingNumber:  neg.BuyerRoutingNumber,
+		BuyerID:             neg.BuyerID,
+		SellerRoutingNumber: neg.SellerRoutingNumber,
+		SellerID:            neg.SellerID,
+
+		Status:    models.InterbankExerciseStatusPending,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := p.db.Transaction(func(dbtx *gorm.DB) error {
+		return p.exerciseRepo.CreateTx(dbtx, row)
+	}); err != nil {
+		return nil, fmt.Errorf("persisting pending exercise: %w", err)
+	}
+
+	slog.Info("interbank: option exercise NEW_TX accepted",
+		"tx_routing", tx.TransactionID.RoutingNumber, "tx_id", tx.TransactionID.ID,
+		"negotiation", neg.NegotiationID, "ticker", neg.StockTicker,
+		"stock_amount", neg.Amount, "cash_amount", expectedCash,
+	)
+	return &TransactionVote{Vote: VoteYes}, nil
+}
+
+// OnCommitTx applies the seller-side effects: reduce the seller's
+// stock holding by StockAmount (recording realised profit at the
+// strike price), credit the seller's account by CashAmount, and CAS
+// the pending row to committed.
+func (p *ExerciseTxProcessor) OnCommitTx(_ context.Context, _ *PartnerBank, txID ForeignBankId) error {
+	pending, err := p.exerciseRepo.GetByTxID(int(txID.RoutingNumber), txID.ID)
+	if err != nil {
+		return fmt.Errorf("loading pending exercise: %w", err)
+	}
+	if pending == nil {
+		return fmt.Errorf("COMMIT_TX for unknown exercise %d/%s", txID.RoutingNumber, txID.ID)
+	}
+	if pending.Direction != models.InterbankExerciseDirectionInbound {
+		return fmt.Errorf("COMMIT_TX dispatched to exercise processor for non-inbound row %d/%s", txID.RoutingNumber, txID.ID)
+	}
+
+	switch pending.Status {
+	case models.InterbankExerciseStatusCommitted:
+		return nil
+	case models.InterbankExerciseStatusRolledBack, models.InterbankExerciseStatusRejected, models.InterbankExerciseStatusFailed:
+		return fmt.Errorf("COMMIT_TX for already-resolved exercise %d/%s (status=%s)",
+			txID.RoutingNumber, txID.ID, pending.Status)
+	case models.InterbankExerciseStatusPending:
+		// proceed
+	default:
+		return fmt.Errorf("exercise %d/%s has unknown status %q", txID.RoutingNumber, txID.ID, pending.Status)
+	}
+
+	// Resolve the seller's local user id from the encoded form. Only
+	// "client-N" is supported — bank-side OTC isn't a thing on the
+	// inter-bank wire yet.
+	sellerType, sellerUID, err := DecodeLocalParticipantID(pending.SellerID)
+	if err != nil {
+		return fmt.Errorf("decoding seller local id %q: %w", pending.SellerID, err)
+	}
+	if sellerType != LocalParticipantClient {
+		return fmt.Errorf("only client-side sellers are supported for exercise (got %q)", string(sellerType))
+	}
+
+	listing, err := p.marketRepo.GetListingRecordByTicker(pending.StockTicker)
+	if err != nil {
+		return fmt.Errorf("looking up listing for ticker %q: %w", pending.StockTicker, err)
+	}
+
+	txErr := p.db.Transaction(func(dbtx *gorm.DB) error {
+		rows, err := p.exerciseRepo.MarkCommittedCAS(dbtx, int(txID.RoutingNumber), txID.ID)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return errExerciseAlreadyResolved
+		}
+
+		// Seller's stocks leave the holding — record at the strike
+		// price so realised profit reflects the agreed-upon terms.
+		if _, err := repository.RecordSellFillTx(
+			dbtx,
+			sellerUID, "client",
+			listing.ID,
+			pending.StockAmount,
+			pending.PricePerUnitAmount,
+		); err != nil {
+			return fmt.Errorf("recording seller sell fill: %w", err)
+		}
+
+		// Seller is credited the strike-price cash in the agreed
+		// currency. Reuses the OTC wallet repo's "first active
+		// account in currency" lookup.
+		if err := p.walletRepo.Credit(dbtx, pending.SellerID, pending.PricePerUnitCurrency, pending.CashAmount); err != nil {
+			return fmt.Errorf("crediting seller cash: %w", err)
+		}
+		return nil
+	})
+	if errors.Is(txErr, errExerciseAlreadyResolved) {
+		return nil
+	}
+	if txErr != nil {
+		return txErr
+	}
+
+	slog.Info("interbank: option exercise COMMIT_TX applied",
+		"tx_routing", txID.RoutingNumber, "tx_id", txID.ID,
+		"negotiation", pending.NegotiationID,
+		"stocks_moved", pending.StockAmount,
+		"cash_credited", pending.CashAmount,
+	)
+	return nil
+}
+
+// OnRollbackTx flips the pending row to rolled_back. No local effects
+// to undo on the seller side: NEW_TX didn't apply anything.
+func (p *ExerciseTxProcessor) OnRollbackTx(_ context.Context, _ *PartnerBank, txID ForeignBankId) error {
+	pending, err := p.exerciseRepo.GetByTxID(int(txID.RoutingNumber), txID.ID)
+	if err != nil {
+		return fmt.Errorf("loading pending exercise: %w", err)
+	}
+	if pending == nil {
+		return nil
+	}
+	if pending.Direction != models.InterbankExerciseDirectionInbound {
+		return fmt.Errorf("ROLLBACK_TX dispatched to exercise processor for non-inbound row %d/%s", txID.RoutingNumber, txID.ID)
+	}
+	switch pending.Status {
+	case models.InterbankExerciseStatusRolledBack:
+		return nil
+	case models.InterbankExerciseStatusCommitted:
+		return fmt.Errorf("ROLLBACK_TX for already-committed exercise %d/%s", txID.RoutingNumber, txID.ID)
+	case models.InterbankExerciseStatusPending:
+		// proceed
+	default:
+		return fmt.Errorf("exercise %d/%s has unknown status %q", txID.RoutingNumber, txID.ID, pending.Status)
+	}
+
+	txErr := p.db.Transaction(func(dbtx *gorm.DB) error {
+		rows, err := p.exerciseRepo.MarkRolledBackCAS(dbtx, int(txID.RoutingNumber), txID.ID)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return errExerciseAlreadyResolved
+		}
+		return nil
+	})
+	if errors.Is(txErr, errExerciseAlreadyResolved) {
+		return nil
+	}
+	if txErr != nil {
+		return txErr
+	}
+	return nil
+}
+
+var errExerciseAlreadyResolved = errors.New("interbank: exercise already resolved by concurrent caller")
+
+// exerciseTx is the parsed view of a 4-posting OPTION-execution NEW_TX.
+type exerciseTx struct {
+	optionCashLeg  *Posting
+	optionStockLeg *Posting
+	buyerCashLeg   *Posting
+	buyerStockLeg  *Posting
+
+	optionRouting    RoutingNumber
+	optionNegRouting RoutingNumber
+	optionNegID      string
+
+	buyerRouting RoutingNumber
+	buyerID      string
+
+	stockTicker  string
+	stockAmount  float64
+	cashCurrency string
+	cashAmount   float64
+}
+
+// parseExerciseTx classifies the four postings of an OPTION-execution
+// NEW_TX. Returns a NoVoteReason if the shape doesn't match.
+func parseExerciseTx(tx *Transaction) (*exerciseTx, *NoVoteReason) {
+	if len(tx.Postings) != 4 {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset}
+	}
+	parsed := &exerciseTx{}
+	for i := range tx.Postings {
+		ptg := &tx.Postings[i]
+		switch ptg.Account.Type {
+		case TxAccountOption:
+			if ptg.Account.ID == nil {
+				return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+			}
+			switch ptg.Asset.Type {
+			case AssetMonas:
+				if ptg.Asset.Monas == nil || parsed.optionCashLeg != nil {
+					return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+				}
+				parsed.optionCashLeg = ptg
+				parsed.optionRouting = ptg.Account.ID.RoutingNumber
+				parsed.optionNegRouting = ptg.Account.ID.RoutingNumber
+				parsed.optionNegID = ptg.Account.ID.ID
+				parsed.cashCurrency = string(ptg.Asset.Monas.Currency)
+				parsed.cashAmount = ptg.Amount
+			case AssetStock:
+				if ptg.Asset.Stock == nil || parsed.optionStockLeg != nil {
+					return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+				}
+				parsed.optionStockLeg = ptg
+				parsed.stockTicker = ptg.Asset.Stock.Ticker
+			default:
+				return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+			}
+		case TxAccountPerson:
+			if ptg.Account.ID == nil {
+				return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+			}
+			switch ptg.Asset.Type {
+			case AssetMonas:
+				if ptg.Asset.Monas == nil || parsed.buyerCashLeg != nil {
+					return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+				}
+				parsed.buyerCashLeg = ptg
+				parsed.buyerRouting = ptg.Account.ID.RoutingNumber
+				parsed.buyerID = ptg.Account.ID.ID
+			case AssetStock:
+				if ptg.Asset.Stock == nil || parsed.buyerStockLeg != nil {
+					return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+				}
+				parsed.buyerStockLeg = ptg
+				parsed.stockAmount = ptg.Amount
+			default:
+				return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+			}
+		default:
+			return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+		}
+	}
+
+	if parsed.optionCashLeg == nil || parsed.optionStockLeg == nil ||
+		parsed.buyerCashLeg == nil || parsed.buyerStockLeg == nil {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset}
+	}
+
+	// Both option-leg postings must refer to the same negotiation.
+	if parsed.optionStockLeg.Account.ID.RoutingNumber != parsed.optionNegRouting ||
+		parsed.optionStockLeg.Account.ID.ID != parsed.optionNegID {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.optionStockLeg}
+	}
+	// Both buyer postings must refer to the same buyer.
+	if parsed.buyerStockLeg.Account.ID.RoutingNumber != parsed.buyerRouting ||
+		parsed.buyerStockLeg.Account.ID.ID != parsed.buyerID {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.buyerStockLeg}
+	}
+
+	// Cash leg signs: option debited (+π·k), buyer credited (-π·k).
+	if parsed.optionCashLeg.Amount <= 0 || parsed.buyerCashLeg.Amount >= 0 {
+		return nil, &NoVoteReason{Reason: ReasonOptionAmountIncorrect, Posting: parsed.optionCashLeg}
+	}
+	if !nearlyEqual(parsed.optionCashLeg.Amount, -parsed.buyerCashLeg.Amount) {
+		return nil, &NoVoteReason{Reason: ReasonUnbalancedTx}
+	}
+	// Stock leg signs: option credited (-k), buyer debited (+k).
+	if parsed.optionStockLeg.Amount >= 0 || parsed.buyerStockLeg.Amount <= 0 {
+		return nil, &NoVoteReason{Reason: ReasonOptionAmountIncorrect, Posting: parsed.optionStockLeg}
+	}
+	if !nearlyEqual(-parsed.optionStockLeg.Amount, parsed.buyerStockLeg.Amount) {
+		return nil, &NoVoteReason{Reason: ReasonUnbalancedTx}
+	}
+	// Tickers and currencies must agree across the two pairs.
+	if parsed.buyerStockLeg.Asset.Stock.Ticker != parsed.stockTicker {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.buyerStockLeg}
+	}
+	if string(parsed.buyerCashLeg.Asset.Monas.Currency) != parsed.cashCurrency {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.buyerCashLeg}
+	}
+	return parsed, nil
+}
+
+// IsExerciseShape returns true when the transaction has at least one
+// OPTION-typed TxAccount, which only the exercise flow uses (acceptance
+// uses PERSON for cash + OPTION asset, but its TxAccounts are PERSON).
+func IsExerciseShape(tx *Transaction) bool {
+	for i := range tx.Postings {
+		if tx.Postings[i].Account.Type == TxAccountOption {
+			return true
+		}
+	}
+	return false
+}
+
+// parseSettlement is a lenient ISO8601 parse for the settlement date
+// string stored on the negotiation row. Returns ok=false on malformed
+// input so the caller can treat it as "no expiry check available".
+func parseSettlement(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}

--- a/exchange-service/internal/interbank/payment_tx_processor.go
+++ b/exchange-service/internal/interbank/payment_tx_processor.go
@@ -1,0 +1,423 @@
+package interbank
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// PaymentTxProcessor is the receiver-side TxProcessor branch for the
+// 2-posting MONAS ACCOUNT shape that represents a direct cross-bank
+// payment (protocol §2.8 + §2.6). The initiator's bank holds the only
+// credited posting locally and reserves there; this processor is what
+// runs in the RECIPIENT bank — we have one debited posting (recipient
+// gains funds), so NEW_TX needs only verification + a pending row, no
+// reservation.
+//
+// State flow on this side:
+//
+//	NEW_TX     → validate, persist InterbankPayment(direction=inbound,
+//	             status=pending), vote YES
+//	COMMIT_TX  → CAS pending→committed, credit recipient (stanje +=,
+//	             raspolozivo_stanje +=) — both effects in one DB tx
+//	ROLLBACK_TX→ CAS pending→rolled_back, no wallet effect (we never
+//	             debited)
+type PaymentTxProcessor struct {
+	db          *gorm.DB
+	registry    *Registry
+	paymentRepo *repository.InterbankPaymentRepository
+	walletRepo  *repository.InterbankPaymentWalletRepository
+}
+
+// NewPaymentTxProcessor wires the receiver-side payment processor.
+func NewPaymentTxProcessor(
+	db *gorm.DB,
+	registry *Registry,
+	paymentRepo *repository.InterbankPaymentRepository,
+	walletRepo *repository.InterbankPaymentWalletRepository,
+) *PaymentTxProcessor {
+	return &PaymentTxProcessor{
+		db:          db,
+		registry:    registry,
+		paymentRepo: paymentRepo,
+		walletRepo:  walletRepo,
+	}
+}
+
+// OnNewTx implements TxProcessor.OnNewTx for the payment shape. The
+// inbound-message idempotence layer (Server.replayCached) already
+// dedupes by (partner, idempotenceKey); business-layer idempotence by
+// transactionId is handled here so a fresh idempotence key carrying
+// the same transactionId can't double-create the pending row.
+func (p *PaymentTxProcessor) OnNewTx(_ context.Context, partner *PartnerBank, tx *Transaction) (*TransactionVote, error) {
+	if reason := checkBalanced(tx); reason != nil {
+		return voteNo(*reason), nil
+	}
+
+	parsed, reason := parsePaymentTx(tx)
+	if reason != nil {
+		return voteNo(*reason), nil
+	}
+
+	// We must be the recipient's bank. The recipient posting is the
+	// positive-amount one — its routing must match our own.
+	ownRouting := p.registry.OwnRoutingNumber()
+	if parsed.recipientRouting != ownRouting {
+		return voteNo(NoVoteReason{Reason: ReasonNoSuchAccount, Posting: parsed.recipientPosting}), nil
+	}
+
+	// Sender posting's routing must match the partner that POSTed this
+	// NEW_TX. Otherwise the envelope was forwarded or spoofed.
+	if parsed.senderRouting != partner.Code {
+		slog.Warn("interbank: payment NEW_TX sender routing does not match partner",
+			"partner", partner.Code,
+			"sender_routing", parsed.senderRouting,
+			"tx_routing", tx.TransactionID.RoutingNumber,
+			"tx_id", tx.TransactionID.ID,
+		)
+		return voteNo(NoVoteReason{Reason: ReasonNoSuchAccount, Posting: parsed.senderPosting}), nil
+	}
+
+	// Idempotent replay past the inbound layer: if we already created
+	// the pending row, the vote stays YES.
+	existing, err := p.paymentRepo.GetByTxID(
+		int(tx.TransactionID.RoutingNumber),
+		tx.TransactionID.ID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("looking up pending payment: %w", err)
+	}
+	if existing != nil {
+		return &TransactionVote{Vote: VoteYes}, nil
+	}
+
+	// First time we've seen this TransactionID. Verify the recipient
+	// account exists, is active, and matches the posting's currency,
+	// then persist the inbound pending row — all under one DB tx so
+	// the lookup + persist are atomic with respect to any concurrent
+	// COMMIT_TX of the same transactionId (impossible per protocol but
+	// cheap to guard against).
+	var (
+		accountID         uint
+		voteNoReason      *NoVoteReason
+		businessErrMsg    string
+	)
+	txErr := p.db.Transaction(func(dbtx *gorm.DB) error {
+		snap, lockErr := p.walletRepo.LockByNumber(dbtx, parsed.recipientAccount, parsed.currency)
+		switch {
+		case errors.Is(lockErr, repository.ErrInterbankPaymentNoSuchAccount):
+			voteNoReason = &NoVoteReason{Reason: ReasonNoSuchAccount, Posting: parsed.recipientPosting}
+			businessErrMsg = "recipient account not found"
+			return errPaymentVoteNo
+		case errors.Is(lockErr, repository.ErrInterbankPaymentAccountInactive):
+			voteNoReason = &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.recipientPosting}
+			businessErrMsg = "recipient account is not active"
+			return errPaymentVoteNo
+		case errors.Is(lockErr, repository.ErrInterbankPaymentCurrencyMismatch):
+			voteNoReason = &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.recipientPosting}
+			businessErrMsg = "recipient account currency does not match posting"
+			return errPaymentVoteNo
+		case lockErr != nil:
+			return lockErr
+		}
+		accountID = snap.ID
+
+		row := &models.InterbankPayment{
+			TxRoutingNumber:        int(tx.TransactionID.RoutingNumber),
+			TxID:                   tx.TransactionID.ID,
+			Direction:              models.InterbankPaymentDirectionInbound,
+			PartnerRoutingNumber:   int(partner.Code),
+			SenderAccountNumber:    parsed.senderAccount,
+			RecipientAccountNumber: parsed.recipientAccount,
+			Currency:               parsed.currency,
+			Amount:                 parsed.amount,
+			LocalAccountID:         &accountID,
+			Message:                tx.Message,
+			PaymentCode:            tx.PaymentCode,
+			PaymentPurpose:         tx.PaymentPurpose,
+			Status:                 models.InterbankPaymentStatusPending,
+			CreatedAt:              time.Now().UTC(),
+		}
+		return p.paymentRepo.CreateTx(dbtx, row)
+	})
+	if errors.Is(txErr, errPaymentVoteNo) {
+		slog.Info("interbank: payment NEW_TX vote NO",
+			"tx_routing", tx.TransactionID.RoutingNumber,
+			"tx_id", tx.TransactionID.ID,
+			"reason", voteNoReason.Reason,
+			"msg", businessErrMsg,
+		)
+		return voteNo(*voteNoReason), nil
+	}
+	if txErr != nil {
+		return nil, fmt.Errorf("recording inbound payment: %w", txErr)
+	}
+
+	slog.Info("interbank: payment NEW_TX accepted",
+		"tx_routing", tx.TransactionID.RoutingNumber,
+		"tx_id", tx.TransactionID.ID,
+		"partner", partner.Code,
+		"recipient_account", parsed.recipientAccount,
+		"currency", parsed.currency,
+		"amount", parsed.amount,
+	)
+	return &TransactionVote{Vote: VoteYes}, nil
+}
+
+// OnCommitTx applies the credit + status flip atomically. Idempotent
+// on already-committed rows; errors on unknown or rolled-back rows so
+// the partner sees a 5xx and can investigate.
+func (p *PaymentTxProcessor) OnCommitTx(_ context.Context, _ *PartnerBank, txID ForeignBankId) error {
+	pending, err := p.paymentRepo.GetByTxID(int(txID.RoutingNumber), txID.ID)
+	if err != nil {
+		return fmt.Errorf("loading inbound payment: %w", err)
+	}
+	if pending == nil {
+		return fmt.Errorf("COMMIT_TX for unknown payment %d/%s", txID.RoutingNumber, txID.ID)
+	}
+	if pending.Direction != models.InterbankPaymentDirectionInbound {
+		return fmt.Errorf("COMMIT_TX dispatched to payment processor for non-inbound row %d/%s", txID.RoutingNumber, txID.ID)
+	}
+
+	switch pending.Status {
+	case models.InterbankPaymentStatusCommitted:
+		return nil
+	case models.InterbankPaymentStatusRolledBack, models.InterbankPaymentStatusRejected, models.InterbankPaymentStatusFailed:
+		return fmt.Errorf("COMMIT_TX for already-resolved payment %d/%s (status=%s)",
+			txID.RoutingNumber, txID.ID, pending.Status)
+	case models.InterbankPaymentStatusPending:
+		// fall through to apply the commit
+	default:
+		return fmt.Errorf("inbound payment %d/%s has unknown status %q",
+			txID.RoutingNumber, txID.ID, pending.Status)
+	}
+
+	if pending.LocalAccountID == nil {
+		return fmt.Errorf("inbound payment %d/%s missing local_account_id", txID.RoutingNumber, txID.ID)
+	}
+
+	txErr := p.db.Transaction(func(dbtx *gorm.DB) error {
+		rows, err := p.paymentRepo.MarkCommittedCAS(dbtx, int(txID.RoutingNumber), txID.ID)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return errPaymentAlreadyResolved
+		}
+		return p.walletRepo.Credit(dbtx, *pending.LocalAccountID, pending.Amount)
+	})
+	if errors.Is(txErr, errPaymentAlreadyResolved) {
+		return nil
+	}
+	if txErr != nil {
+		return txErr
+	}
+
+	slog.Info("interbank: payment COMMIT_TX applied",
+		"tx_routing", txID.RoutingNumber,
+		"tx_id", txID.ID,
+		"recipient_account", pending.RecipientAccountNumber,
+		"currency", pending.Currency,
+		"amount", pending.Amount,
+	)
+	return nil
+}
+
+// OnRollbackTx flips the pending row to rolled_back. No wallet effect:
+// we never reserved or debited the recipient. Idempotent.
+func (p *PaymentTxProcessor) OnRollbackTx(_ context.Context, _ *PartnerBank, txID ForeignBankId) error {
+	pending, err := p.paymentRepo.GetByTxID(int(txID.RoutingNumber), txID.ID)
+	if err != nil {
+		return fmt.Errorf("loading inbound payment: %w", err)
+	}
+	if pending == nil {
+		// We never voted YES — nothing to undo. The protocol allows
+		// the initiator to send ROLLBACK_TX to participants that
+		// voted NO; treat that as success.
+		return nil
+	}
+	if pending.Direction != models.InterbankPaymentDirectionInbound {
+		return fmt.Errorf("ROLLBACK_TX dispatched to payment processor for non-inbound row %d/%s", txID.RoutingNumber, txID.ID)
+	}
+
+	switch pending.Status {
+	case models.InterbankPaymentStatusRolledBack:
+		return nil
+	case models.InterbankPaymentStatusCommitted:
+		return fmt.Errorf("ROLLBACK_TX for already-committed payment %d/%s", txID.RoutingNumber, txID.ID)
+	case models.InterbankPaymentStatusPending:
+		// proceed
+	default:
+		return fmt.Errorf("inbound payment %d/%s has unknown status %q",
+			txID.RoutingNumber, txID.ID, pending.Status)
+	}
+
+	txErr := p.db.Transaction(func(dbtx *gorm.DB) error {
+		rows, err := p.paymentRepo.MarkRolledBackCAS(dbtx, int(txID.RoutingNumber), txID.ID)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return errPaymentAlreadyResolved
+		}
+		return nil
+	})
+	if errors.Is(txErr, errPaymentAlreadyResolved) {
+		return nil
+	}
+	if txErr != nil {
+		return txErr
+	}
+
+	slog.Info("interbank: payment ROLLBACK_TX applied",
+		"tx_routing", txID.RoutingNumber,
+		"tx_id", txID.ID,
+	)
+	return nil
+}
+
+// errPaymentVoteNo is an internal sentinel used inside OnNewTx's DB
+// transaction to roll back the open tx and propagate the precomputed
+// NoVoteReason out to the caller.
+var errPaymentVoteNo = errors.New("interbank: payment NEW_TX must vote NO")
+
+// errPaymentAlreadyResolved is the per-flow analogue of
+// errAlreadyResolved in the OTC processor — surfaced when the CAS
+// update finds the pending row already flipped by a concurrent caller.
+var errPaymentAlreadyResolved = errors.New("interbank: payment already resolved by concurrent caller")
+
+// paymentTx is the parsed view of a 2-posting MONAS ACCOUNT payment.
+type paymentTx struct {
+	senderPosting    *Posting
+	recipientPosting *Posting
+
+	senderAccount    string
+	recipientAccount string
+	senderRouting    RoutingNumber
+	recipientRouting RoutingNumber
+
+	currency string
+	amount   float64
+}
+
+// parsePaymentTx classifies a 2-posting MONAS-only ACCOUNT-only NEW_TX
+// as a payment. Any other shape returns nil so the dispatcher can try
+// the next processor (currently: only OTC and payment exist).
+func parsePaymentTx(tx *Transaction) (*paymentTx, *NoVoteReason) {
+	if len(tx.Postings) != 2 {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset}
+	}
+
+	parsed := &paymentTx{}
+	for i := range tx.Postings {
+		ptg := &tx.Postings[i]
+		if ptg.Account.Type != TxAccountAccount {
+			return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+		}
+		if strings.TrimSpace(ptg.Account.Num) == "" {
+			return nil, &NoVoteReason{Reason: ReasonNoSuchAccount, Posting: ptg}
+		}
+		if ptg.Asset.Type != AssetMonas || ptg.Asset.Monas == nil {
+			return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+		}
+		if ptg.Amount < 0 {
+			if parsed.senderPosting != nil {
+				return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+			}
+			parsed.senderPosting = ptg
+			parsed.senderAccount = ptg.Account.Num
+			parsed.amount = -ptg.Amount
+			parsed.currency = string(ptg.Asset.Monas.Currency)
+		} else {
+			if parsed.recipientPosting != nil {
+				return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: ptg}
+			}
+			parsed.recipientPosting = ptg
+			parsed.recipientAccount = ptg.Account.Num
+		}
+	}
+	if parsed.senderPosting == nil || parsed.recipientPosting == nil {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset}
+	}
+	if !nearlyEqual(parsed.senderPosting.Amount, -parsed.recipientPosting.Amount) {
+		return nil, &NoVoteReason{Reason: ReasonUnbalancedTx}
+	}
+	if parsed.senderPosting.Asset.Monas.Currency != parsed.recipientPosting.Asset.Monas.Currency {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.recipientPosting}
+	}
+	if parsed.amount <= 0 {
+		return nil, &NoVoteReason{Reason: ReasonUnacceptableAsset, Posting: parsed.senderPosting}
+	}
+
+	sendRouting, err := RoutingNumberFromAccount(parsed.senderAccount)
+	if err != nil {
+		return nil, &NoVoteReason{Reason: ReasonNoSuchAccount, Posting: parsed.senderPosting}
+	}
+	recvRouting, err := RoutingNumberFromAccount(parsed.recipientAccount)
+	if err != nil {
+		return nil, &NoVoteReason{Reason: ReasonNoSuchAccount, Posting: parsed.recipientPosting}
+	}
+	parsed.senderRouting = sendRouting
+	parsed.recipientRouting = recvRouting
+
+	return parsed, nil
+}
+
+// BuildPaymentTx assembles the 2-posting MONAS ACCOUNT Transaction that
+// represents a direct cross-bank payment on the wire. Sender posting is
+// credited (-amount, account loses funds), recipient is debited
+// (+amount, account gains funds), both in the same currency. Used by
+// both the sender-side HTTP handler and the reconciliation cron when
+// retrying a stuck NEW_TX.
+func BuildPaymentTx(txID ForeignBankId, senderAcc, recipientAcc, currency string, amount float64, message, paymentCode, paymentPurpose string) Transaction {
+	monas := Asset{
+		Type:  AssetMonas,
+		Monas: &MonetaryAsset{Currency: CurrencyCode(currency)},
+	}
+	return Transaction{
+		TransactionID:  txID,
+		Message:        message,
+		PaymentCode:    paymentCode,
+		PaymentPurpose: paymentPurpose,
+		Postings: []Posting{
+			{
+				Account: TxAccount{Type: TxAccountAccount, Num: senderAcc},
+				Amount:  -amount,
+				Asset:   monas,
+			},
+			{
+				Account: TxAccount{Type: TxAccountAccount, Num: recipientAcc},
+				Amount:  amount,
+				Asset:   monas,
+			},
+		},
+	}
+}
+
+// IsPaymentShape returns true when the transaction looks like a direct
+// cross-bank payment (2 MONAS ACCOUNT postings) rather than an OTC
+// option acceptance. Used by the dispatching TxProcessor to route
+// NEW_TX bodies to the right processor.
+func IsPaymentShape(tx *Transaction) bool {
+	if len(tx.Postings) != 2 {
+		return false
+	}
+	for i := range tx.Postings {
+		ptg := &tx.Postings[i]
+		if ptg.Account.Type != TxAccountAccount {
+			return false
+		}
+		if ptg.Asset.Type != AssetMonas {
+			return false
+		}
+	}
+	return true
+}

--- a/exchange-service/internal/models/interbank.go
+++ b/exchange-service/internal/models/interbank.go
@@ -21,6 +21,19 @@ const (
 )
 
 const (
+	InterbankPaymentDirectionOutbound = "outbound"
+	InterbankPaymentDirectionInbound  = "inbound"
+)
+
+const (
+	InterbankPaymentStatusPending    = "pending"
+	InterbankPaymentStatusCommitted  = "committed"
+	InterbankPaymentStatusRolledBack = "rolled_back"
+	InterbankPaymentStatusRejected   = "rejected"
+	InterbankPaymentStatusFailed     = "failed"
+)
+
+const (
 	InterbankOptionContractStatusValid     = "valid"
 	InterbankOptionContractStatusExercised = "exercised"
 	InterbankOptionContractStatusExpired   = "expired"
@@ -205,3 +218,165 @@ type InterbankOptionContract struct {
 }
 
 func (InterbankOptionContract) TableName() string { return "interbank_option_contracts" }
+
+// InterbankPayment is the per-side state record for a cross-bank direct
+// payment (the 2-posting MONAS shape of NEW_TX, where both postings are
+// TxAccount type ACCOUNT — see protocol §2.6). One row per side: the
+// initiator persists Direction=outbound, the recipient persists
+// Direction=inbound. The (TxRoutingNumber, TxID) composite is the
+// protocol's transactionId — globally unique because the initiator owns
+// its routing number.
+//
+// State machine:
+//
+//	pending → committed     (NEW_TX YES → COMMIT_TX applied)
+//	pending → rolled_back   (we voted YES, then ROLLBACK_TX arrived)
+//	pending → rejected      (partner voted NO; sender-side only)
+//	pending → failed        (transport error after NEW_TX; sender-side only)
+type InterbankPayment struct {
+	ID uint `gorm:"primaryKey"`
+
+	TxRoutingNumber int    `gorm:"column:tx_routing_number;not null;uniqueIndex:idx_interbank_payment_key,priority:1"`
+	TxID            string `gorm:"column:tx_id;type:varchar(64);not null;uniqueIndex:idx_interbank_payment_key,priority:2"`
+
+	// Direction: outbound = we initiated this payment; inbound = a
+	// partner POSTed NEW_TX to us as the recipient bank.
+	Direction string `gorm:"not null;index"`
+
+	// PartnerRoutingNumber is the OTHER bank in this payment.
+	PartnerRoutingNumber int `gorm:"column:partner_routing_number;not null;index"`
+
+	// Wire posting snapshot — needed so commit/rollback can apply local
+	// effects without re-parsing the original NEW_TX envelope.
+	SenderAccountNumber    string  `gorm:"column:sender_account_number;type:varchar(32);not null"`
+	RecipientAccountNumber string  `gorm:"column:recipient_account_number;type:varchar(32);not null"`
+	Currency               string  `gorm:"not null"`
+	Amount                 float64 `gorm:"not null"`
+
+	// LocalAccountID is the account we touched (sender's for outbound,
+	// recipient's for inbound). Used for status lookups and audit.
+	LocalAccountID *uint `gorm:"column:local_account_id;index"`
+
+	// LocalClientID identifies the local owner (outbound only — we
+	// persist nothing about the partner's customer for inbound).
+	LocalClientID *uint `gorm:"column:local_client_id;index"`
+
+	// Tx metadata copied verbatim from the envelope.
+	Message        string `gorm:"type:text"`
+	PaymentCode    string `gorm:"column:payment_code"`
+	PaymentPurpose string `gorm:"column:payment_purpose;type:text"`
+
+	Status    string `gorm:"not null;default:'pending';index"`
+	LastError string `gorm:"column:last_error;type:text"`
+
+	// PartnerFinalisedAt is set when the terminal partner message
+	// (COMMIT_TX for committed; ROLLBACK_TX for failed) has been
+	// acknowledged. The reconciliation cron picks up resolved
+	// outbound rows where this is still null and replays the terminal
+	// message until the partner ACKs. Always nil for inbound rows —
+	// the receiver doesn't drive retransmission, the sender does.
+	PartnerFinalisedAt *time.Time `gorm:"column:partner_finalised_at"`
+
+	CreatedAt  time.Time  `gorm:"not null"`
+	UpdatedAt  time.Time  `gorm:"not null"`
+	ResolvedAt *time.Time `gorm:"column:resolved_at"`
+}
+
+func (InterbankPayment) TableName() string { return "interbank_payments" }
+
+// RemotePublicStockSnapshot caches one partner bank's /public-stock
+// response so the local frontend's "browse cross-bank OTC offers" page
+// doesn't pay a fan-out cost on every request. The reconciliation cron
+// refreshes one row per partner @every 5m. Stale-but-good rows are
+// returned with a `stale=true` flag rather than dropped, so a transient
+// partner outage doesn't blank the catalogue.
+//
+// PartnerRoutingNumber is the primary key — one row per partner.
+// PayloadJSON holds the raw interbank.PublicStocksResponse JSON to
+// keep the cache schema-agnostic; the handler unmarshals on read.
+type RemotePublicStockSnapshot struct {
+	PartnerRoutingNumber int    `gorm:"column:partner_routing_number;primaryKey"`
+	PayloadJSON          string `gorm:"column:payload_json;type:text"`
+	LastError            string `gorm:"column:last_error;type:text"`
+
+	FetchedAt time.Time `gorm:"column:fetched_at;not null"`
+	UpdatedAt time.Time `gorm:"not null"`
+}
+
+func (RemotePublicStockSnapshot) TableName() string { return "remote_public_stock_snapshots" }
+
+const (
+	InterbankExerciseDirectionOutbound = "outbound" // we are the buyer's bank initiating
+	InterbankExerciseDirectionInbound  = "inbound"  // we are the seller's bank receiving
+)
+
+const (
+	InterbankExerciseStatusPending    = "pending"
+	InterbankExerciseStatusCommitted  = "committed"
+	InterbankExerciseStatusRolledBack = "rolled_back"
+	InterbankExerciseStatusRejected   = "rejected"
+	InterbankExerciseStatusFailed     = "failed"
+)
+
+// InterbankPendingExercise tracks the per-side state of a cross-bank
+// option exercise (the 4-posting MONAS+STOCK transaction described in
+// protocol §2.7.2: debit OPTION pseudo for π·k cash, credit buyer for
+// π·k cash, credit OPTION pseudo for k stocks, debit buyer for k
+// stocks).
+//
+// Outbound (Direction='outbound'): we own the option, our bank is the
+// initiator. BuyerLocal* fields point at our own client + account that
+// will be debited the cash on COMMIT_TX. OptionContractID points at
+// the local InterbankOptionContract row being consumed.
+//
+// Inbound (Direction='inbound'): partner-bank's user holds the option
+// and exercises against us. On COMMIT_TX we reduce the seller's
+// holding by StockAmount and credit the seller's account by
+// CashAmount; the seller identity comes from the linked
+// InterbankOtcNegotiation row.
+type InterbankPendingExercise struct {
+	ID uint `gorm:"primaryKey"`
+
+	TxRoutingNumber int    `gorm:"column:tx_routing_number;not null;uniqueIndex:idx_interbank_pending_exercise_key,priority:1"`
+	TxID            string `gorm:"column:tx_id;type:varchar(64);not null;uniqueIndex:idx_interbank_pending_exercise_key,priority:2"`
+
+	Direction string `gorm:"not null;index"`
+
+	PartnerRoutingNumber int `gorm:"column:partner_routing_number;not null;index"`
+
+	// NegotiationRoutingNumber/ID identify the option being exercised.
+	// On inbound, this is also the join key to InterbankOtcNegotiation
+	// so we can find the seller. On outbound, it's the key to the
+	// InterbankOptionContract.
+	NegotiationRoutingNumber int    `gorm:"column:negotiation_routing_number;not null;index"`
+	NegotiationID            string `gorm:"column:negotiation_id;type:varchar(64);not null"`
+
+	StockTicker string  `gorm:"column:stock_ticker;not null"`
+	StockAmount float64 `gorm:"column:stock_amount;not null"`
+
+	PricePerUnitCurrency string  `gorm:"column:price_per_unit_currency;not null"`
+	PricePerUnitAmount   float64 `gorm:"column:price_per_unit_amount;not null"`
+
+	// CashAmount is StockAmount × PricePerUnitAmount, denormalised for
+	// idempotent ledger ops.
+	CashAmount float64 `gorm:"column:cash_amount;not null"`
+
+	BuyerRoutingNumber  int    `gorm:"column:buyer_routing_number;not null"`
+	BuyerID             string `gorm:"column:buyer_id;type:varchar(64);not null"`
+	SellerRoutingNumber int    `gorm:"column:seller_routing_number;not null"`
+	SellerID            string `gorm:"column:seller_id;type:varchar(64);not null"`
+
+	BuyerLocalAccountID *uint `gorm:"column:buyer_local_account_id;index"`
+	BuyerLocalClientID  *uint `gorm:"column:buyer_local_client_id;index"`
+	OptionContractID    *uint `gorm:"column:option_contract_id;index"`
+
+	Status    string `gorm:"not null;default:'pending';index"`
+	LastError string `gorm:"column:last_error;type:text"`
+
+	PartnerFinalisedAt *time.Time `gorm:"column:partner_finalised_at"`
+	CreatedAt          time.Time  `gorm:"not null"`
+	UpdatedAt          time.Time  `gorm:"not null"`
+	ResolvedAt         *time.Time `gorm:"column:resolved_at"`
+}
+
+func (InterbankPendingExercise) TableName() string { return "interbank_pending_exercises" }

--- a/exchange-service/internal/repository/interbank_exercise_repository.go
+++ b/exchange-service/internal/repository/interbank_exercise_repository.go
@@ -1,0 +1,154 @@
+package repository
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+)
+
+// InterbankExerciseRepository persists InterbankPendingExercise rows
+// and the CAS status flips that the exercise TxProcessor + initiator
+// drive. Both sides (outbound buyer-bank and inbound seller-bank) use
+// the same table; rows are distinguished by Direction.
+type InterbankExerciseRepository struct {
+	db *gorm.DB
+}
+
+func NewInterbankExerciseRepository(db *gorm.DB) *InterbankExerciseRepository {
+	return &InterbankExerciseRepository{db: db}
+}
+
+func (r *InterbankExerciseRepository) DB() *gorm.DB { return r.db }
+
+// GetByTxID returns the exercise row keyed by the protocol transactionId.
+func (r *InterbankExerciseRepository) GetByTxID(routing int, id string) (*models.InterbankPendingExercise, error) {
+	var row models.InterbankPendingExercise
+	err := r.db.Where("tx_routing_number = ? AND tx_id = ?", routing, id).First(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("loading pending exercise %d/%s: %w", routing, id, err)
+	}
+	return &row, nil
+}
+
+// HasCommittedForNegotiation returns true when any exercise for the
+// given negotiation has already committed. Used by the inbound
+// processor to vote NO with OPTION_USED_OR_EXPIRED on a double-exercise
+// attempt.
+func (r *InterbankExerciseRepository) HasCommittedForNegotiation(routing int, id string) (bool, error) {
+	var count int64
+	err := r.db.Model(&models.InterbankPendingExercise{}).
+		Where("negotiation_routing_number = ? AND negotiation_id = ? AND status = ?",
+			routing, id, models.InterbankExerciseStatusCommitted).
+		Count(&count).Error
+	if err != nil {
+		return false, fmt.Errorf("checking exercise commit history for %d/%s: %w", routing, id, err)
+	}
+	return count > 0, nil
+}
+
+// CreateTx inserts a new exercise row under the caller's DB tx.
+func (r *InterbankExerciseRepository) CreateTx(tx *gorm.DB, row *models.InterbankPendingExercise) error {
+	now := time.Now().UTC()
+	if row.CreatedAt.IsZero() {
+		row.CreatedAt = now
+	}
+	row.UpdatedAt = now
+	if row.Status == "" {
+		row.Status = models.InterbankExerciseStatusPending
+	}
+	return tx.Create(row).Error
+}
+
+// MarkCommittedCAS flips pending → committed atomically.
+func (r *InterbankExerciseRepository) MarkCommittedCAS(tx *gorm.DB, routing int, id string) (int64, error) {
+	now := time.Now().UTC()
+	res := tx.Model(&models.InterbankPendingExercise{}).
+		Where("tx_routing_number = ? AND tx_id = ? AND status = ?",
+			routing, id, models.InterbankExerciseStatusPending).
+		Updates(map[string]interface{}{
+			"status":      models.InterbankExerciseStatusCommitted,
+			"resolved_at": now,
+			"updated_at":  now,
+		})
+	if res.Error != nil {
+		return 0, fmt.Errorf("marking exercise committed: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}
+
+// MarkRolledBackCAS flips pending → rolled_back atomically.
+func (r *InterbankExerciseRepository) MarkRolledBackCAS(tx *gorm.DB, routing int, id string) (int64, error) {
+	now := time.Now().UTC()
+	res := tx.Model(&models.InterbankPendingExercise{}).
+		Where("tx_routing_number = ? AND tx_id = ? AND status = ?",
+			routing, id, models.InterbankExerciseStatusPending).
+		Updates(map[string]interface{}{
+			"status":      models.InterbankExerciseStatusRolledBack,
+			"resolved_at": now,
+			"updated_at":  now,
+		})
+	if res.Error != nil {
+		return 0, fmt.Errorf("marking exercise rolled back: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}
+
+// MarkRejectedCAS flips pending → rejected (sender side, partner NO).
+func (r *InterbankExerciseRepository) MarkRejectedCAS(tx *gorm.DB, routing int, id string, reason string) (int64, error) {
+	now := time.Now().UTC()
+	res := tx.Model(&models.InterbankPendingExercise{}).
+		Where("tx_routing_number = ? AND tx_id = ? AND status = ?",
+			routing, id, models.InterbankExerciseStatusPending).
+		Updates(map[string]interface{}{
+			"status":      models.InterbankExerciseStatusRejected,
+			"last_error":  reason,
+			"resolved_at": now,
+			"updated_at":  now,
+		})
+	if res.Error != nil {
+		return 0, fmt.Errorf("marking exercise rejected: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}
+
+// MarkFailedCAS flips pending → failed (sender side, transport error).
+func (r *InterbankExerciseRepository) MarkFailedCAS(tx *gorm.DB, routing int, id string, errMsg string) (int64, error) {
+	now := time.Now().UTC()
+	res := tx.Model(&models.InterbankPendingExercise{}).
+		Where("tx_routing_number = ? AND tx_id = ? AND status = ?",
+			routing, id, models.InterbankExerciseStatusPending).
+		Updates(map[string]interface{}{
+			"status":      models.InterbankExerciseStatusFailed,
+			"last_error":  errMsg,
+			"resolved_at": now,
+			"updated_at":  now,
+		})
+	if res.Error != nil {
+		return 0, fmt.Errorf("marking exercise failed: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}
+
+// MarkPartnerFinalised stamps PartnerFinalisedAt — used by the (future)
+// reconciliation cron to stop replaying the terminal message once the
+// partner has ACKed it.
+func (r *InterbankExerciseRepository) MarkPartnerFinalised(tx *gorm.DB, routing int, id string) (int64, error) {
+	now := time.Now().UTC()
+	res := tx.Model(&models.InterbankPendingExercise{}).
+		Where("tx_routing_number = ? AND tx_id = ? AND partner_finalised_at IS NULL", routing, id).
+		Updates(map[string]interface{}{
+			"partner_finalised_at": now,
+			"updated_at":           now,
+		})
+	if res.Error != nil {
+		return 0, fmt.Errorf("marking exercise partner-finalised: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}

--- a/exchange-service/internal/repository/interbank_payment_repository.go
+++ b/exchange-service/internal/repository/interbank_payment_repository.go
@@ -1,0 +1,358 @@
+package repository
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+)
+
+// ErrInterbankPaymentNoSuchAccount is returned by the payment wallet
+// lookup when the account number does not exist, is not active, or
+// does not match the requested currency. The TxProcessor maps each
+// distinct cause to a different NoVoteReason, so the caller checks
+// against the more specific sentinels below before falling back to
+// this.
+var (
+	ErrInterbankPaymentNoSuchAccount      = errors.New("interbank payment wallet: no such account")
+	ErrInterbankPaymentAccountInactive    = errors.New("interbank payment wallet: account is not active")
+	ErrInterbankPaymentCurrencyMismatch   = errors.New("interbank payment wallet: account currency does not match posting")
+	ErrInterbankPaymentInsufficientFunds  = errors.New("interbank payment wallet: insufficient available balance")
+)
+
+// InterbankPaymentRepository persists and looks up InterbankPayment rows
+// keyed by the protocol's globally-unique transactionId. Methods that
+// must run inside a caller-supplied DB transaction take a *gorm.DB so
+// the row write lands together with the wallet effect.
+type InterbankPaymentRepository struct {
+	db *gorm.DB
+}
+
+func NewInterbankPaymentRepository(db *gorm.DB) *InterbankPaymentRepository {
+	return &InterbankPaymentRepository{db: db}
+}
+
+// DB exposes the underlying *gorm.DB so callers can open their own
+// transactions when bundling repo writes with wallet effects.
+func (r *InterbankPaymentRepository) DB() *gorm.DB { return r.db }
+
+// GetByTxID returns the row keyed by the protocol transactionId
+// (routingNumber, id), or nil if none exists.
+func (r *InterbankPaymentRepository) GetByTxID(routing int, id string) (*models.InterbankPayment, error) {
+	var row models.InterbankPayment
+	err := r.db.Where("tx_routing_number = ? AND tx_id = ?", routing, id).First(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("loading payment %d/%s: %w", routing, id, err)
+	}
+	return &row, nil
+}
+
+// GetByID returns the row keyed by its local autoincrement ID, used by
+// the local frontend to poll a payment it just initiated.
+func (r *InterbankPaymentRepository) GetByID(id uint) (*models.InterbankPayment, error) {
+	var row models.InterbankPayment
+	err := r.db.First(&row, id).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("loading payment id %d: %w", id, err)
+	}
+	return &row, nil
+}
+
+// CreateTx inserts a new payment row under the caller's DB transaction.
+// Used by both the sender-side initiator (after reserving funds) and
+// the receiver-side TxProcessor (after voting YES).
+func (r *InterbankPaymentRepository) CreateTx(tx *gorm.DB, row *models.InterbankPayment) error {
+	now := time.Now().UTC()
+	if row.CreatedAt.IsZero() {
+		row.CreatedAt = now
+	}
+	row.UpdatedAt = now
+	if row.Status == "" {
+		row.Status = models.InterbankPaymentStatusPending
+	}
+	return tx.Create(row).Error
+}
+
+// ListOutboundForClient returns the most recent outbound payments owned
+// by the given client. Newest first. Used by the frontend "my cross-bank
+// payments" view.
+func (r *InterbankPaymentRepository) ListOutboundForClient(clientID uint, limit int) ([]models.InterbankPayment, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	var rows []models.InterbankPayment
+	err := r.db.
+		Where("direction = ? AND local_client_id = ?", models.InterbankPaymentDirectionOutbound, clientID).
+		Order("created_at DESC").
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("listing outbound payments: %w", err)
+	}
+	return rows, nil
+}
+
+// MarkCommittedCAS flips a pending row to committed atomically. Returns
+// rowsAffected so the caller can distinguish "we did the work" (1) from
+// "somebody else already resolved this" (0).
+func (r *InterbankPaymentRepository) MarkCommittedCAS(tx *gorm.DB, routing int, id string) (int64, error) {
+	now := time.Now().UTC()
+	res := tx.Model(&models.InterbankPayment{}).
+		Where("tx_routing_number = ? AND tx_id = ? AND status = ?",
+			routing, id, models.InterbankPaymentStatusPending).
+		Updates(map[string]interface{}{
+			"status":      models.InterbankPaymentStatusCommitted,
+			"resolved_at": now,
+			"updated_at":  now,
+		})
+	if res.Error != nil {
+		return 0, fmt.Errorf("marking payment committed: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}
+
+// MarkRolledBackCAS flips a pending row to rolled_back atomically.
+func (r *InterbankPaymentRepository) MarkRolledBackCAS(tx *gorm.DB, routing int, id string) (int64, error) {
+	now := time.Now().UTC()
+	res := tx.Model(&models.InterbankPayment{}).
+		Where("tx_routing_number = ? AND tx_id = ? AND status = ?",
+			routing, id, models.InterbankPaymentStatusPending).
+		Updates(map[string]interface{}{
+			"status":      models.InterbankPaymentStatusRolledBack,
+			"resolved_at": now,
+			"updated_at":  now,
+		})
+	if res.Error != nil {
+		return 0, fmt.Errorf("marking payment rolled back: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}
+
+// MarkRejectedCAS flips a pending row to rejected (partner voted NO) and
+// records the reason text. Sender-side only.
+func (r *InterbankPaymentRepository) MarkRejectedCAS(tx *gorm.DB, routing int, id string, reason string) (int64, error) {
+	now := time.Now().UTC()
+	res := tx.Model(&models.InterbankPayment{}).
+		Where("tx_routing_number = ? AND tx_id = ? AND status = ?",
+			routing, id, models.InterbankPaymentStatusPending).
+		Updates(map[string]interface{}{
+			"status":      models.InterbankPaymentStatusRejected,
+			"last_error":  reason,
+			"resolved_at": now,
+			"updated_at":  now,
+		})
+	if res.Error != nil {
+		return 0, fmt.Errorf("marking payment rejected: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}
+
+// MarkPartnerFinalised stamps PartnerFinalisedAt = now on a resolved
+// row so the reconciliation cron stops retrying the terminal message.
+// No-op (RowsAffected == 0) on rows that already have it set; callers
+// don't need to distinguish.
+func (r *InterbankPaymentRepository) MarkPartnerFinalised(tx *gorm.DB, routing int, id string) (int64, error) {
+	now := time.Now().UTC()
+	res := tx.Model(&models.InterbankPayment{}).
+		Where("tx_routing_number = ? AND tx_id = ? AND partner_finalised_at IS NULL", routing, id).
+		Updates(map[string]interface{}{
+			"partner_finalised_at": now,
+			"updated_at":           now,
+		})
+	if res.Error != nil {
+		return 0, fmt.Errorf("marking payment partner-finalised: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}
+
+// ListStuckPending returns outbound payments still in `pending` whose
+// updated_at is older than threshold. Used by the reconciliation cron
+// to retry NEW_TX. Limit caps the batch so a backlog can't starve the
+// scheduler.
+func (r *InterbankPaymentRepository) ListStuckPending(threshold time.Time, limit int) ([]models.InterbankPayment, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	var rows []models.InterbankPayment
+	err := r.db.
+		Where("direction = ? AND status = ? AND updated_at < ?",
+			models.InterbankPaymentDirectionOutbound,
+			models.InterbankPaymentStatusPending,
+			threshold,
+		).
+		Order("updated_at ASC").
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("listing stuck pending payments: %w", err)
+	}
+	return rows, nil
+}
+
+// ListUndispatchedTerminal returns outbound payments whose status is
+// resolved (committed / failed) but whose terminal partner message has
+// not yet been acknowledged. The cron replays COMMIT_TX or ROLLBACK_TX
+// for these. `rejected` is excluded — the partner already voted NO and
+// holds no resources, so no terminal message is owed.
+func (r *InterbankPaymentRepository) ListUndispatchedTerminal(threshold time.Time, limit int) ([]models.InterbankPayment, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	var rows []models.InterbankPayment
+	err := r.db.
+		Where("direction = ? AND status IN ? AND partner_finalised_at IS NULL AND updated_at < ?",
+			models.InterbankPaymentDirectionOutbound,
+			[]string{models.InterbankPaymentStatusCommitted, models.InterbankPaymentStatusFailed},
+			threshold,
+		).
+		Order("updated_at ASC").
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, fmt.Errorf("listing undispatched terminal payments: %w", err)
+	}
+	return rows, nil
+}
+
+// MarkFailedCAS flips a pending row to failed (transport error or
+// timeout). Sender-side only.
+func (r *InterbankPaymentRepository) MarkFailedCAS(tx *gorm.DB, routing int, id string, errMsg string) (int64, error) {
+	now := time.Now().UTC()
+	res := tx.Model(&models.InterbankPayment{}).
+		Where("tx_routing_number = ? AND tx_id = ? AND status = ?",
+			routing, id, models.InterbankPaymentStatusPending).
+		Updates(map[string]interface{}{
+			"status":      models.InterbankPaymentStatusFailed,
+			"last_error":  errMsg,
+			"resolved_at": now,
+			"updated_at":  now,
+		})
+	if res.Error != nil {
+		return 0, fmt.Errorf("marking payment failed: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}
+
+// InterbankPaymentWalletRepository wraps the local accounts table for
+// the cross-bank payment flow. The protocol's payment shape uses
+// TxAccount type ACCOUNT (currency account number), so all lookups
+// here go by broj_racuna — distinct from InterbankWalletRepository
+// which uses "first active account in currency" for the OTC flow.
+type InterbankPaymentWalletRepository struct {
+	db *gorm.DB
+}
+
+func NewInterbankPaymentWalletRepository(db *gorm.DB) *InterbankPaymentWalletRepository {
+	return &InterbankPaymentWalletRepository{db: db}
+}
+
+// AccountSnapshot is the subset of the accounts row this flow needs.
+type AccountSnapshot struct {
+	ID                uint    `gorm:"column:id"`
+	BrojRacuna        string  `gorm:"column:broj_racuna"`
+	ClientID          *uint   `gorm:"column:client_id"`
+	CurrencyCode      string  `gorm:"column:currency_code"`
+	Status            string  `gorm:"column:status"`
+	Stanje            float64 `gorm:"column:stanje"`
+	RaspolozivoStanje float64 `gorm:"column:raspolozivo_stanje"`
+}
+
+// LockByNumber finds the account by broj_racuna, locks the row FOR
+// UPDATE under the caller's tx, and validates status + currency.
+// Returns the typed sentinels above so the caller can map each cause
+// to the right NoVoteReason / HTTP error.
+func (r *InterbankPaymentWalletRepository) LockByNumber(tx *gorm.DB, brojRacuna, currency string) (*AccountSnapshot, error) {
+	var row AccountSnapshot
+	err := tx.Table("accounts").
+		Select("accounts.id, accounts.broj_racuna, accounts.client_id, currencies.kod AS currency_code, accounts.status, accounts.stanje, accounts.raspolozivo_stanje").
+		Joins("JOIN currencies ON currencies.id = accounts.currency_id").
+		Where("accounts.broj_racuna = ?", brojRacuna).
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		First(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrInterbankPaymentNoSuchAccount
+		}
+		return nil, fmt.Errorf("locking account %s: %w", brojRacuna, err)
+	}
+	if row.Status != "aktivan" {
+		return &row, ErrInterbankPaymentAccountInactive
+	}
+	if row.CurrencyCode != currency {
+		return &row, ErrInterbankPaymentCurrencyMismatch
+	}
+	return &row, nil
+}
+
+// Reserve decrements raspolozivo_stanje by amount on the locked sender
+// account. Caller MUST have run LockByNumber inside the same tx first.
+// Returns ErrInterbankPaymentInsufficientFunds when the available
+// balance is below amount.
+func (r *InterbankPaymentWalletRepository) Reserve(tx *gorm.DB, accountID uint, amount float64) error {
+	res := tx.Table("accounts").
+		Where("id = ? AND raspolozivo_stanje >= ?", accountID, amount).
+		Updates(map[string]interface{}{
+			"raspolozivo_stanje": gorm.Expr("raspolozivo_stanje - ?", amount),
+		})
+	if res.Error != nil {
+		return fmt.Errorf("reserving sender funds: %w", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return ErrInterbankPaymentInsufficientFunds
+	}
+	return nil
+}
+
+// Debit completes the reservation: stanje -= amount. raspolozivo_stanje
+// was already decremented by Reserve, so we don't touch it again.
+func (r *InterbankPaymentWalletRepository) Debit(tx *gorm.DB, accountID uint, amount float64) error {
+	res := tx.Table("accounts").
+		Where("id = ?", accountID).
+		Updates(map[string]interface{}{
+			"stanje": gorm.Expr("stanje - ?", amount),
+		})
+	if res.Error != nil {
+		return fmt.Errorf("debiting sender funds: %w", res.Error)
+	}
+	return nil
+}
+
+// Release refunds a Reserve by bumping raspolozivo_stanje back up.
+// stanje was never touched on a reserved-but-not-committed payment.
+func (r *InterbankPaymentWalletRepository) Release(tx *gorm.DB, accountID uint, amount float64) error {
+	res := tx.Table("accounts").
+		Where("id = ?", accountID).
+		Updates(map[string]interface{}{
+			"raspolozivo_stanje": gorm.Expr("raspolozivo_stanje + ?", amount),
+		})
+	if res.Error != nil {
+		return fmt.Errorf("releasing sender reservation: %w", res.Error)
+	}
+	return nil
+}
+
+// Credit applies the recipient-side commit: both stanje and
+// raspolozivo_stanje go up so the recipient can both see and spend the
+// funds immediately.
+func (r *InterbankPaymentWalletRepository) Credit(tx *gorm.DB, accountID uint, amount float64) error {
+	res := tx.Table("accounts").
+		Where("id = ?", accountID).
+		Updates(map[string]interface{}{
+			"stanje":             gorm.Expr("stanje + ?", amount),
+			"raspolozivo_stanje": gorm.Expr("raspolozivo_stanje + ?", amount),
+		})
+	if res.Error != nil {
+		return fmt.Errorf("crediting recipient funds: %w", res.Error)
+	}
+	return nil
+}

--- a/exchange-service/internal/repository/interbank_tx_repository.go
+++ b/exchange-service/internal/repository/interbank_tx_repository.go
@@ -114,3 +114,44 @@ func (r *InterbankOptionContractRepository) Get(negotiationRoutingNumber int, ne
 	}
 	return &row, nil
 }
+
+// GetByID fetches a contract by autoincrement primary key. Used by the
+// buyer-side exercise endpoint where the FE poll knows the local id.
+func (r *InterbankOptionContractRepository) GetByID(id uint) (*models.InterbankOptionContract, error) {
+	var row models.InterbankOptionContract
+	err := r.db.First(&row, id).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &row, nil
+}
+
+// ListByBuyerLocalID returns the contracts owned by the given encoded
+// local participant id (the "client-N" form), newest first. Used by
+// the FE "my cross-bank options" view.
+func (r *InterbankOptionContractRepository) ListByBuyerLocalID(buyerLocalID string) ([]models.InterbankOptionContract, error) {
+	var rows []models.InterbankOptionContract
+	if err := r.db.
+		Where("buyer_local_id = ?", buyerLocalID).
+		Order("created_at DESC").
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// MarkExercisedCAS flips a valid contract to exercised. Returns rows
+// affected so the caller can detect concurrent double-exercise.
+func (r *InterbankOptionContractRepository) MarkExercisedCAS(tx *gorm.DB, id uint) (int64, error) {
+	now := time.Now().UTC()
+	res := tx.Model(&models.InterbankOptionContract{}).
+		Where("id = ? AND status = ?", id, models.InterbankOptionContractStatusValid).
+		Updates(map[string]interface{}{
+			"status":     models.InterbankOptionContractStatusExercised,
+			"updated_at": now,
+		})
+	return res.RowsAffected, res.Error
+}

--- a/exchange-service/internal/repository/interbank_wallet_repository.go
+++ b/exchange-service/internal/repository/interbank_wallet_repository.go
@@ -122,6 +122,16 @@ func (r *InterbankWalletRepository) Credit(tx *gorm.DB, localID, currency string
 	return nil
 }
 
+// LookupClientAccountID is the exported version of lockClientAccount,
+// for callers that need the account ID for downstream non-wallet
+// effects (e.g. setting the account_id on a new portfolio_holdings row
+// after cross-bank option exercise). Behaves identically to the
+// internal helper — locks the row FOR UPDATE under the caller's tx so
+// repeated calls within the same tx serialise on the same row.
+func (r *InterbankWalletRepository) LookupClientAccountID(tx *gorm.DB, localID, currency string) (uint, error) {
+	return r.lockClientAccount(tx, localID, currency)
+}
+
 // lockClientAccount finds and SELECT-FOR-UPDATE-locks the client's
 // first active account in the given currency — used for both buyer
 // debits (Reserve/Debit/Release) and seller credits (Credit). Returns

--- a/exchange-service/internal/repository/remote_public_stock_repository.go
+++ b/exchange-service/internal/repository/remote_public_stock_repository.go
@@ -1,0 +1,99 @@
+package repository
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+)
+
+// RemotePublicStockRepository persists one cached /public-stock response
+// per partner bank. The cron writes through Upsert*; the handler reads
+// through List.
+type RemotePublicStockRepository struct {
+	db *gorm.DB
+}
+
+func NewRemotePublicStockRepository(db *gorm.DB) *RemotePublicStockRepository {
+	return &RemotePublicStockRepository{db: db}
+}
+
+// UpsertPayload writes a successful refresh: replaces payload_json, clears
+// last_error, bumps fetched_at + updated_at. The upsert is on the
+// primary key (partner_routing_number), so one row per partner.
+func (r *RemotePublicStockRepository) UpsertPayload(partner int, payloadJSON string) error {
+	now := time.Now().UTC()
+	row := models.RemotePublicStockSnapshot{
+		PartnerRoutingNumber: partner,
+		PayloadJSON:          payloadJSON,
+		LastError:            "",
+		FetchedAt:            now,
+		UpdatedAt:            now,
+	}
+	err := r.db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "partner_routing_number"}},
+		DoUpdates: clause.Assignments(map[string]interface{}{
+			"payload_json": payloadJSON,
+			"last_error":   "",
+			"fetched_at":   now,
+			"updated_at":   now,
+		}),
+	}).Create(&row).Error
+	if err != nil {
+		return fmt.Errorf("upserting public-stock snapshot for partner %d: %w", partner, err)
+	}
+	return nil
+}
+
+// UpsertError records a failed refresh. We keep the previously-cached
+// payload_json untouched (stale-but-good is better than blank) and
+// only bump last_error + updated_at. Insert-or-update so a partner
+// that's never succeeded still gets a row visible to the handler.
+func (r *RemotePublicStockRepository) UpsertError(partner int, errMsg string) error {
+	now := time.Now().UTC()
+	existing := models.RemotePublicStockSnapshot{
+		PartnerRoutingNumber: partner,
+		PayloadJSON:          "",
+		LastError:            errMsg,
+		FetchedAt:            now,
+		UpdatedAt:            now,
+	}
+	err := r.db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "partner_routing_number"}},
+		DoUpdates: clause.Assignments(map[string]interface{}{
+			"last_error": errMsg,
+			"updated_at": now,
+		}),
+	}).Create(&existing).Error
+	if err != nil {
+		return fmt.Errorf("recording public-stock snapshot error for partner %d: %w", partner, err)
+	}
+	return nil
+}
+
+// List returns every cached snapshot, in insertion order. Caller
+// iterates and unmarshals the payloads.
+func (r *RemotePublicStockRepository) List() ([]models.RemotePublicStockSnapshot, error) {
+	var rows []models.RemotePublicStockSnapshot
+	if err := r.db.Order("partner_routing_number ASC").Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("listing public-stock snapshots: %w", err)
+	}
+	return rows, nil
+}
+
+// Get returns a single partner's snapshot, or nil if no row exists.
+func (r *RemotePublicStockRepository) Get(partner int) (*models.RemotePublicStockSnapshot, error) {
+	var row models.RemotePublicStockSnapshot
+	err := r.db.Where("partner_routing_number = ?", partner).First(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("loading public-stock snapshot for partner %d: %w", partner, err)
+	}
+	return &row, nil
+}

--- a/exchange-service/internal/service/cron_service.go
+++ b/exchange-service/internal/service/cron_service.go
@@ -15,8 +15,19 @@ import (
 // StartCronJobs sets up and starts the cron scheduler for the exchange service.
 // portfolioSvc is created in main and shared with the portfolio HTTP handler.
 // sagaRetry is optional; when non-nil it is invoked every 5 minutes to retry
-// stuck SAGA compensations.
-func StartCronJobs(db *gorm.DB, portfolioSvc *PortfolioService, rateProvider RateProviderInterface, sagaRetry *SagaRetryRunner, fundSvc *FundService) *cron.Cron {
+// stuck SAGA compensations. interbankReconcile is optional; when non-nil it
+// is invoked every 2 minutes to retry stuck cross-bank payments.
+// publicStockCache is optional; when non-nil it is invoked every 5 minutes
+// to refresh partner /public-stock snapshots.
+func StartCronJobs(
+	db *gorm.DB,
+	portfolioSvc *PortfolioService,
+	rateProvider RateProviderInterface,
+	sagaRetry *SagaRetryRunner,
+	fundSvc *FundService,
+	interbankReconcile *InterbankReconcileRunner,
+	publicStockCache *PublicStockCacheRunner,
+) *cron.Cron {
 	c := cron.New()
 
 	// Refresh listing prices every 15 minutes.
@@ -54,6 +65,34 @@ func StartCronJobs(db *gorm.DB, portfolioSvc *PortfolioService, rateProvider Rat
 		})
 		if err != nil {
 			slog.Error("Failed to add SAGA retry cron job", "error", err)
+		}
+	}
+
+	// Inter-bank payment reconciliation: retransmit stuck NEW_TX and
+	// pending COMMIT_TX/ROLLBACK_TX messages every 2 minutes. The
+	// partner's idempotency by transactionId means replays are safe.
+	if interbankReconcile != nil {
+		_, err = c.AddFunc("@every 2m", func() {
+			interbankReconcile.Run()
+		})
+		if err != nil {
+			slog.Error("Failed to add inter-bank reconcile cron job", "error", err)
+		}
+	}
+
+	// Partner /public-stock cache refresh: fan out every 5 minutes so
+	// the local cross-bank OTC discovery page reads pre-fetched
+	// snapshots instead of paying the network cost on every request.
+	if publicStockCache != nil {
+		// Kick off one refresh immediately so the cache is warm on
+		// process start rather than waiting up to 5m for the first
+		// tick.
+		go publicStockCache.Run()
+		_, err = c.AddFunc("@every 5m", func() {
+			publicStockCache.Run()
+		})
+		if err != nil {
+			slog.Error("Failed to add public-stock cache cron job", "error", err)
 		}
 	}
 

--- a/exchange-service/internal/service/interbank_reconcile.go
+++ b/exchange-service/internal/service/interbank_reconcile.go
@@ -1,0 +1,341 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// InterbankReconcileRunner drives the BANKA-BE-8 reconciliation cron
+// for cross-bank payments. Two responsibilities per tick:
+//
+//  1. Re-dispatch NEW_TX for outbound payments stuck in `pending` past
+//     a staleness threshold. This covers crashes between Reserve and
+//     SendNewTx, partner timeouts, and 202-poll budget exhaustion.
+//     The partner's business-level idempotency (keyed by transactionId)
+//     replays the cached vote without re-applying effects, so a retry
+//     with a fresh idempotence key is safe.
+//
+//  2. Re-dispatch terminal messages (COMMIT_TX for committed,
+//     ROLLBACK_TX for failed) where partner_finalised_at is still NULL.
+//     Receiver-side idempotency makes resends a no-op once the partner
+//     has applied the effect.
+//
+// `rejected` rows are never re-dispatched — the partner voted NO and
+// holds no resources, so no terminal message is owed; finaliseRejected
+// stamps partner_finalised_at at the same time as the status flip.
+//
+// The runner is intentionally pull-driven (cron scans rows on each
+// tick) instead of push-driven (queued from the HTTP path) so a crash
+// of the inline path can't lose work — the row in the DB is the
+// authoritative source of "this needs reconciling".
+type InterbankReconcileRunner struct {
+	db          *gorm.DB
+	registry    *interbank.Registry
+	client      *interbank.Client
+	paymentRepo *repository.InterbankPaymentRepository
+	walletRepo  *repository.InterbankPaymentWalletRepository
+
+	// staleness is how old updated_at must be before a row is eligible.
+	// Defaults to 5 minutes; tests can override to exercise the cron
+	// without waiting wall-clock time.
+	staleness time.Duration
+
+	// batchSize caps rows examined per tick to keep one slow partner
+	// from starving the scheduler.
+	batchSize int
+}
+
+// NewInterbankReconcileRunner wires the cron runner.
+func NewInterbankReconcileRunner(
+	db *gorm.DB,
+	registry *interbank.Registry,
+	client *interbank.Client,
+	paymentRepo *repository.InterbankPaymentRepository,
+	walletRepo *repository.InterbankPaymentWalletRepository,
+) *InterbankReconcileRunner {
+	return &InterbankReconcileRunner{
+		db:          db,
+		registry:    registry,
+		client:      client,
+		paymentRepo: paymentRepo,
+		walletRepo:  walletRepo,
+		staleness:   5 * time.Minute,
+		batchSize:   25,
+	}
+}
+
+// WithStaleness overrides the default staleness window. Primarily for tests.
+func (r *InterbankReconcileRunner) WithStaleness(d time.Duration) *InterbankReconcileRunner {
+	r.staleness = d
+	return r
+}
+
+// Run executes one reconciliation tick. Errors per-row are logged and
+// the run continues; the cron caller doesn't need a result.
+func (r *InterbankReconcileRunner) Run() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	threshold := time.Now().UTC().Add(-r.staleness)
+
+	pending, err := r.paymentRepo.ListStuckPending(threshold, r.batchSize)
+	if err != nil {
+		slog.Error("interbank reconcile: listing stuck pending payments", "err", err)
+	} else {
+		for i := range pending {
+			r.reconcilePending(ctx, &pending[i])
+		}
+	}
+
+	terminal, err := r.paymentRepo.ListUndispatchedTerminal(threshold, r.batchSize)
+	if err != nil {
+		slog.Error("interbank reconcile: listing undispatched terminal payments", "err", err)
+	} else {
+		for i := range terminal {
+			r.reconcileTerminal(ctx, &terminal[i])
+		}
+	}
+}
+
+// reconcilePending retries NEW_TX for a single stuck row. The partner's
+// business-level idempotency means a retry collapses with any previous
+// successful delivery — we get back the same vote either way.
+func (r *InterbankReconcileRunner) reconcilePending(ctx context.Context, row *models.InterbankPayment) {
+	tx := interbank.BuildPaymentTx(
+		interbank.ForeignBankId{
+			RoutingNumber: interbank.RoutingNumber(row.TxRoutingNumber),
+			ID:            row.TxID,
+		},
+		row.SenderAccountNumber, row.RecipientAccountNumber,
+		row.Currency, row.Amount,
+		row.Message, row.PaymentCode, row.PaymentPurpose,
+	)
+	idemKey := r.client.NewIdempotenceKey()
+	partnerCode := interbank.RoutingNumber(row.PartnerRoutingNumber)
+
+	vote, err := r.client.SendNewTx(ctx, partnerCode, idemKey, &tx)
+	if err != nil {
+		// Permanent 4xx → mark failed + release reservation; the next
+		// tick will pick up the failed row and send ROLLBACK_TX.
+		if isPermanentRemoteError(err) {
+			if err := r.applyFailed(row, err.Error()); err != nil {
+				slog.Error("interbank reconcile: marking pending payment failed",
+					"err", err, "payment_id", row.ID)
+			}
+			return
+		}
+		// Transient — leave for next tick. Bump updated_at so the
+		// scan ordering keeps stale rows ahead of recently-retried
+		// ones (a simple back-off).
+		r.bumpUpdatedAt(row)
+		slog.Info("interbank reconcile: NEW_TX retry transient failure, leaving for next tick",
+			"err", err, "payment_id", row.ID, "tx_id", row.TxID)
+		return
+	}
+
+	if vote.Vote != interbank.VoteYes {
+		reason := summarisePartnerVote(vote)
+		if err := r.applyRejected(row, reason); err != nil {
+			slog.Error("interbank reconcile: marking pending payment rejected",
+				"err", err, "payment_id", row.ID)
+		}
+		return
+	}
+
+	// YES vote — apply local commit, then send COMMIT_TX inline. The
+	// resend loop will retry COMMIT_TX on the next tick if dispatch
+	// itself fails.
+	if err := r.applyCommit(row); err != nil {
+		slog.Error("interbank reconcile: applying local commit after retry YES vote",
+			"err", err, "payment_id", row.ID)
+		return
+	}
+	commitKey := r.client.NewIdempotenceKey()
+	txID := interbank.ForeignBankId{
+		RoutingNumber: interbank.RoutingNumber(row.TxRoutingNumber),
+		ID:            row.TxID,
+	}
+	if err := r.client.SendCommitTx(ctx, partnerCode, commitKey, txID); err != nil {
+		slog.Warn("interbank reconcile: COMMIT_TX dispatch failed after retry YES vote, will retry next tick",
+			"err", err, "payment_id", row.ID)
+		return
+	}
+	r.markPartnerFinalised(row)
+}
+
+// reconcileTerminal re-sends the appropriate terminal message
+// (COMMIT_TX for committed, ROLLBACK_TX for failed) until the partner
+// acknowledges. Idempotent on the receiver side.
+func (r *InterbankReconcileRunner) reconcileTerminal(ctx context.Context, row *models.InterbankPayment) {
+	partnerCode := interbank.RoutingNumber(row.PartnerRoutingNumber)
+	key := r.client.NewIdempotenceKey()
+	txID := interbank.ForeignBankId{
+		RoutingNumber: interbank.RoutingNumber(row.TxRoutingNumber),
+		ID:            row.TxID,
+	}
+
+	var sendErr error
+	switch row.Status {
+	case models.InterbankPaymentStatusCommitted:
+		sendErr = r.client.SendCommitTx(ctx, partnerCode, key, txID)
+	case models.InterbankPaymentStatusFailed:
+		sendErr = r.client.SendRollbackTx(ctx, partnerCode, key, txID)
+	default:
+		// Belt-and-braces — the scan filter shouldn't return other
+		// statuses, but log and skip if it ever does.
+		slog.Warn("interbank reconcile: unexpected terminal-row status",
+			"payment_id", row.ID, "status", row.Status)
+		return
+	}
+
+	if sendErr != nil {
+		slog.Info("interbank reconcile: terminal retry transient failure",
+			"err", sendErr, "payment_id", row.ID, "status", row.Status)
+		r.bumpUpdatedAt(row)
+		return
+	}
+	r.markPartnerFinalised(row)
+}
+
+// applyCommit applies the local debit + status flip after a retry YES
+// vote. Mirrors the inline path in interbank_payment_http_handler.go.
+func (r *InterbankReconcileRunner) applyCommit(row *models.InterbankPayment) error {
+	if row.LocalAccountID == nil {
+		return fmt.Errorf("payment row missing local_account_id")
+	}
+	return r.db.Transaction(func(dbtx *gorm.DB) error {
+		rows, err := r.paymentRepo.MarkCommittedCAS(dbtx, row.TxRoutingNumber, row.TxID)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return nil
+		}
+		row.Status = models.InterbankPaymentStatusCommitted
+		return r.walletRepo.Debit(dbtx, *row.LocalAccountID, row.Amount)
+	})
+}
+
+// applyRejected releases the reservation and CAS-marks the row
+// rejected, mirroring the inline rejection path. Stamps
+// partner_finalised_at since no terminal message is owed for a NO vote.
+func (r *InterbankReconcileRunner) applyRejected(row *models.InterbankPayment, reason string) error {
+	if row.LocalAccountID == nil {
+		return fmt.Errorf("payment row missing local_account_id")
+	}
+	return r.db.Transaction(func(dbtx *gorm.DB) error {
+		rows, err := r.paymentRepo.MarkRejectedCAS(dbtx, row.TxRoutingNumber, row.TxID, reason)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return nil
+		}
+		row.Status = models.InterbankPaymentStatusRejected
+		row.LastError = reason
+		if _, err := r.paymentRepo.MarkPartnerFinalised(dbtx, row.TxRoutingNumber, row.TxID); err != nil {
+			return err
+		}
+		return r.walletRepo.Release(dbtx, *row.LocalAccountID, row.Amount)
+	})
+}
+
+// applyFailed releases the reservation and CAS-marks the row failed.
+// Does NOT stamp partner_finalised_at — the next tick will pick the
+// row up and send ROLLBACK_TX (the partner may have a stranded pending
+// row).
+func (r *InterbankReconcileRunner) applyFailed(row *models.InterbankPayment, errMsg string) error {
+	if row.LocalAccountID == nil {
+		return fmt.Errorf("payment row missing local_account_id")
+	}
+	return r.db.Transaction(func(dbtx *gorm.DB) error {
+		rows, err := r.paymentRepo.MarkFailedCAS(dbtx, row.TxRoutingNumber, row.TxID, errMsg)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			return nil
+		}
+		row.Status = models.InterbankPaymentStatusFailed
+		row.LastError = errMsg
+		return r.walletRepo.Release(dbtx, *row.LocalAccountID, row.Amount)
+	})
+}
+
+func (r *InterbankReconcileRunner) markPartnerFinalised(row *models.InterbankPayment) {
+	err := r.db.Transaction(func(dbtx *gorm.DB) error {
+		_, mErr := r.paymentRepo.MarkPartnerFinalised(dbtx, row.TxRoutingNumber, row.TxID)
+		return mErr
+	})
+	if err != nil {
+		slog.Warn("interbank reconcile: failed to stamp partner_finalised_at",
+			"err", err, "payment_id", row.ID)
+		return
+	}
+	now := time.Now().UTC()
+	row.PartnerFinalisedAt = &now
+}
+
+// bumpUpdatedAt nudges the row's updated_at forward so it doesn't get
+// picked up again on the very next tick. Acts as a coarse back-off
+// without needing a separate "next_retry_at" column.
+func (r *InterbankReconcileRunner) bumpUpdatedAt(row *models.InterbankPayment) {
+	now := time.Now().UTC()
+	err := r.db.Model(&models.InterbankPayment{}).
+		Where("id = ?", row.ID).
+		Update("updated_at", now).Error
+	if err != nil {
+		slog.Warn("interbank reconcile: failed to bump updated_at",
+			"err", err, "payment_id", row.ID)
+		return
+	}
+	row.UpdatedAt = now
+}
+
+// isPermanentRemoteError returns true when the partner's HTTP response
+// indicates a permanent (not retry-able) failure. 4xx other than 408
+// (request timeout) and 429 (rate limit) are permanent.
+func isPermanentRemoteError(err error) bool {
+	var rerr *interbank.RemoteError
+	if !errors.As(err, &rerr) {
+		return false
+	}
+	if rerr.StatusCode < 400 || rerr.StatusCode >= 500 {
+		return false
+	}
+	switch rerr.StatusCode {
+	case 408, 429:
+		return false
+	}
+	return true
+}
+
+// summarisePartnerVote turns a NO TransactionVote into a short string
+// for last_error. Mirrors the handler-side helper so cron-reconciled
+// rejections look the same in the FE as inline ones.
+func summarisePartnerVote(vote *interbank.TransactionVote) string {
+	if vote == nil || len(vote.Reasons) == 0 {
+		return "partner voted NO without reason"
+	}
+	parts := make([]string, 0, len(vote.Reasons))
+	for _, r := range vote.Reasons {
+		parts = append(parts, string(r.Reason))
+	}
+	out := "partner voted NO: "
+	for i, s := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += s
+	}
+	return out
+}

--- a/exchange-service/internal/service/public_stock_cache.go
+++ b/exchange-service/internal/service/public_stock_cache.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// PublicStockCacheRunner is the cron half of BANKA-BE-5. Every tick it
+// fans out across the registry, fetches each partner's /public-stock,
+// and persists the response into remote_public_stock_snapshots. The
+// local OTC discovery handler reads from that table — so a slow or
+// down partner doesn't block a user opening the discovery page.
+//
+// On per-partner failure we record the error against the existing
+// snapshot (keeping the previous payload around) so the handler can
+// still show stale-but-good data with a `stale=true` flag.
+type PublicStockCacheRunner struct {
+	registry *interbank.Registry
+	client   *interbank.Client
+	repo     *repository.RemotePublicStockRepository
+
+	// perPartnerTimeout caps each outbound /public-stock call. Total
+	// run time is bounded by perPartnerTimeout * partner count, which
+	// keeps the cron from overlapping itself even with several slow
+	// partners.
+	perPartnerTimeout time.Duration
+}
+
+func NewPublicStockCacheRunner(
+	registry *interbank.Registry,
+	client *interbank.Client,
+	repo *repository.RemotePublicStockRepository,
+) *PublicStockCacheRunner {
+	return &PublicStockCacheRunner{
+		registry:          registry,
+		client:            client,
+		repo:              repo,
+		perPartnerTimeout: 8 * time.Second,
+	}
+}
+
+// Run executes one cache refresh. Per-partner errors are logged + saved
+// to the snapshot row; the run continues so one slow partner doesn't
+// block fresh data for others. Fan-out is parallel because partners
+// are independent.
+func (r *PublicStockCacheRunner) Run() {
+	partners := r.registry.All()
+	if len(partners) == 0 {
+		return
+	}
+
+	var wg sync.WaitGroup
+	for i := range partners {
+		p := partners[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r.refreshOne(p.Code)
+		}()
+	}
+	wg.Wait()
+}
+
+func (r *PublicStockCacheRunner) refreshOne(partner interbank.RoutingNumber) {
+	ctx, cancel := context.WithTimeout(context.Background(), r.perPartnerTimeout)
+	defer cancel()
+
+	stocks, err := r.client.FetchPublicStock(ctx, partner)
+	if err != nil {
+		if upErr := r.repo.UpsertError(int(partner), err.Error()); upErr != nil {
+			slog.Error("public-stock cache: recording partner error failed",
+				"err", upErr, "partner", partner, "fetch_err", err)
+			return
+		}
+		slog.Info("public-stock cache: partner refresh failed, kept stale snapshot",
+			"partner", partner, "err", err)
+		return
+	}
+
+	payload, mErr := json.Marshal(stocks)
+	if mErr != nil {
+		slog.Error("public-stock cache: marshalling response failed",
+			"err", mErr, "partner", partner)
+		return
+	}
+
+	if err := r.repo.UpsertPayload(int(partner), string(payload)); err != nil {
+		slog.Error("public-stock cache: writing snapshot failed",
+			"err", err, "partner", partner)
+		return
+	}
+}


### PR DESCRIPTION
…stock cache, option exercise

Closes BANKA-BE-2/3/4 (cross-bank direct payments), BANKA-BE-5 (partner public-stock cache), BANKA-BE-8 (CHECK_STATUS reconciliation cron), and the cross-bank option exercise leg of BANKA-BE-7.

Cross-bank direct payments
- PaymentTxProcessor receiver for the 2-posting MONAS ACCOUNT shape: votes YES on NEW_TX without reservation (recipient gains), credits + CAS commits on COMMIT_TX, flips status on ROLLBACK_TX.
- DispatchTxProcessor classifies inbound NEW_TX/COMMIT_TX/ROLLBACK_TX across the three flows (otc, payment, exercise) by posting shape and pending-row lookup.
- InterbankPaymentHTTPHandler exposes sender-side POST/GET /api/v1/payments/cross-bank with single-DB-tx reserve + send, YES → debit + CAS commit + COMMIT_TX, NO → release + rejected, transport error → release + failed + best-effort ROLLBACK_TX.

CHECK_STATUS reconciliation cron (BANKA-BE-8)
- InterbankReconcileRunner @every 2m re-dispatches NEW_TX for stuck pending payments and resends COMMIT_TX / ROLLBACK_TX for resolved outbound rows where partner_finalised_at is still null. Permanent 4xx marks the row failed; transient errors back off via updated_at.
- Added partner_finalised_at column on interbank_payments and the ListStuckPending / ListUndispatchedTerminal scans on the repo.

Partner public-stock cache (BANKA-BE-5)
- PublicStockCacheRunner @every 5m fans out across the partner registry with an 8s per-partner timeout, persisting the JSON payload to a new remote_public_stock_snapshots table. On per-partner error the previous payload is preserved (stale-but-good).
- interbank_otc/public-stocks now reads the cache by default and returns partnerStale flags; ?live=true forces a fan-out and cold start falls back to live.

Cross-bank option exercise
- ExerciseTxProcessor receiver for the 4-posting OPTION-execution shape: validates against InterbankOtcNegotiation, blocks double exercise via HasCommittedForNegotiation, settlement-window check. On COMMIT_TX reduces the seller's local holding via RecordSellFillTx and credits the seller's account.
- Buyer-side initiator on /api/v1/interbank-otc/option-contracts: list / get / exercise. Exercise reserves cash, sends NEW_TX, on YES debits + upserts the buyer's local stock holding (weighted avg) + CAS-marks the contract exercised, then sends COMMIT_TX.

Schema
- AutoMigrate adds InterbankPayment, RemotePublicStockSnapshot, and InterbankPendingExercise. Existing InterbankOptionContract gained GetByID, ListByBuyerLocalID, MarkExercisedCAS.

Verification
- go build ./... clean
- go vet ./... clean
- go test ./... all packages OK