### PR TITLE
fix(exchange): wire bank treasury cash flow through margin loans

### DIFF
--- a/exchange-service/internal/service/order_executor.go
+++ b/exchange-service/internal/service/order_executor.go
@@ -142,9 +142,14 @@ func (e *OrderExecutor) Run() {
 		}
 
 		// Credit the bank's account with the proportional commission for buy fills.
-		// Commission was already deducted from the client's account at order creation.
+		// Commission was already deducted from the client's account at order creation
+		// for non-margin orders. For margin orders the commission is part of the
+		// bank's loan disbursement at create (totalCost includes commission), and
+		// gets recovered when the client sells and the loan is repaid — so no
+		// separate commission credit is needed here, or the bank would gain it
+		// back twice and the "bank cash drop" wouldn't equal the loan amount.
 		// The commission is in the asset's trading currency (exchange currency), not the user's account currency.
-		if order.Direction == "buy" && order.Commission > 0 {
+		if order.Direction == "buy" && order.Commission > 0 && !order.IsMargin {
 			fillCommission := round2(order.Commission * float64(fillQty) / float64(order.Quantity))
 			if fillCommission > 0 {
 				currencyKod := order.Asset.Exchange.Currency
@@ -267,6 +272,27 @@ func (e *OrderExecutor) settleMarginLoansFromProceeds(sellOrder *models.OrderRec
 			slog.Error("order executor: failed to reduce margin loan",
 				"sellOrderID", sellOrder.ID, "buyOrderID", loan.ID, "error", err)
 			continue
+		}
+		// Credit the bank account in the loan's currency: this is the cash the
+		// bank originally fronted at order creation, now coming back from the
+		// sell proceeds. Without this, the loan number on the order zeroes out
+		// but the bank's account never recovers the funds.
+		if applied > 0 {
+			_, loanCurrency, balErr := e.orderRepo.GetAccountBalance(loan.AccountID)
+			if balErr != nil {
+				slog.Error("order executor: failed to read account currency for margin repayment", "buyOrderID", loan.ID, "error", balErr)
+			} else if loanCurrency != "" {
+				bankID, err := e.orderRepo.GetBankAccountByCurrency(loanCurrency)
+				if err != nil {
+					slog.Error("order executor: bank lookup failed for margin repayment", "currency", loanCurrency, "buyOrderID", loan.ID, "error", err)
+				} else if bankID > 0 {
+					if err := e.orderRepo.CreditAccount(bankID, applied); err != nil {
+						slog.Error("order executor: failed to credit bank for margin repayment", "bankID", bankID, "amount", applied, "buyOrderID", loan.ID, "error", err)
+					}
+				} else {
+					slog.Warn("order executor: no bank account for currency, margin repayment not credited", "currency", loanCurrency, "buyOrderID", loan.ID)
+				}
+			}
 		}
 		remaining = round2(remaining - applied)
 		slog.Info("order executor: applied sell proceeds to margin loan",

--- a/exchange-service/internal/service/order_service.go
+++ b/exchange-service/internal/service/order_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"log/slog"
 	"math"
 	"time"
 
@@ -163,6 +164,14 @@ func (s *OrderService) CreateOrder(input CreateOrderInput) (*CreateOrderResult, 
 		if err := s.orderRepo.DebitAccount(input.AccountID, debit); err != nil {
 			return nil, fmt.Errorf("insufficient funds: %w", err)
 		}
+		if input.IsMargin && marginLoan > 0 {
+			_, accountCurrency, balErr := s.orderRepo.GetAccountBalance(input.AccountID)
+			if balErr != nil {
+				slog.Error("order: failed to read account currency for bank margin debit", "accountID", input.AccountID, "error", balErr)
+			} else {
+				s.adjustBankForMarginLoan(accountCurrency, -marginLoan, 0, "create")
+			}
+		}
 	}
 
 	now := time.Now().UTC()
@@ -320,7 +329,14 @@ func (s *OrderService) DeclineOrder(orderID, supervisorID uint) error {
 			return fmt.Errorf("failed to refund account on decline: %w", err)
 		}
 		// Discharge the (now unused) margin loan since the order was declined.
+		// The bank's cash that was fronted at create time is returned to its account.
 		if order.MarginLoan > 0 {
+			_, accountCurrency, balErr := s.orderRepo.GetAccountBalance(order.AccountID)
+			if balErr != nil {
+				slog.Error("order: failed to read account currency for bank margin refund on decline", "orderID", order.ID, "error", balErr)
+			} else {
+				s.adjustBankForMarginLoan(accountCurrency, order.MarginLoan, order.ID, "decline")
+			}
 			if err := s.orderRepo.SetMarginLoan(order.ID, 0); err != nil {
 				return fmt.Errorf("failed to clear margin loan on decline: %w", err)
 			}
@@ -369,6 +385,12 @@ func (s *OrderService) CancelOrder(orderID, requesterID uint, newRemaining int64
 			if _, err := s.orderRepo.ReduceMarginLoan(orderID, loanCancelled); err != nil {
 				return fmt.Errorf("failed to reduce margin loan on cancel: %w", err)
 			}
+			_, accountCurrency, balErr := s.orderRepo.GetAccountBalance(order.AccountID)
+			if balErr != nil {
+				slog.Error("order: failed to read account currency for bank margin refund on cancel", "orderID", order.ID, "error", balErr)
+			} else {
+				s.adjustBankForMarginLoan(accountCurrency, loanCancelled, order.ID, "cancel")
+			}
 		}
 	}
 
@@ -390,6 +412,36 @@ func (s *OrderService) CancelOrder(orderID, requesterID uint, newRemaining int64
 	}
 
 	return nil
+}
+
+// adjustBankForMarginLoan moves cash to/from EXBanka's account in the given
+// currency to mirror a margin loan disbursement or repayment.
+//   delta < 0 → debit the bank (loan disbursed at order creation)
+//   delta > 0 → credit the bank (loan repaid via sell proceeds, decline, or cancel)
+// Mis-seeded treasury accounts are logged but do not abort the caller, mirroring
+// the policy used by commission crediting in the order executor.
+func (s *OrderService) adjustBankForMarginLoan(currency string, delta float64, orderID uint, ctx string) {
+	if delta == 0 || currency == "" {
+		return
+	}
+	bankAccountID, err := s.orderRepo.GetBankAccountByCurrency(currency)
+	if err != nil {
+		slog.Error("order: bank account lookup failed for margin "+ctx, "currency", currency, "orderID", orderID, "error", err)
+		return
+	}
+	if bankAccountID == 0 {
+		slog.Warn("order: no bank account for currency, margin "+ctx+" skipped", "currency", currency, "orderID", orderID)
+		return
+	}
+	if delta < 0 {
+		if err := s.orderRepo.DebitAccount(bankAccountID, -delta); err != nil {
+			slog.Error("order: bank debit failed for margin "+ctx, "bankAccountID", bankAccountID, "amount", -delta, "orderID", orderID, "error", err)
+		}
+	} else {
+		if err := s.orderRepo.CreditAccount(bankAccountID, delta); err != nil {
+			slog.Error("order: bank credit failed for margin "+ctx, "bankAccountID", bankAccountID, "amount", delta, "orderID", orderID, "error", err)
+		}
+	}
 }
 
 // isSettlementExpired returns true when the listing is a futures or options


### PR DESCRIPTION
Margin orders only updated the marginLoan number on the order record; the bank's treasury account in the order's currency was never touched. The bank's books drifted silently with every margin trade.

Fixes the four missing flows:
- CreateOrder: debit bank by marginLoan in the client's account currency
- DeclineOrder / CancelOrder: refund bank by the cancelled loan portion
- settleMarginLoansFromProceeds: credit bank by the repaid amount on sell

Also skips the buy-fill commission credit to bank for margin orders so the bank's net debit equals the displayed marginLoan exactly (commission is already part of the loan via totalCost = price + commission).

A new helper adjustBankForMarginLoan centralises the lookup/debit/credit and logs (rather than aborts) when the treasury currency is mis-seeded, matching the policy used for commission crediting.