### PR TITLE
Add backend Kubernetes migration safety

### DIFF
--- a/account-service/internal/database/database.go
+++ b/account-service/internal/database/database.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+const migrationAdvisoryLockID int64 = 2025062701
+
 func Connect(cfg *config.Config) (*gorm.DB, error) {
 	dsn := fmt.Sprintf(
 		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s TimeZone=UTC",
@@ -30,18 +32,33 @@ func Connect(cfg *config.Config) (*gorm.DB, error) {
 
 func Migrate(db *gorm.DB) error {
 	slog.Info("Running account-service database migrations...")
-	if err := db.AutoMigrate(
-		&models.Currency{},
-		&models.SifraDelatnosti{},
-		&models.Firma{},
-		&models.Client{},
-		&models.Account{},
-		&models.Card{},
-		&models.OvlascenoLice{},
-		&models.CardRequest{},
-	); err != nil {
+	if err := withMigrationLock(db, func(tx *gorm.DB) error {
+		return tx.AutoMigrate(
+			&models.Currency{},
+			&models.SifraDelatnosti{},
+			&models.Firma{},
+			&models.Client{},
+			&models.Account{},
+			&models.Card{},
+			&models.OvlascenoLice{},
+			&models.CardRequest{},
+		)
+	}); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}
 	slog.Info("Account-service migrations complete")
 	return nil
+}
+
+func withMigrationLock(db *gorm.DB, migrate func(*gorm.DB) error) error {
+	if db.Dialector.Name() != "postgres" {
+		return migrate(db)
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", migrationAdvisoryLockID).Error; err != nil {
+			return fmt.Errorf("failed to acquire migration advisory lock: %w", err)
+		}
+		return migrate(tx)
+	})
 }

--- a/account-service/internal/service/db_coverage_test.go
+++ b/account-service/internal/service/db_coverage_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 )
+
+var seedAcctSvcAccountSeq atomic.Uint64
 
 func newAcctSvcTestDB(t *testing.T, name string) *gorm.DB {
 	t.Helper()
@@ -63,7 +66,7 @@ func seedAcctSvcAccount(t *testing.T, db *gorm.DB, clientID, currencyID uint, vr
 	t.Helper()
 	cid := clientID
 	acc := &models.Account{
-		BrojRacuna: fmt.Sprintf("AC-%d-%d-%d", clientID, currencyID, time.Now().UnixNano()),
+		BrojRacuna: fmt.Sprintf("AC-%d-%d-%d-%d", clientID, currencyID, time.Now().UnixNano(), seedAcctSvcAccountSeq.Add(1)),
 		ClientID:   &cid, CurrencyID: currencyID, Vrsta: vrsta, Tip: "tekuci",
 		Status: "aktivan",
 	}

--- a/auth-service/internal/database/database.go
+++ b/auth-service/internal/database/database.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+const migrationAdvisoryLockID int64 = 2025062701
+
 func Connect(cfg *config.Config) (*gorm.DB, error) {
 	dsn := fmt.Sprintf(
 		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s TimeZone=UTC",
@@ -30,16 +32,31 @@ func Connect(cfg *config.Config) (*gorm.DB, error) {
 
 func Migrate(db *gorm.DB) error {
 	slog.Info("Running auth-service database migrations...")
-	if err := db.AutoMigrate(
-		&models.Employee{},
-		&models.Permission{},
-		&models.Token{},
-	); err != nil {
+	if err := withMigrationLock(db, func(tx *gorm.DB) error {
+		return tx.AutoMigrate(
+			&models.Employee{},
+			&models.Permission{},
+			&models.Token{},
+		)
+	}); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}
 
 	slog.Info("Auth-service migrations complete")
 	return nil
+}
+
+func withMigrationLock(db *gorm.DB, migrate func(*gorm.DB) error) error {
+	if db.Dialector.Name() != "postgres" {
+		return migrate(db)
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", migrationAdvisoryLockID).Error; err != nil {
+			return fmt.Errorf("failed to acquire migration advisory lock: %w", err)
+		}
+		return migrate(tx)
+	})
 }
 
 func SeedPermissions(db *gorm.DB) error {

--- a/client-service/internal/database/database.go
+++ b/client-service/internal/database/database.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+const migrationAdvisoryLockID int64 = 2025062701
+
 func Connect(cfg *config.Config) (*gorm.DB, error) {
 	dsn := fmt.Sprintf(
 		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s TimeZone=UTC",
@@ -30,21 +32,39 @@ func Connect(cfg *config.Config) (*gorm.DB, error) {
 
 func Migrate(db *gorm.DB) error {
 	slog.Info("Running client-service database migrations...")
-	if err := db.AutoMigrate(
-		&models.Client{},
-		&models.Permission{},
-	); err != nil {
-		return fmt.Errorf("migration failed: %w", err)
-	}
+	if err := withMigrationLock(db, func(tx *gorm.DB) error {
+		if err := tx.AutoMigrate(
+			&models.Client{},
+			&models.Permission{},
+		); err != nil {
+			return err
+		}
 
-	if err := db.Model(&models.Client{}).
-		Where("password <> ? AND salt_password <> ?", "pending", "pending").
-		Update("aktivan", true).Error; err != nil {
-		return fmt.Errorf("failed to backfill active clients: %w", err)
+		if err := tx.Model(&models.Client{}).
+			Where("password <> ? AND salt_password <> ?", "pending", "pending").
+			Update("aktivan", true).Error; err != nil {
+			return fmt.Errorf("failed to backfill active clients: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("migration failed: %w", err)
 	}
 
 	slog.Info("Client-service migrations complete")
 	return nil
+}
+
+func withMigrationLock(db *gorm.DB, migrate func(*gorm.DB) error) error {
+	if db.Dialector.Name() != "postgres" {
+		return migrate(db)
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", migrationAdvisoryLockID).Error; err != nil {
+			return fmt.Errorf("failed to acquire migration advisory lock: %w", err)
+		}
+		return migrate(tx)
+	})
 }
 
 func SeedPermissions(db *gorm.DB) error {

--- a/employee-service/internal/database/database.go
+++ b/employee-service/internal/database/database.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+const migrationAdvisoryLockID int64 = 2025062701
+
 func Connect(cfg *config.Config) (*gorm.DB, error) {
 	dsn := fmt.Sprintf(
 		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s TimeZone=UTC",
@@ -30,21 +32,39 @@ func Connect(cfg *config.Config) (*gorm.DB, error) {
 
 func Migrate(db *gorm.DB) error {
 	slog.Info("Running employee-service database migrations...")
-	if err := db.AutoMigrate(
-		&models.Employee{},
-		&models.ActuaryProfile{},
-		&models.Permission{},
-		&models.Token{},
-	); err != nil {
-		return fmt.Errorf("migration failed: %w", err)
-	}
+	if err := withMigrationLock(db, func(tx *gorm.DB) error {
+		if err := tx.AutoMigrate(
+			&models.Employee{},
+			&models.ActuaryProfile{},
+			&models.Permission{},
+			&models.Token{},
+		); err != nil {
+			return err
+		}
 
-	if err := BackfillActuaryProfiles(db); err != nil {
-		return fmt.Errorf("actuary profile backfill failed: %w", err)
+		if err := BackfillActuaryProfiles(tx); err != nil {
+			return fmt.Errorf("actuary profile backfill failed: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("migration failed: %w", err)
 	}
 
 	slog.Info("Employee-service migrations complete")
 	return nil
+}
+
+func withMigrationLock(db *gorm.DB, migrate func(*gorm.DB) error) error {
+	if db.Dialector.Name() != "postgres" {
+		return migrate(db)
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", migrationAdvisoryLockID).Error; err != nil {
+			return fmt.Errorf("failed to acquire migration advisory lock: %w", err)
+		}
+		return migrate(tx)
+	})
 }
 
 func SeedPermissions(db *gorm.DB) error {

--- a/exchange-service/internal/database/database.go
+++ b/exchange-service/internal/database/database.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+const migrationAdvisoryLockID int64 = 2025062701
+
 func Connect(cfg *config.Config) (*gorm.DB, error) {
 	dsn := fmt.Sprintf(
 		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s TimeZone=UTC",
@@ -30,37 +32,52 @@ func Connect(cfg *config.Config) (*gorm.DB, error) {
 
 func Migrate(db *gorm.DB) error {
 	slog.Info("Running exchange-service database migrations...")
-	if err := db.AutoMigrate(
-		&models.MarketExchangeRecord{},
-		&models.ExchangeWorkingDayRecord{},
-		&models.MarketListingRecord{},
-		&models.MarketListingDailyPriceInfoRecord{},
-		&models.StockRecord{},
-		&models.ForexPairRecord{},
-		&models.FuturesContractRecord{},
-		&models.OptionRecord{},
-		&models.OrderRecord{},
-		&models.OrderTransactionRecord{},
-		&models.PortfolioHoldingRecord{},
-		&models.OtcOfferRecord{},
-		&models.OtcContractRecord{},
-		&models.TaxRecord{},
-		&models.SagaTransactionRecord{},
-		&models.SagaStepRecord{},
-		&models.InvestmentFundRecord{},
-		&models.ClientFundTransactionRecord{},
-		&models.ClientFundPositionRecord{},
-		&models.FundPerformanceHistoryRecord{},
-		&models.InterbankInboundMessage{},
-		&models.InterbankOtcNegotiation{},
-		&models.InterbankPendingTx{},
-		&models.InterbankOptionContract{},
-		&models.InterbankPayment{},
-		&models.RemotePublicStockSnapshot{},
-		&models.InterbankPendingExercise{},
-	); err != nil {
+	if err := withMigrationLock(db, func(tx *gorm.DB) error {
+		return tx.AutoMigrate(
+			&models.MarketExchangeRecord{},
+			&models.ExchangeWorkingDayRecord{},
+			&models.MarketListingRecord{},
+			&models.MarketListingDailyPriceInfoRecord{},
+			&models.StockRecord{},
+			&models.ForexPairRecord{},
+			&models.FuturesContractRecord{},
+			&models.OptionRecord{},
+			&models.OrderRecord{},
+			&models.OrderTransactionRecord{},
+			&models.PortfolioHoldingRecord{},
+			&models.OtcOfferRecord{},
+			&models.OtcContractRecord{},
+			&models.TaxRecord{},
+			&models.SagaTransactionRecord{},
+			&models.SagaStepRecord{},
+			&models.InvestmentFundRecord{},
+			&models.ClientFundTransactionRecord{},
+			&models.ClientFundPositionRecord{},
+			&models.FundPerformanceHistoryRecord{},
+			&models.InterbankInboundMessage{},
+			&models.InterbankOtcNegotiation{},
+			&models.InterbankPendingTx{},
+			&models.InterbankOptionContract{},
+			&models.InterbankPayment{},
+			&models.RemotePublicStockSnapshot{},
+			&models.InterbankPendingExercise{},
+		)
+	}); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}
 	slog.Info("Exchange-service migrations complete")
 	return nil
+}
+
+func withMigrationLock(db *gorm.DB, migrate func(*gorm.DB) error) error {
+	if db.Dialector.Name() != "postgres" {
+		return migrate(db)
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", migrationAdvisoryLockID).Error; err != nil {
+			return fmt.Errorf("failed to acquire migration advisory lock: %w", err)
+		}
+		return migrate(tx)
+	})
 }

--- a/loan-service/internal/database/database.go
+++ b/loan-service/internal/database/database.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+const migrationAdvisoryLockID int64 = 2025062701
+
 func Connect(cfg *config.Config) (*gorm.DB, error) {
 	dsn := fmt.Sprintf(
 		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s TimeZone=UTC",
@@ -30,12 +32,27 @@ func Connect(cfg *config.Config) (*gorm.DB, error) {
 
 func Migrate(db *gorm.DB) error {
 	slog.Info("Running loan-service database migrations...")
-	if err := db.AutoMigrate(
-		&models.Loan{},
-		&models.LoanInstallment{},
-	); err != nil {
+	if err := withMigrationLock(db, func(tx *gorm.DB) error {
+		return tx.AutoMigrate(
+			&models.Loan{},
+			&models.LoanInstallment{},
+		)
+	}); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}
 	slog.Info("Loan-service migrations complete")
 	return nil
+}
+
+func withMigrationLock(db *gorm.DB, migrate func(*gorm.DB) error) error {
+	if db.Dialector.Name() != "postgres" {
+		return migrate(db)
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", migrationAdvisoryLockID).Error; err != nil {
+			return fmt.Errorf("failed to acquire migration advisory lock: %w", err)
+		}
+		return migrate(tx)
+	})
 }

--- a/payment-service/internal/database/database.go
+++ b/payment-service/internal/database/database.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+const migrationAdvisoryLockID int64 = 2025062701
+
 func Connect(cfg *config.Config) (*gorm.DB, error) {
 	dsn := fmt.Sprintf(
 		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s TimeZone=UTC",
@@ -30,14 +32,29 @@ func Connect(cfg *config.Config) (*gorm.DB, error) {
 
 func Migrate(db *gorm.DB) error {
 	slog.Info("Running payment-service database migrations...")
-	if err := db.AutoMigrate(
-		&models.Account{},
-		&models.SifraPlacanja{},
-		&models.PaymentRecipient{},
-		&models.Payment{},
-	); err != nil {
+	if err := withMigrationLock(db, func(tx *gorm.DB) error {
+		return tx.AutoMigrate(
+			&models.Account{},
+			&models.SifraPlacanja{},
+			&models.PaymentRecipient{},
+			&models.Payment{},
+		)
+	}); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}
 	slog.Info("Payment-service migrations complete")
 	return nil
+}
+
+func withMigrationLock(db *gorm.DB, migrate func(*gorm.DB) error) error {
+	if db.Dialector.Name() != "postgres" {
+		return migrate(db)
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", migrationAdvisoryLockID).Error; err != nil {
+			return fmt.Errorf("failed to acquire migration advisory lock: %w", err)
+		}
+		return migrate(tx)
+	})
 }

--- a/transfer-service/internal/database/database.go
+++ b/transfer-service/internal/database/database.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+const migrationAdvisoryLockID int64 = 2025062701
+
 func Connect(cfg *config.Config) (*gorm.DB, error) {
 	dsn := fmt.Sprintf(
 		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s TimeZone=UTC",
@@ -30,13 +32,28 @@ func Connect(cfg *config.Config) (*gorm.DB, error) {
 
 func Migrate(db *gorm.DB) error {
 	slog.Info("Running transfer-service database migrations...")
-	if err := db.AutoMigrate(
-		&models.Currency{},
-		&models.Account{},
-		&models.Transfer{},
-	); err != nil {
+	if err := withMigrationLock(db, func(tx *gorm.DB) error {
+		return tx.AutoMigrate(
+			&models.Currency{},
+			&models.Account{},
+			&models.Transfer{},
+		)
+	}); err != nil {
 		return fmt.Errorf("migration failed: %w", err)
 	}
 	slog.Info("Transfer-service migrations complete")
 	return nil
+}
+
+func withMigrationLock(db *gorm.DB, migrate func(*gorm.DB) error) error {
+	if db.Dialector.Name() != "postgres" {
+		return migrate(db)
+	}
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Exec("SELECT pg_advisory_xact_lock(?)", migrationAdvisoryLockID).Error; err != nil {
+			return fmt.Errorf("failed to acquire migration advisory lock: %w", err)
+		}
+		return migrate(tx)
+	})
 }


### PR DESCRIPTION
## Summary
- Serializes backend service database migrations during Kubernetes startup.
- Uses PostgreSQL advisory transaction locking for shared database safety.
- Keeps non-Postgres test paths unchanged.
- Stabilizes one account-service test seed helper.

## Testing
- go test ./... in auth-service
- go test ./... in account-service
- go test ./... in client-service
- go test ./... in employee-service
- go test ./... in transfer-service
- go test ./... in payment-service
- go test ./... in exchange-service
- go test ./... in loan-service