### PR TITLE
feat(exchange): OTC profit, simplified margin, stop-limit latch

### DIFF
--- a/exchange-service/internal/handler/order_http_handler.go
+++ b/exchange-service/internal/handler/order_http_handler.go
@@ -425,6 +425,8 @@ type orderResponse struct {
 	StopValue         *float64 `json:"stopValue"`
 	IsAON             bool     `json:"isAON"`
 	IsMargin          bool     `json:"isMargin"`
+	MarginLoan        float64  `json:"marginLoan"`
+	StopTriggered     bool     `json:"stopTriggered"`
 	Status            string   `json:"status"`
 	IsDone            bool     `json:"isDone"`
 	RemainingPortions int64    `json:"remainingPortions"`
@@ -460,6 +462,8 @@ func orderToResponse(o *models.OrderRecord) orderResponse {
 		StopValue:         o.StopValue,
 		IsAON:             o.IsAON,
 		IsMargin:          o.IsMargin,
+		MarginLoan:        o.MarginLoan,
+		StopTriggered:     o.StopTriggered,
 		Status:            o.Status,
 		IsDone:            o.IsDone,
 		RemainingPortions: o.RemainingPortions,

--- a/exchange-service/internal/handler/otc_http_handler.go
+++ b/exchange-service/internal/handler/otc_http_handler.go
@@ -555,27 +555,30 @@ type otcOfferResponse struct {
 }
 
 type otcContractResponse struct {
-	ID              uint                    `json:"id"`
-	OfferID         *uint                   `json:"offerId,omitempty"`
-	StockListingID  uint                    `json:"stockListingId"`
-	SellerHoldingID uint                    `json:"sellerHoldingId"`
-	Ticker          string                  `json:"ticker"`
-	Name            string                  `json:"name"`
-	Exchange        exchangeSummaryResponse `json:"exchange"`
-	Amount          float64                 `json:"amount"`
-	StrikePrice     float64                 `json:"strikePrice"`
-	CurrentPrice    float64                 `json:"currentPrice"`
-	Premium         float64                 `json:"premium"`
-	Profit          float64                 `json:"profit"`
-	SettlementDate  string                  `json:"settlementDate"`
-	BuyerID         uint                    `json:"buyerId"`
-	BuyerType       string                  `json:"buyerType"`
-	BuyerAccountID  uint                    `json:"buyerAccountId"`
-	SellerID        uint                    `json:"sellerId"`
-	SellerType      string                  `json:"sellerType"`
-	SellerAccountID uint                    `json:"sellerAccountId"`
-	Status          string                  `json:"status"`
-	CreatedAt       string                  `json:"createdAt"`
+	ID               uint                    `json:"id"`
+	OfferID          *uint                   `json:"offerId,omitempty"`
+	StockListingID   uint                    `json:"stockListingId"`
+	SellerHoldingID  uint                    `json:"sellerHoldingId"`
+	Ticker           string                  `json:"ticker"`
+	Name             string                  `json:"name"`
+	Exchange         exchangeSummaryResponse `json:"exchange"`
+	Amount           float64                 `json:"amount"`
+	StrikePrice      float64                 `json:"strikePrice"`
+	CurrentPrice     float64                 `json:"currentPrice"`
+	ExercisedAtPrice float64                 `json:"exercisedAtPrice"`
+	Premium          float64                 `json:"premium"`
+	Profit           float64                 `json:"profit"`       // buyer's perspective (legacy field name; kept for compatibility)
+	BuyerProfit      float64                 `json:"buyerProfit"`  // realized (exercised/expired) or live (valid)
+	SellerProfit     float64                 `json:"sellerProfit"` // realized (exercised/expired) or live (valid)
+	SettlementDate   string                  `json:"settlementDate"`
+	BuyerID          uint                    `json:"buyerId"`
+	BuyerType        string                  `json:"buyerType"`
+	BuyerAccountID   uint                    `json:"buyerAccountId"`
+	SellerID         uint                    `json:"sellerId"`
+	SellerType       string                  `json:"sellerType"`
+	SellerAccountID  uint                    `json:"sellerAccountId"`
+	Status           string                  `json:"status"`
+	CreatedAt        string                  `json:"createdAt"`
 }
 
 func otcOfferToResponse(offer models.OtcOfferRecord) otcOfferResponse {
@@ -612,28 +615,44 @@ func otcOfferToResponse(offer models.OtcOfferRecord) otcOfferResponse {
 }
 
 func otcContractToResponse(contract models.OtcContractRecord) otcContractResponse {
+	// For finalized contracts (exercised/expired) use the snapshotted P&L written at
+	// finalize/expire time so historical values don't drift with the market. For still
+	// "valid" contracts compute a live mark-to-market for buyer/seller from current price.
+	var buyerProfit, sellerProfit float64
+	if contract.Status == models.OtcContractStatusValid {
+		intrinsic := (contract.StockListing.Price - contract.StrikePrice) * contract.Amount
+		buyerProfit = roundOtcDisplayValue(intrinsic - contract.Premium)
+		sellerProfit = roundOtcDisplayValue(contract.Premium - intrinsic)
+	} else {
+		buyerProfit = roundOtcDisplayValue(contract.BuyerProfit)
+		sellerProfit = roundOtcDisplayValue(contract.SellerProfit)
+	}
+
 	return otcContractResponse{
-		ID:              contract.ID,
-		OfferID:         contract.OfferID,
-		StockListingID:  contract.StockListingID,
-		SellerHoldingID: contract.SellerHoldingID,
-		Ticker:          contract.StockListing.Ticker,
-		Name:            contract.StockListing.Name,
-		Exchange:        exchangeSummaryToResponse(contract.StockListing.Exchange.ToSummary()),
-		Amount:          contract.Amount,
-		StrikePrice:     contract.StrikePrice,
-		CurrentPrice:    contract.StockListing.Price,
-		Premium:         contract.Premium,
-		Profit:          roundOtcDisplayValue((contract.StockListing.Price-contract.StrikePrice)*contract.Amount - contract.Premium),
-		SettlementDate:  contract.SettlementDate.UTC().Format("2006-01-02"),
-		BuyerID:         contract.BuyerID,
-		BuyerType:       contract.BuyerType,
-		BuyerAccountID:  contract.BuyerAccountID,
-		SellerID:        contract.SellerID,
-		SellerType:      contract.SellerType,
-		SellerAccountID: contract.SellerAccountID,
-		Status:          contract.Status,
-		CreatedAt:       contract.CreatedAt.UTC().Format(time.RFC3339),
+		ID:               contract.ID,
+		OfferID:          contract.OfferID,
+		StockListingID:   contract.StockListingID,
+		SellerHoldingID:  contract.SellerHoldingID,
+		Ticker:           contract.StockListing.Ticker,
+		Name:             contract.StockListing.Name,
+		Exchange:         exchangeSummaryToResponse(contract.StockListing.Exchange.ToSummary()),
+		Amount:           contract.Amount,
+		StrikePrice:      contract.StrikePrice,
+		CurrentPrice:     contract.StockListing.Price,
+		ExercisedAtPrice: contract.ExercisedAtPrice,
+		Premium:          contract.Premium,
+		Profit:           buyerProfit, // legacy alias for buyerProfit
+		BuyerProfit:      buyerProfit,
+		SellerProfit:     sellerProfit,
+		SettlementDate:   contract.SettlementDate.UTC().Format("2006-01-02"),
+		BuyerID:          contract.BuyerID,
+		BuyerType:        contract.BuyerType,
+		BuyerAccountID:   contract.BuyerAccountID,
+		SellerID:         contract.SellerID,
+		SellerType:       contract.SellerType,
+		SellerAccountID:  contract.SellerAccountID,
+		Status:           contract.Status,
+		CreatedAt:        contract.CreatedAt.UTC().Format(time.RFC3339),
 	}
 }
 

--- a/exchange-service/internal/models/market_entities.go
+++ b/exchange-service/internal/models/market_entities.go
@@ -185,6 +185,8 @@ type OrderRecord struct {
 	StopValue         *float64                 `gorm:"column:stop_value"`
 	IsAON             bool                     `gorm:"column:is_aon;not null;default:false"`
 	IsMargin          bool                     `gorm:"column:is_margin;not null;default:false"`
+	MarginLoan        float64                  `gorm:"column:margin_loan;not null;default:0"` // outstanding bank-fronted balance for margin buys, in the account's currency
+	StopTriggered     bool                     `gorm:"column:stop_triggered;not null;default:false"` // stop_limit latch: true once the stop value has been crossed
 	Status            string                   `gorm:"not null;default:'pending'"` // pending, approved, declined, done
 	ApprovedBy        *uint                    `gorm:"column:approved_by"`
 	PlacedBy          *uint                    `gorm:"column:placed_by"` // employee who placed the order on the bank's behalf (nil for client orders)
@@ -310,8 +312,13 @@ type OtcContractRecord struct {
 	SellerAccountID uint                   `gorm:"column:seller_account_id;not null;index"`
 	Status          string                 `gorm:"not null;default:'valid';index"`
 	BankID          *uint                  `gorm:"column:bank_id;index"`
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
+	// Snapshotted at exercise (or expiry) so historical P&L doesn't drift with the market.
+	// Zero on still-valid contracts.
+	ExercisedAtPrice float64 `gorm:"column:exercised_at_price;not null;default:0"`
+	BuyerProfit      float64 `gorm:"column:buyer_profit;not null;default:0"`
+	SellerProfit     float64 `gorm:"column:seller_profit;not null;default:0"`
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
 }
 
 func (OtcContractRecord) TableName() string { return "otc_contracts" }

--- a/exchange-service/internal/repository/order_repository.go
+++ b/exchange-service/internal/repository/order_repository.go
@@ -315,3 +315,66 @@ func (r *OrderRepository) GetAccountBalance(accountID uint) (balance float64, cu
 	err = row.Scan(&balance, &currencyKod)
 	return
 }
+
+// SetStopTriggered latches the stop_triggered flag on a stop_limit order so the
+// executor no longer re-evaluates the stop condition. Once set the order behaves
+// as a pure limit order even if the price oscillates back across the stop.
+func (r *OrderRepository) SetStopTriggered(orderID uint) error {
+	return r.db.Model(&models.OrderRecord{}).
+		Where("id = ?", orderID).
+		Updates(map[string]interface{}{
+			"stop_triggered":    true,
+			"last_modification": time.Now().UTC(),
+		}).Error
+}
+
+// SetMarginLoan persists the outstanding bank-fronted balance for a margin order.
+// Called from OrderService.CreateOrder right after the order is created.
+func (r *OrderRepository) SetMarginLoan(orderID uint, amount float64) error {
+	return r.db.Model(&models.OrderRecord{}).
+		Where("id = ?", orderID).
+		UpdateColumn("margin_loan", amount).Error
+}
+
+// ListOutstandingMarginLoansForUserAsset returns buy orders for the given
+// user+asset that still carry a non-zero margin loan, ordered oldest-first so
+// proceeds repay FIFO.
+func (r *OrderRepository) ListOutstandingMarginLoansForUserAsset(userID uint, userType string, assetID uint) ([]models.OrderRecord, error) {
+	var records []models.OrderRecord
+	err := r.db.
+		Where("user_id = ? AND user_type = ? AND asset_id = ? AND direction = ? AND is_margin = ? AND margin_loan > 0",
+			userID, userType, assetID, "buy", true).
+		Order("created_at ASC, id ASC").
+		Find(&records).Error
+	if err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+// ReduceMarginLoan subtracts amount from the order's margin_loan, clamping at
+// zero. Returns the actual amount applied (≤ amount when the loan was smaller).
+func (r *OrderRepository) ReduceMarginLoan(orderID uint, amount float64) (float64, error) {
+	if amount <= 0 {
+		return 0, nil
+	}
+	var applied float64
+	err := r.db.Transaction(func(tx *gorm.DB) error {
+		var order models.OrderRecord
+		if err := tx.Select("id, margin_loan").First(&order, orderID).Error; err != nil {
+			return err
+		}
+		applied = amount
+		if applied > order.MarginLoan {
+			applied = order.MarginLoan
+		}
+		if applied <= 0 {
+			applied = 0
+			return nil
+		}
+		return tx.Model(&models.OrderRecord{}).
+			Where("id = ?", orderID).
+			UpdateColumn("margin_loan", gorm.Expr("margin_loan - ?", applied)).Error
+	})
+	return applied, err
+}

--- a/exchange-service/internal/repository/otc_repository.go
+++ b/exchange-service/internal/repository/otc_repository.go
@@ -291,11 +291,15 @@ func (r *OtcRepository) ExpireValidContracts(referenceTime time.Time) (int, erro
 				return err
 			}
 
+			// Unexercised expiry: buyer's loss is the premium paid up-front; seller keeps it.
+			// (No new cash moves — premium was settled at offer acceptance.)
 			result := tx.Model(&models.OtcContractRecord{}).
 				Where("id = ? AND status = ?", contract.ID, models.OtcContractStatusValid).
 				Updates(map[string]interface{}{
-					"status":     models.OtcContractStatusExpired,
-					"updated_at": now,
+					"status":        models.OtcContractStatusExpired,
+					"buyer_profit":  -contract.Premium,
+					"seller_profit": contract.Premium,
+					"updated_at":    now,
 				})
 			if result.Error != nil {
 				return result.Error

--- a/exchange-service/internal/service/order_executor.go
+++ b/exchange-service/internal/service/order_executor.go
@@ -41,8 +41,21 @@ func (e *OrderExecutor) Run() {
 
 		listing := &order.Asset // preloaded by ListPendingActiveOrders
 
-		// Check if order conditions are currently satisfied.
-		if !conditionsMet(&order, listing) {
+		// Evaluate the order's execution conditions for this tick.
+		eval := evaluateOrder(&order, listing)
+
+		// stop_limit: persist the stop-triggered latch the first tick we cross the stop.
+		// This keeps the order armed as a pure limit order on subsequent ticks even if
+		// the price moves back through the stop value.
+		if eval.justTriggered {
+			if err := e.orderRepo.SetStopTriggered(order.ID); err != nil {
+				slog.Error("order executor: failed to latch stop_triggered", "orderID", order.ID, "error", err)
+			} else {
+				order.StopTriggered = true
+			}
+		}
+
+		if !eval.fillNow {
 			continue
 		}
 
@@ -115,8 +128,16 @@ func (e *OrderExecutor) Run() {
 					netAmount = round2(netAmount * rate)
 				}
 			}
-			if err := e.orderRepo.CreditAccount(order.AccountID, netAmount); err != nil {
-				slog.Error("order executor: failed to credit account on sell", "orderID", order.ID, "error", err)
+
+			// Apply sell proceeds toward outstanding margin loans on the same asset
+			// (FIFO by buy order creation date) before crediting the user. Loans were
+			// recorded in the account's currency, so netAmount must already be converted.
+			netAmount = e.settleMarginLoansFromProceeds(&order, netAmount)
+
+			if netAmount > 0 {
+				if err := e.orderRepo.CreditAccount(order.AccountID, netAmount); err != nil {
+					slog.Error("order executor: failed to credit account on sell", "orderID", order.ID, "error", err)
+				}
 			}
 		}
 
@@ -151,39 +172,110 @@ func (e *OrderExecutor) Run() {
 	}
 }
 
-// conditionsMet reports whether current market prices satisfy the order's
-// execution trigger.
+// orderEval is the per-tick verdict for an order.
+type orderEval struct {
+	fillNow       bool // the order should fill this tick at executeFillPrice
+	justTriggered bool // stop_limit: stop crossed for the first time this tick; persist the latch
+}
+
+// evaluateOrder reports whether current market prices satisfy the order's
+// execution trigger, and (for stop_limit) whether the stop just crossed.
 //
 //	market:     always executable
 //	limit buy:  ask <= limit_value
 //	limit sell: bid >= limit_value
 //	stop buy:   ask > stop_value  (then executes at market)
 //	stop sell:  bid < stop_value  (then executes at market)
-//	stop_limit: stop must trigger AND limit condition must be satisfied
-func conditionsMet(order *models.OrderRecord, listing *models.MarketListingRecord) bool {
+//
+// Stop-limit is two-phase. The stop acts as a one-way trigger:
+//   Buy:  arms when Ask >= stop_value (price rising into stop).
+//   Sell: arms when Bid <= stop_value (price falling into stop).
+//
+// Once armed, the latch is persisted and the order behaves as a limit order on
+// every subsequent tick — even if the price moves back through the stop value:
+//   Buy:  fill while Ask <= limit_value
+//   Sell: fill while Bid >= limit_value
+func evaluateOrder(order *models.OrderRecord, listing *models.MarketListingRecord) orderEval {
 	switch order.OrderType {
 	case "market":
-		return true
+		return orderEval{fillNow: true}
+
 	case "limit":
 		if order.Direction == "buy" {
-			return listing.Ask <= *order.LimitValue
+			return orderEval{fillNow: listing.Ask <= *order.LimitValue}
 		}
-		return listing.Bid >= *order.LimitValue
+		return orderEval{fillNow: listing.Bid >= *order.LimitValue}
+
 	case "stop":
 		if order.Direction == "buy" {
-			return listing.Ask > *order.StopValue
+			return orderEval{fillNow: listing.Ask > *order.StopValue}
 		}
-		return listing.Bid < *order.StopValue
+		return orderEval{fillNow: listing.Bid < *order.StopValue}
+
 	case "stop_limit":
-		// Stop triggers activation; limit guards the fill price.
-		// Buy:  Ask reaches or exceeds stop value, AND Ask is still within limit.
-		// Sell: Bid falls below stop value, AND Bid is still within limit.
-		if order.Direction == "buy" {
-			return listing.Ask >= *order.StopValue && listing.Ask <= *order.LimitValue
+		// Phase 1: arm the stop the first time the trigger price is crossed.
+		armed := order.StopTriggered
+		justArmed := false
+		if !armed {
+			if order.Direction == "buy" && listing.Ask >= *order.StopValue {
+				armed = true
+				justArmed = true
+			} else if order.Direction == "sell" && listing.Bid <= *order.StopValue {
+				armed = true
+				justArmed = true
+			}
 		}
-		return listing.Bid < *order.StopValue && listing.Bid >= *order.LimitValue
+		if !armed {
+			return orderEval{}
+		}
+		// Phase 2: once armed, behave as a pure limit order.
+		var fillNow bool
+		if order.Direction == "buy" {
+			fillNow = listing.Ask <= *order.LimitValue
+		} else {
+			fillNow = listing.Bid >= *order.LimitValue
+		}
+		return orderEval{fillNow: fillNow, justTriggered: justArmed}
 	}
-	return false
+	return orderEval{}
+}
+
+// settleMarginLoansFromProceeds applies sell proceeds (in the account's currency)
+// against the user's outstanding margin loans on the same asset, FIFO by buy order
+// creation date. Returns the remaining proceeds available to credit to the user.
+func (e *OrderExecutor) settleMarginLoansFromProceeds(sellOrder *models.OrderRecord, proceeds float64) float64 {
+	if proceeds <= 0 {
+		return proceeds
+	}
+	loans, err := e.orderRepo.ListOutstandingMarginLoansForUserAsset(sellOrder.UserID, sellOrder.UserType, sellOrder.AssetID)
+	if err != nil {
+		slog.Error("order executor: failed to list margin loans for sell settlement",
+			"orderID", sellOrder.ID, "error", err)
+		return proceeds
+	}
+	remaining := proceeds
+	for _, loan := range loans {
+		if remaining <= 0 {
+			break
+		}
+		toRepay := loan.MarginLoan
+		if toRepay > remaining {
+			toRepay = remaining
+		}
+		applied, err := e.orderRepo.ReduceMarginLoan(loan.ID, toRepay)
+		if err != nil {
+			slog.Error("order executor: failed to reduce margin loan",
+				"sellOrderID", sellOrder.ID, "buyOrderID", loan.ID, "error", err)
+			continue
+		}
+		remaining = round2(remaining - applied)
+		slog.Info("order executor: applied sell proceeds to margin loan",
+			"sellOrderID", sellOrder.ID, "buyOrderID", loan.ID, "applied", applied, "remaining", remaining)
+	}
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
 }
 
 // fillQuantity returns how many units to fill in this cycle.

--- a/exchange-service/internal/service/order_executor_test.go
+++ b/exchange-service/internal/service/order_executor_test.go
@@ -10,90 +10,173 @@ func mkOrder(orderType, direction string) *models.OrderRecord {
 	return &models.OrderRecord{OrderType: orderType, Direction: direction}
 }
 
-func TestConditionsMet_Market(t *testing.T) {
-	if !conditionsMet(mkOrder("market", "buy"), &models.MarketListingRecord{}) {
-		t.Error("market should always meet conditions")
+func TestEvaluateOrder_Market(t *testing.T) {
+	if !evaluateOrder(mkOrder("market", "buy"), &models.MarketListingRecord{}).fillNow {
+		t.Error("market should always fill")
 	}
 }
 
-func TestConditionsMet_LimitBuy(t *testing.T) {
+func TestEvaluateOrder_LimitBuy(t *testing.T) {
 	o := mkOrder("limit", "buy")
 	o.LimitValue = ptrFloat(100)
-	if !conditionsMet(o, &models.MarketListingRecord{Ask: 99}) {
-		t.Error("buy limit should trigger when ask<=limit")
+	if !evaluateOrder(o, &models.MarketListingRecord{Ask: 99}).fillNow {
+		t.Error("buy limit should fill when ask<=limit")
 	}
-	if conditionsMet(o, &models.MarketListingRecord{Ask: 101}) {
-		t.Error("buy limit should NOT trigger when ask>limit")
+	if evaluateOrder(o, &models.MarketListingRecord{Ask: 101}).fillNow {
+		t.Error("buy limit should NOT fill when ask>limit")
 	}
 }
 
-func TestConditionsMet_LimitSell(t *testing.T) {
+func TestEvaluateOrder_LimitSell(t *testing.T) {
 	o := mkOrder("limit", "sell")
 	o.LimitValue = ptrFloat(100)
-	if !conditionsMet(o, &models.MarketListingRecord{Bid: 101}) {
-		t.Error("sell limit should trigger when bid>=limit")
+	if !evaluateOrder(o, &models.MarketListingRecord{Bid: 101}).fillNow {
+		t.Error("sell limit should fill when bid>=limit")
 	}
-	if conditionsMet(o, &models.MarketListingRecord{Bid: 99}) {
-		t.Error("sell limit should NOT trigger when bid<limit")
+	if evaluateOrder(o, &models.MarketListingRecord{Bid: 99}).fillNow {
+		t.Error("sell limit should NOT fill when bid<limit")
 	}
 }
 
-func TestConditionsMet_StopBuy(t *testing.T) {
+func TestEvaluateOrder_StopBuy(t *testing.T) {
 	o := mkOrder("stop", "buy")
 	o.StopValue = ptrFloat(100)
-	if !conditionsMet(o, &models.MarketListingRecord{Ask: 101}) {
-		t.Error("buy stop should trigger when ask>stop")
+	if !evaluateOrder(o, &models.MarketListingRecord{Ask: 101}).fillNow {
+		t.Error("buy stop should fill when ask>stop")
 	}
-	if conditionsMet(o, &models.MarketListingRecord{Ask: 99}) {
-		t.Error("buy stop should NOT trigger when ask<=stop")
+	if evaluateOrder(o, &models.MarketListingRecord{Ask: 99}).fillNow {
+		t.Error("buy stop should NOT fill when ask<=stop")
 	}
 }
 
-func TestConditionsMet_StopSell(t *testing.T) {
+func TestEvaluateOrder_StopSell(t *testing.T) {
 	o := mkOrder("stop", "sell")
 	o.StopValue = ptrFloat(100)
-	if !conditionsMet(o, &models.MarketListingRecord{Bid: 99}) {
-		t.Error("sell stop should trigger when bid<stop")
+	if !evaluateOrder(o, &models.MarketListingRecord{Bid: 99}).fillNow {
+		t.Error("sell stop should fill when bid<stop")
 	}
-	if conditionsMet(o, &models.MarketListingRecord{Bid: 101}) {
-		t.Error("sell stop should NOT trigger when bid>=stop")
+	if evaluateOrder(o, &models.MarketListingRecord{Bid: 101}).fillNow {
+		t.Error("sell stop should NOT fill when bid>=stop")
 	}
 }
 
-func TestConditionsMet_StopLimitBuy(t *testing.T) {
+// stop_limit BUY: stop_value=100 arms the order (when ask >= 100), then it
+// behaves as a limit order with limit_value=105 (fills while ask <= 105).
+func TestEvaluateOrder_StopLimitBuy_ArmsAndFillsInsideWindow(t *testing.T) {
 	o := mkOrder("stop_limit", "buy")
 	o.StopValue = ptrFloat(100)
 	o.LimitValue = ptrFloat(105)
-	// triggered: 100 <= ask <= 105
-	if !conditionsMet(o, &models.MarketListingRecord{Ask: 102}) {
-		t.Error("expected triggered")
-	}
-	if conditionsMet(o, &models.MarketListingRecord{Ask: 99}) {
-		t.Error("ask below stop should not trigger")
-	}
-	if conditionsMet(o, &models.MarketListingRecord{Ask: 110}) {
-		t.Error("ask above limit should not trigger")
+
+	// Ask=102 crosses stop and is inside limit window — should arm + fill on this tick.
+	eval := evaluateOrder(o, &models.MarketListingRecord{Ask: 102})
+	if !eval.fillNow || !eval.justTriggered {
+		t.Errorf("expected fillNow=true justTriggered=true, got %+v", eval)
 	}
 }
 
-func TestConditionsMet_StopLimitSell(t *testing.T) {
+func TestEvaluateOrder_StopLimitBuy_BelowStopDoesNothing(t *testing.T) {
+	o := mkOrder("stop_limit", "buy")
+	o.StopValue = ptrFloat(100)
+	o.LimitValue = ptrFloat(105)
+
+	eval := evaluateOrder(o, &models.MarketListingRecord{Ask: 99})
+	if eval.fillNow || eval.justTriggered {
+		t.Errorf("ask below stop should neither arm nor fill, got %+v", eval)
+	}
+}
+
+// Critical case: ask gaps above the limit. The order arms (stop crossed) but
+// does not fill — it sits waiting for ask to drop back into the limit window.
+func TestEvaluateOrder_StopLimitBuy_GapsAboveLimitArmsButDoesNotFill(t *testing.T) {
+	o := mkOrder("stop_limit", "buy")
+	o.StopValue = ptrFloat(100)
+	o.LimitValue = ptrFloat(105)
+
+	eval := evaluateOrder(o, &models.MarketListingRecord{Ask: 110})
+	if eval.fillNow {
+		t.Errorf("ask above limit must not fill yet, got fillNow=true")
+	}
+	if !eval.justTriggered {
+		t.Errorf("ask above stop should arm the latch even if outside limit window")
+	}
+}
+
+// Once armed, the latch persists: on a later tick the order fills as a limit
+// order EVEN IF the ask is now below the stop value (the latch is sticky).
+func TestEvaluateOrder_StopLimitBuy_LatchSticksAfterPriceRetreats(t *testing.T) {
+	o := mkOrder("stop_limit", "buy")
+	o.StopValue = ptrFloat(100)
+	o.LimitValue = ptrFloat(105)
+	o.StopTriggered = true // already armed from a prior tick
+
+	// Ask=98 is below the stop, but since the latch is sticky, the order behaves
+	// as a pure limit order and fills (ask <= limit_value).
+	eval := evaluateOrder(o, &models.MarketListingRecord{Ask: 98})
+	if !eval.fillNow {
+		t.Errorf("latched order should fill while ask<=limit, got fillNow=false")
+	}
+	if eval.justTriggered {
+		t.Errorf("already-armed order should not signal justTriggered, got true")
+	}
+}
+
+// stop_limit SELL: stop_value=100 arms when bid <= 100, then limit_value=95
+// gates the fill (sell while bid >= 95).
+func TestEvaluateOrder_StopLimitSell_ArmsAndFillsInsideWindow(t *testing.T) {
 	o := mkOrder("stop_limit", "sell")
 	o.StopValue = ptrFloat(100)
 	o.LimitValue = ptrFloat(95)
-	if !conditionsMet(o, &models.MarketListingRecord{Bid: 97}) {
-		t.Error("expected triggered")
-	}
-	if conditionsMet(o, &models.MarketListingRecord{Bid: 105}) {
-		t.Error("bid above stop should not trigger sell")
-	}
-	if conditionsMet(o, &models.MarketListingRecord{Bid: 90}) {
-		t.Error("bid below limit should not trigger")
+
+	eval := evaluateOrder(o, &models.MarketListingRecord{Bid: 97})
+	if !eval.fillNow || !eval.justTriggered {
+		t.Errorf("expected fillNow=true justTriggered=true, got %+v", eval)
 	}
 }
 
-func TestConditionsMet_UnknownType(t *testing.T) {
-	if conditionsMet(mkOrder("foo", "buy"), &models.MarketListingRecord{}) {
-		t.Error("unknown order type should not meet conditions")
+func TestEvaluateOrder_StopLimitSell_AboveStopDoesNothing(t *testing.T) {
+	o := mkOrder("stop_limit", "sell")
+	o.StopValue = ptrFloat(100)
+	o.LimitValue = ptrFloat(95)
+
+	eval := evaluateOrder(o, &models.MarketListingRecord{Bid: 105})
+	if eval.fillNow || eval.justTriggered {
+		t.Errorf("bid above stop should neither arm nor fill, got %+v", eval)
+	}
+}
+
+func TestEvaluateOrder_StopLimitSell_GapsBelowLimitArmsButDoesNotFill(t *testing.T) {
+	o := mkOrder("stop_limit", "sell")
+	o.StopValue = ptrFloat(100)
+	o.LimitValue = ptrFloat(95)
+
+	eval := evaluateOrder(o, &models.MarketListingRecord{Bid: 90})
+	if eval.fillNow {
+		t.Errorf("bid below limit must not fill yet, got fillNow=true")
+	}
+	if !eval.justTriggered {
+		t.Errorf("bid below stop should arm the latch even if outside limit window")
+	}
+}
+
+func TestEvaluateOrder_StopLimitSell_LatchSticksAfterPriceRecovers(t *testing.T) {
+	o := mkOrder("stop_limit", "sell")
+	o.StopValue = ptrFloat(100)
+	o.LimitValue = ptrFloat(95)
+	o.StopTriggered = true
+
+	eval := evaluateOrder(o, &models.MarketListingRecord{Bid: 102})
+	if !eval.fillNow {
+		t.Errorf("latched sell order should fill while bid>=limit, got fillNow=false")
+	}
+	if eval.justTriggered {
+		t.Errorf("already-armed order should not signal justTriggered, got true")
+	}
+}
+
+func TestEvaluateOrder_UnknownType(t *testing.T) {
+	eval := evaluateOrder(mkOrder("foo", "buy"), &models.MarketListingRecord{})
+	if eval.fillNow || eval.justTriggered {
+		t.Error("unknown order type should be inert")
 	}
 }
 

--- a/exchange-service/internal/service/order_helpers_test.go
+++ b/exchange-service/internal/service/order_helpers_test.go
@@ -261,6 +261,60 @@ func TestCalcCommission_StopLimitUsesLimitRate(t *testing.T) {
 	}
 }
 
+// --- computeInitialMarginCost (Initial Margin Cost = MaintenanceMargin × 1.1) ---
+
+func TestComputeInitialMarginCost_Stock(t *testing.T) {
+	svc := &OrderService{}
+	listing := &models.MarketListingRecord{Type: "stock"}
+	// 10 shares × $100 × 50% (stock rate) × 1.1 (IMC buffer) × 1.0 (same currency) = 550
+	got, err := svc.computeInitialMarginCost(listing, 10, 1, 100, 1.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !almostEqual(got, 550) {
+		t.Errorf("expected stock IMC=550, got %v", got)
+	}
+}
+
+func TestComputeInitialMarginCost_StockWithContractSizeAndFx(t *testing.T) {
+	svc := &OrderService{}
+	listing := &models.MarketListingRecord{Type: "stock"}
+	// 5 contracts × 100 shares × $50 × 50% × 1.1 × 1.2 (fx) = 16500
+	got, err := svc.computeInitialMarginCost(listing, 5, 100, 50, 1.2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !almostEqual(got, 16500) {
+		t.Errorf("expected 16500, got %v", got)
+	}
+}
+
+func TestComputeInitialMarginCost_Forex(t *testing.T) {
+	svc := &OrderService{}
+	listing := &models.MarketListingRecord{Type: "forex"}
+	// 1000 units × 1 × $1.10 × 10% (forex rate) × 1.1 × 1.0 = 121
+	got, err := svc.computeInitialMarginCost(listing, 1000, 1, 1.10, 1.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !almostEqual(got, 121) {
+		t.Errorf("expected forex IMC=121, got %v", got)
+	}
+}
+
+func TestComputeInitialMarginCost_Futures(t *testing.T) {
+	svc := &OrderService{}
+	listing := &models.MarketListingRecord{Type: "futures"}
+	// 2 × 50 × $200 × 10% × 1.1 × 1.0 = 2200
+	got, err := svc.computeInitialMarginCost(listing, 2, 50, 200, 1.0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !almostEqual(got, 2200) {
+		t.Errorf("expected futures IMC=2200, got %v", got)
+	}
+}
+
 // --- round2 ---
 
 func TestRound2(t *testing.T) {

--- a/exchange-service/internal/service/order_service.go
+++ b/exchange-service/internal/service/order_service.go
@@ -112,10 +112,21 @@ func (s *OrderService) CreateOrder(input CreateOrderInput) (*CreateOrderResult, 
 
 	// Margin orders: verify the account has enough available balance to cover
 	// the Initial Margin Cost (MaintenanceMargin × 1.1) before accepting the order.
+	// We capture the IMC so the buy debit path below uses it instead of the full price.
+	var initialMarginCost float64
 	if input.IsMargin {
-		if err := s.validateMargin(input.AccountID, listing, input.Quantity, contractSize, pricePerUnit, currencyRate); err != nil {
+		imc, err := s.computeInitialMarginCost(listing, input.Quantity, contractSize, pricePerUnit, currencyRate)
+		if err != nil {
 			return nil, err
 		}
+		balance, _, err := s.orderRepo.GetAccountBalance(input.AccountID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read account balance: %w", err)
+		}
+		if balance < imc {
+			return nil, fmt.Errorf("insufficient balance for margin order: need %.2f, have %.2f", imc, balance)
+		}
+		initialMarginCost = imc
 	}
 
 	// Convert totalPrice to RSD for agent limit checks (limits are always in RSD).
@@ -134,11 +145,22 @@ func (s *OrderService) CreateOrder(input CreateOrderInput) (*CreateOrderResult, 
 		}
 	}
 
-	// For buy orders, debit the full order value + commission from the account upfront,
-	// converted to the account's currency if it differs from the asset's currency.
+	// For buy orders, debit the account upfront.
+	//   Non-margin: full order value + commission, in the account's currency.
+	//   Margin:     only the Initial Margin Cost; the rest is fronted by the bank
+	//               and recorded as MarginLoan on the order, repaid from sell proceeds.
+	var marginLoan float64
 	if input.Direction == "buy" {
-		totalDebit := round2((totalPrice + commission) * currencyRate)
-		if err := s.orderRepo.DebitAccount(input.AccountID, totalDebit); err != nil {
+		totalCost := round2((totalPrice + commission) * currencyRate)
+		debit := totalCost
+		if input.IsMargin {
+			debit = initialMarginCost
+			marginLoan = round2(totalCost - initialMarginCost)
+			if marginLoan < 0 {
+				marginLoan = 0
+			}
+		}
+		if err := s.orderRepo.DebitAccount(input.AccountID, debit); err != nil {
 			return nil, fmt.Errorf("insufficient funds: %w", err)
 		}
 	}
@@ -169,6 +191,7 @@ func (s *OrderService) CreateOrder(input CreateOrderInput) (*CreateOrderResult, 
 		CurrencyRate:      currencyRate,
 		AfterHours:        input.AfterHours,
 		AccountID:         input.AccountID,
+		MarginLoan:        marginLoan,
 		LastModification:  now,
 		CreatedAt:         now,
 	}
@@ -284,12 +307,23 @@ func (s *OrderService) DeclineOrder(orderID, supervisorID uint) error {
 		return fmt.Errorf("order is not pending (status: %s)", order.Status)
 	}
 
-	// Refund the full debit that was taken on creation, converting back to account currency.
+	// Refund what was actually debited on creation, converting back to account currency.
+	//   Non-margin: full order value + commission.
+	//   Margin:     only the IMC (total cost - margin loan); the loan was bank-funded.
 	if order.Direction == "buy" {
 		totalPrice := round2(float64(order.Quantity) * float64(order.ContractSize) * order.PricePerUnit)
-		refund := round2((totalPrice + order.Commission) * order.CurrencyRate)
+		refund := round2((totalPrice+order.Commission)*order.CurrencyRate - order.MarginLoan)
+		if refund < 0 {
+			refund = 0
+		}
 		if err := s.orderRepo.RefundToAccount(order.AccountID, refund); err != nil {
 			return fmt.Errorf("failed to refund account on decline: %w", err)
+		}
+		// Discharge the (now unused) margin loan since the order was declined.
+		if order.MarginLoan > 0 {
+			if err := s.orderRepo.SetMarginLoan(order.ID, 0); err != nil {
+				return fmt.Errorf("failed to clear margin loan on decline: %w", err)
+			}
 		}
 	}
 
@@ -318,7 +352,25 @@ func (s *OrderService) CancelOrder(orderID, requesterID uint, newRemaining int64
 	}
 
 	cancelledQty := order.RemainingPortions - newRemaining
-	refundAmount := round2(float64(cancelledQty) * float64(order.ContractSize) * order.PricePerUnit * order.CurrencyRate)
+	cancelledValue := round2(float64(cancelledQty) * float64(order.ContractSize) * order.PricePerUnit * order.CurrencyRate)
+	refundAmount := cancelledValue
+
+	// For margin buys, only the proportional share of the IMC was actually debited from
+	// the user — the rest is bank-funded margin loan. Refund only the user's share and
+	// reduce the outstanding margin loan by the bank's share of the cancelled qty.
+	if order.Direction == "buy" && order.IsMargin && order.RemainingPortions > 0 {
+		share := float64(cancelledQty) / float64(order.RemainingPortions)
+		loanCancelled := round2(order.MarginLoan * share)
+		refundAmount = round2(cancelledValue - loanCancelled)
+		if refundAmount < 0 {
+			refundAmount = 0
+		}
+		if loanCancelled > 0 {
+			if _, err := s.orderRepo.ReduceMarginLoan(orderID, loanCancelled); err != nil {
+				return fmt.Errorf("failed to reduce margin loan on cancel: %w", err)
+			}
+		}
+	}
 
 	if newRemaining == 0 {
 		// Full cancel.
@@ -475,23 +527,15 @@ func orderPricePerUnit(listing *models.MarketListingRecord, input CreateOrderInp
 	}
 }
 
-// validateMargin checks that the account's available balance covers the
-// Initial Margin Cost for a margin order.
+// computeInitialMarginCost returns the IMC the user must cover up-front for a margin order,
+// in the account's currency.
 //
-//	MaintenanceMargin = contractSize * pricePerUnit * 10%
-//	InitialMarginCost = MaintenanceMargin * 1.1
-// validateMargin checks that the account's available balance covers the Initial Margin Cost.
 // Margin rates per asset type:
-//   stock:   50% of total position value  (quantity × contractSize × price × 50%)
-//   option:  100 shares/contract × 50% × underlying stock price  (quantity × contractSize × 100 × stockPrice × 50%)
-//   forex / futures: 10% of nominal value (quantity × contractSize × price × 10%)
-// InitialMarginCost = MaintenanceMargin × 1.1
-func (s *OrderService) validateMargin(accountID uint, listing *models.MarketListingRecord, quantity, contractSize int64, pricePerUnit, currencyRate float64) error {
-	balance, _, err := s.orderRepo.GetAccountBalance(accountID)
-	if err != nil {
-		return fmt.Errorf("failed to read account balance: %w", err)
-	}
-
+//   stock:           50% of total position value
+//   option:          100 shares/contract × 50% × underlying stock price
+//   forex / futures: 10% of nominal value
+// InitialMarginCost = MaintenanceMargin × 1.1 × currencyRate
+func (s *OrderService) computeInitialMarginCost(listing *models.MarketListingRecord, quantity, contractSize int64, pricePerUnit, currencyRate float64) (float64, error) {
 	qty := float64(quantity) * float64(contractSize)
 	var maintenanceMargin float64
 
@@ -501,23 +545,18 @@ func (s *OrderService) validateMargin(accountID uint, listing *models.MarketList
 	case "option":
 		opt, err := s.marketRepo.GetOptionByListingID(listing.ID)
 		if err != nil || opt == nil {
-			return fmt.Errorf("option contract data not found for margin calculation")
+			return 0, fmt.Errorf("option contract data not found for margin calculation")
 		}
 		underlying, err := s.marketRepo.GetListingRecordByID(opt.StockListingID)
 		if err != nil || underlying == nil {
-			return fmt.Errorf("underlying stock not found for option margin calculation")
+			return 0, fmt.Errorf("underlying stock not found for option margin calculation")
 		}
-		// Each option contract covers 100 shares; margin = 50% of underlying position value.
 		maintenanceMargin = qty * 100 * underlying.Price * 0.50
 	default: // forex, futures
 		maintenanceMargin = qty * pricePerUnit * 0.10
 	}
 
-	imc := round2(maintenanceMargin * 1.1 * currencyRate)
-	if balance < imc {
-		return fmt.Errorf("insufficient balance for margin order: need %.2f, have %.2f", imc, balance)
-	}
-	return nil
+	return round2(maintenanceMargin * 1.1 * currencyRate), nil
 }
 
 // toRSD converts an amount from the given currency to RSD using the rate provider.

--- a/exchange-service/internal/service/otc_exercise_saga.go
+++ b/exchange-service/internal/service/otc_exercise_saga.go
@@ -369,12 +369,32 @@ func finalizeOtcExercise(tx *gorm.DB, contractID uint, buyerAccountID, sellerAcc
 
 	_ = cost // kept in the signature for symmetry with the compensation
 
+	// Snapshot the underlying market price and the contract's premium at exercise
+	// time so historical buyer/seller P&L is preserved on the contract row.
+	// Buyer (call holder) profit  = (market - strike) × amount - premium
+	// Seller (writer)     profit  = premium - (market - strike) × amount
+	var contract models.OtcContractRecord
+	if err := tx.First(&contract, contractID).Error; err != nil {
+		return fmt.Errorf("finalize: load contract for P&L snapshot: %w", err)
+	}
+	var listing models.MarketListingRecord
+	if err := tx.First(&listing, assetID).Error; err != nil {
+		return fmt.Errorf("finalize: load underlying listing for P&L snapshot: %w", err)
+	}
+	exercisedAtPrice := listing.Price
+	intrinsic := (exercisedAtPrice - contract.StrikePrice) * amount
+	buyerProfit := intrinsic - contract.Premium
+	sellerProfit := contract.Premium - intrinsic
+
 	now := time.Now().UTC()
 	result := tx.Model(&models.OtcContractRecord{}).
 		Where("id = ? AND status = ?", contractID, models.OtcContractStatusValid).
 		Updates(map[string]interface{}{
-			"status":     models.OtcContractStatusExercised,
-			"updated_at": now,
+			"status":             models.OtcContractStatusExercised,
+			"exercised_at_price": exercisedAtPrice,
+			"buyer_profit":       buyerProfit,
+			"seller_profit":      sellerProfit,
+			"updated_at":         now,
 		})
 	if result.Error != nil {
 		return result.Error
@@ -392,8 +412,11 @@ func revertOtcExerciseFinalization(tx *gorm.DB, contractID, buyerAccountID uint,
 	return tx.Model(&models.OtcContractRecord{}).
 		Where("id = ? AND status = ?", contractID, models.OtcContractStatusExercised).
 		Updates(map[string]interface{}{
-			"status":     models.OtcContractStatusValid,
-			"updated_at": now,
+			"status":             models.OtcContractStatusValid,
+			"exercised_at_price": 0,
+			"buyer_profit":       0,
+			"seller_profit":      0,
+			"updated_at":         now,
 		}).Error
 }
 


### PR DESCRIPTION
## Summary

Addresses three issues from `Current_Problems.md`:

- **OTC profit tracking** — persist `ExercisedAtPrice`, `BuyerProfit`, `SellerProfit` on `OtcContractRecord`. `finalizeOtcExercise` snapshots the live price and writes both legs as `(market - strike) * amount - premium`; rollback clears them. `ExpireValidContracts` sets `BuyerProfit = -premium / SellerProfit = +premium` so expired contracts surface the premium loss/gain cleanly. The HTTP handler exposes the new fields; valid contracts still mark-to-market live, finalized contracts return the stored snapshot.
- **Simplified margin (option 2)** — replaces `validateMargin` with `computeInitialMarginCost` (`IMC = MaintenanceMargin * 1.1`; rates: 50% stock, 100×50% of underlying for options, 10% forex/futures). Buy debits only IMC and records the remainder as `MarginLoan` on the order; sell proceeds repay outstanding loans FIFO via `settleMarginLoansFromProceeds`. `DeclineOrder` refunds the IMC and clears the loan; `CancelOrder` scales both refund and loan proportionally.
- **Stop-limit latch** — refactored `conditionsMet` → `evaluateOrder` returning `{fillNow, justTriggered}`. `stop_limit` arms on the first stop cross (persisted as `StopTriggered`) and then behaves as a plain limit; the latch is sticky across price retreats.

## Test plan

- [x] `go vet ./...` clean
- [x] 12 new `evaluateOrder` tests pass (market / limit buy+sell / stop buy+sell / stop_limit: arms-and-fills, below-stop, gap-above-limit, latch-sticks, unknown type)
- [x] 4 new `computeInitialMarginCost` tests pass (stock, stock w/ contract size + fx, forex, futures)
- [ ] Manual: place a margin buy → verify only IMC debited and `marginLoan` recorded
- [ ] Manual: matching sell → verify FIFO loan repayment from proceeds
- [ ] Manual: stop_limit with stop crossed but price above limit → armed, not filled; price drops back → still armed
- [ ] Manual: exercise an OTC contract → `exercisedAtPrice`, `buyerProfit`, `sellerProfit` populated
- [ ] Manual: let an OTC contract expire → `buyerProfit = -premium`, `sellerProfit = +premium`

Paired frontend PR: RAF-SI-2025/EXBanka-3-Frontend `feat/otc-margin-stoplimit-fixes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)