### PR TITLE
Add Redis integration for exchange-service cache

### DIFF
--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	exchangev1 "github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/gen/proto/exchange/v1"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/cache"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/database"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/handler"
@@ -41,9 +42,26 @@ func main() {
 		os.Exit(1)
 	}
 
+	redisClient := cache.NewRedisClient(cfg.RedisAddr, cfg.RedisPassword, cfg.RedisDB)
+	if redisClient != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		if err := redisClient.Ping(ctx); err != nil {
+			slog.Warn("Redis unavailable, continuing with local exchange caches", "error", err)
+			_ = redisClient.Close()
+			redisClient = nil
+		} else {
+			slog.Info("Redis connected for exchange-service cache/coordination", "addr", cfg.RedisAddr, "db", cfg.RedisDB)
+			defer redisClient.Close()
+		}
+		cancel()
+	}
+
 	// Shared rate provider: same static rates used by the exchange rates page, with caching.
 	staticRates := provider.NewStaticRateProvider()
 	rateProvider := provider.NewCachedProvider(staticRates, staticRates, 24*time.Hour)
+	if redisClient != nil {
+		rateProvider.WithRedis(redisClient)
+	}
 
 	// Build shared repos and services before starting cron so they're reusable.
 	marketRepo := repository.NewMarketRepository(db)

--- a/exchange-service/go.mod
+++ b/exchange-service/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
 	github.com/joho/godotenv v1.5.1
+	github.com/redis/go-redis/v9 v9.7.0
 	github.com/robfig/cron/v3 v3.0.1
 	google.golang.org/genproto/googleapis/api v0.0.0-20260209200024-4cfbd4190f57
 	google.golang.org/grpc v1.79.1
@@ -17,6 +18,8 @@ require (
 )
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/glebarez/go-sqlite v1.21.2 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/exchange-service/go.sum
+++ b/exchange-service/go.sum
@@ -1,8 +1,14 @@
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/glebarez/go-sqlite v1.21.2 h1:3a6LFC4sKahUunAmynQKLZceZCOzUthkRkEAl9gAXWo=
@@ -43,6 +49,8 @@ github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPn
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
+github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/exchange-service/internal/cache/redis.go
+++ b/exchange-service/internal/cache/redis.go
@@ -1,0 +1,66 @@
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const defaultRedisTimeout = 500 * time.Millisecond
+
+// RedisClient is a thin wrapper around go-redis with short timeouts so Redis
+// outages degrade cache users instead of blocking request paths for seconds.
+type RedisClient struct {
+	client *redis.Client
+}
+
+func NewRedisClient(addr, password string, db int) *RedisClient {
+	if addr == "" {
+		return nil
+	}
+	return &RedisClient{
+		client: redis.NewClient(&redis.Options{
+			Addr:         addr,
+			Password:     password,
+			DB:           db,
+			DialTimeout:  defaultRedisTimeout,
+			ReadTimeout:  defaultRedisTimeout,
+			WriteTimeout: defaultRedisTimeout,
+		}),
+	}
+}
+
+func (c *RedisClient) Ping(ctx context.Context) error {
+	if c == nil || c.client == nil {
+		return nil
+	}
+	return c.client.Ping(ctx).Err()
+}
+
+func (c *RedisClient) Close() error {
+	if c == nil || c.client == nil {
+		return nil
+	}
+	return c.client.Close()
+}
+
+func (c *RedisClient) HGet(ctx context.Context, key, field string) (string, error) {
+	return c.client.HGet(ctx, key, field).Result()
+}
+
+func (c *RedisClient) HGetAll(ctx context.Context, key string) (map[string]string, error) {
+	return c.client.HGetAll(ctx, key).Result()
+}
+
+func (c *RedisClient) HSet(ctx context.Context, key, field, value string) error {
+	return c.client.HSet(ctx, key, field, value).Err()
+}
+
+func (c *RedisClient) Expire(ctx context.Context, key string, ttl time.Duration) error {
+	return c.client.Expire(ctx, key, ttl).Err()
+}
+
+func (c *RedisClient) Incr(ctx context.Context, key string) (int64, error) {
+	return c.client.Incr(ctx, key).Result()
+}

--- a/exchange-service/internal/config/config.go
+++ b/exchange-service/internal/config/config.go
@@ -22,6 +22,10 @@ type Config struct {
 
 	AlphaVantageAPIKey string
 
+	RedisAddr     string
+	RedisPassword string
+	RedisDB       int
+
 	// Inter-bank protocol (Celina 5). OwnRoutingNumber is the 3-digit prefix
 	// used in our account numbers. PartnerBanksJSON is a JSON array of
 	// {code,baseUrl,outboundKey,inboundKey,displayName} entries; parsed once
@@ -34,16 +38,19 @@ func Load() *Config {
 	_ = godotenv.Load()
 
 	cfg := &Config{
-		DBHost:     getEnv("DB_HOST", "localhost"),
-		DBPort:     getEnv("DB_PORT", "5432"),
-		DBUser:     getEnv("DB_USER", "postgres"),
-		DBPassword: getEnv("DB_PASSWORD", "postgres"),
-		DBName:     getEnv("DB_NAME", "bankdb"),
-		DBSSLMode:  getEnv("DB_SSL_MODE", "disable"),
-		GRPCPort:   getEnv("GRPC_PORT", "9098"),
-		HTTPPort:   getEnv("HTTP_PORT", "8088"),
+		DBHost:             getEnv("DB_HOST", "localhost"),
+		DBPort:             getEnv("DB_PORT", "5432"),
+		DBUser:             getEnv("DB_USER", "postgres"),
+		DBPassword:         getEnv("DB_PASSWORD", "postgres"),
+		DBName:             getEnv("DB_NAME", "bankdb"),
+		DBSSLMode:          getEnv("DB_SSL_MODE", "disable"),
+		GRPCPort:           getEnv("GRPC_PORT", "9098"),
+		HTTPPort:           getEnv("HTTP_PORT", "8088"),
 		JWTSecret:          getEnv("JWT_SECRET", "super-secret-jwt-key-change-in-production"),
 		AlphaVantageAPIKey: getEnv("ALPHA_VANTAGE_API_KEY", "demo"),
+		RedisAddr:          getEnv("REDIS_ADDR", ""),
+		RedisPassword:      getEnv("REDIS_PASSWORD", ""),
+		RedisDB:            getEnvInt("REDIS_DB", 0),
 		OwnRoutingNumber:   getEnvInt("BANK_ROUTING_NUMBER", 333),
 		PartnerBanksJSON:   getEnv("PARTNER_BANKS_JSON", "[]"),
 	}

--- a/exchange-service/internal/provider/alphavantage_client.go
+++ b/exchange-service/internal/provider/alphavantage_client.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -21,6 +22,7 @@ type AlphaVantageClient struct {
 	mu          sync.Mutex
 	lastRequest time.Time
 	minInterval time.Duration // rate limit interval between requests
+	limiter     RateLimiter
 }
 
 func NewAlphaVantageClient(apiKey string) *AlphaVantageClient {
@@ -34,7 +36,24 @@ func NewAlphaVantageClient(apiKey string) *AlphaVantageClient {
 	}
 }
 
+func (c *AlphaVantageClient) WithRateLimiter(limiter RateLimiter) *AlphaVantageClient {
+	c.limiter = limiter
+	return c
+}
+
 func (c *AlphaVantageClient) rateLimit() {
+	if c.limiter != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		if err := c.limiter.Wait(ctx); err == nil {
+			return
+		}
+		slog.Warn("AlphaVantage Redis rate limiter unavailable, using local limiter")
+	}
+	c.localRateLimit()
+}
+
+func (c *AlphaVantageClient) localRateLimit() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/exchange-service/internal/provider/cached_provider.go
+++ b/exchange-service/internal/provider/cached_provider.go
@@ -1,11 +1,24 @@
 package provider
 
 import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
 )
+
+const defaultFXRedisKey = "fx:rates"
+
+type rateCacheStore interface {
+	HGet(ctx context.Context, key, field string) (string, error)
+	HGetAll(ctx context.Context, key string) (map[string]string, error)
+	HSet(ctx context.Context, key, field, value string) error
+	Expire(ctx context.Context, key string, ttl time.Duration) error
+}
 
 // CachedProvider wraps a primary and fallback RateProviderInterface.
 // It refreshes the rate cache lazily: on each call it checks whether the TTL
@@ -19,6 +32,9 @@ type CachedProvider struct {
 	allRates    []service.ExchangeRate
 	lastUpdated time.Time
 	ttl         time.Duration
+
+	redisCache rateCacheStore
+	redisKey   string
 }
 
 // NewCachedProvider creates a CachedProvider with the given primary provider,
@@ -31,12 +47,26 @@ func NewCachedProvider(primary, fallback service.RateProviderInterface, ttl time
 	}
 }
 
+// WithRedis stores and reads rates through a shared Redis hash. The provider
+// keeps the existing in-memory cache as a fallback when Redis is unavailable.
+func (c *CachedProvider) WithRedis(cache rateCacheStore) *CachedProvider {
+	if cache == nil {
+		return c
+	}
+	c.redisCache = cache
+	c.redisKey = defaultFXRedisKey
+	return c
+}
+
 // GetRate returns the exchange rate for the given currency pair.
 // For identical currencies it returns 1.0 immediately. Otherwise it
 // ensures the cache is fresh and looks up the pair.
 func (c *CachedProvider) GetRate(from, to string) (float64, error) {
 	if from == to {
 		return 1.0, nil
+	}
+	if rate, ok := c.getRedisRate(from, to); ok {
+		return rate, nil
 	}
 	c.ensureFresh()
 	c.mu.RLock()
@@ -52,6 +82,9 @@ func (c *CachedProvider) GetRate(from, to string) (float64, error) {
 
 // GetAllRates returns all available exchange rates, refreshing the cache if stale.
 func (c *CachedProvider) GetAllRates() []service.ExchangeRate {
+	if rates, ok := c.getRedisRates(); ok {
+		return rates
+	}
 	c.ensureFresh()
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -94,4 +127,100 @@ func (c *CachedProvider) refresh() {
 	c.allRates = rates
 	c.lastUpdated = time.Now()
 	c.mu.Unlock()
+
+	c.storeRedisRates(rates)
+}
+
+func (c *CachedProvider) getRedisRate(from, to string) (float64, bool) {
+	if c.redisCache == nil {
+		return 0, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	raw, err := c.redisCache.HGet(ctx, c.redisKey, redisRateField(from, to))
+	if err != nil || raw == "" {
+		return 0, false
+	}
+	rate, err := strconv.ParseFloat(raw, 64)
+	if err != nil || rate <= 0 {
+		return 0, false
+	}
+	return rate, true
+}
+
+func (c *CachedProvider) getRedisRates() ([]service.ExchangeRate, bool) {
+	if c.redisCache == nil {
+		return nil, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	rawRates, err := c.redisCache.HGetAll(ctx, c.redisKey)
+	if err != nil || len(rawRates) == 0 {
+		return nil, false
+	}
+
+	fields := make([]string, 0, len(rawRates))
+	for field := range rawRates {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+
+	rates := make([]service.ExchangeRate, 0, len(fields))
+	for _, field := range fields {
+		from, to, ok := splitRedisRateField(field)
+		if !ok {
+			continue
+		}
+		rate, err := strconv.ParseFloat(rawRates[field], 64)
+		if err != nil || rate <= 0 {
+			continue
+		}
+		rates = append(rates, service.ExchangeRate{
+			From:     from,
+			To:       to,
+			Rate:     rate,
+			BuyRate:  rate * (1 - spread),
+			SellRate: rate * (1 + spread),
+		})
+	}
+
+	return rates, len(rates) > 0
+}
+
+func (c *CachedProvider) storeRedisRates(rates []service.ExchangeRate) {
+	if c.redisCache == nil || len(rates) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	for _, rate := range rates {
+		if rate.Rate <= 0 {
+			continue
+		}
+		if err := c.redisCache.HSet(ctx, c.redisKey, redisRateField(rate.From, rate.To), strconv.FormatFloat(rate.Rate, 'f', -1, 64)); err != nil {
+			return
+		}
+	}
+	if c.ttl > 0 {
+		_ = c.redisCache.Expire(ctx, c.redisKey, c.ttl)
+	}
+}
+
+func redisRateField(from, to string) string {
+	return fmt.Sprintf("%s:%s", from, to)
+}
+
+func splitRedisRateField(field string) (string, string, bool) {
+	for i := 0; i < len(field); i++ {
+		if field[i] == ':' {
+			if i == 0 || i == len(field)-1 {
+				return "", "", false
+			}
+			return field[:i], field[i+1:], true
+		}
+	}
+	return "", "", false
 }

--- a/exchange-service/internal/provider/cached_provider_test.go
+++ b/exchange-service/internal/provider/cached_provider_test.go
@@ -1,6 +1,7 @@
 package provider_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -108,6 +109,59 @@ func TestCachedProvider_DoesNotRefreshBeforeExpiry(t *testing.T) {
 	}
 }
 
+func TestCachedProvider_GetRate_UsesRedisHit(t *testing.T) {
+	callCount := 0
+	primary := &countingProvider{rate: 117.5, count: &callCount}
+	cache := newFakeRateCache()
+	_ = cache.HSet(context.Background(), "fx:rates", "EUR:RSD", "118.25")
+
+	cp := provider.NewCachedProvider(primary, provider.NewStaticRateProvider(), 24*time.Hour).WithRedis(cache)
+
+	rate, err := cp.GetRate("EUR", "RSD")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rate != 118.25 {
+		t.Fatalf("expected Redis rate 118.25, got %f", rate)
+	}
+	if callCount != 0 {
+		t.Fatalf("expected primary provider not to be called on Redis hit, got %d", callCount)
+	}
+}
+
+func TestCachedProvider_RedisMissFallsBackAndPopulatesRedis(t *testing.T) {
+	cache := newFakeRateCache()
+	cp := provider.NewCachedProvider(&alwaysOKProvider{rate: 119.5}, provider.NewStaticRateProvider(), time.Hour).WithRedis(cache)
+
+	rate, err := cp.GetRate("EUR", "RSD")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rate != 119.5 {
+		t.Fatalf("expected provider rate 119.5, got %f", rate)
+	}
+
+	raw, err := cache.HGet(context.Background(), "fx:rates", "EUR:RSD")
+	if err != nil {
+		t.Fatalf("expected Redis cache to be populated: %v", err)
+	}
+	if raw != "119.5" {
+		t.Fatalf("expected cached raw rate 119.5, got %q", raw)
+	}
+}
+
+func TestCachedProvider_RedisDownFallsBackToMemory(t *testing.T) {
+	cp := provider.NewCachedProvider(&alwaysOKProvider{rate: 120.5}, provider.NewStaticRateProvider(), time.Hour).WithRedis(failingRateCache{})
+
+	rate, err := cp.GetRate("EUR", "RSD")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rate != 120.5 {
+		t.Fatalf("expected provider fallback rate 120.5, got %f", rate)
+	}
+}
+
 type countingProvider struct {
 	rate  float64
 	count *int
@@ -123,4 +177,59 @@ func (m *countingProvider) GetRate(from, to string) (float64, error) {
 func (m *countingProvider) GetAllRates() []service.ExchangeRate {
 	(*m.count)++
 	return []service.ExchangeRate{{From: "EUR", To: "RSD", Rate: m.rate}}
+}
+
+type fakeRateCache struct {
+	values map[string]map[string]string
+}
+
+func newFakeRateCache() *fakeRateCache {
+	return &fakeRateCache{values: make(map[string]map[string]string)}
+}
+
+func (f *fakeRateCache) HGet(_ context.Context, key, field string) (string, error) {
+	if fields, ok := f.values[key]; ok {
+		if value, ok := fields[field]; ok {
+			return value, nil
+		}
+	}
+	return "", errors.New("cache miss")
+}
+
+func (f *fakeRateCache) HGetAll(_ context.Context, key string) (map[string]string, error) {
+	result := make(map[string]string)
+	for field, value := range f.values[key] {
+		result[field] = value
+	}
+	return result, nil
+}
+
+func (f *fakeRateCache) HSet(_ context.Context, key, field, value string) error {
+	if f.values[key] == nil {
+		f.values[key] = make(map[string]string)
+	}
+	f.values[key][field] = value
+	return nil
+}
+
+func (f *fakeRateCache) Expire(_ context.Context, _ string, _ time.Duration) error {
+	return nil
+}
+
+type failingRateCache struct{}
+
+func (failingRateCache) HGet(context.Context, string, string) (string, error) {
+	return "", errors.New("redis unavailable")
+}
+
+func (failingRateCache) HGetAll(context.Context, string) (map[string]string, error) {
+	return nil, errors.New("redis unavailable")
+}
+
+func (failingRateCache) HSet(context.Context, string, string, string) error {
+	return errors.New("redis unavailable")
+}
+
+func (failingRateCache) Expire(context.Context, string, time.Duration) error {
+	return errors.New("redis unavailable")
 }

--- a/exchange-service/internal/provider/redis_rate_limiter.go
+++ b/exchange-service/internal/provider/redis_rate_limiter.go
@@ -1,0 +1,74 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type rateCounterStore interface {
+	Incr(ctx context.Context, key string) (int64, error)
+	Expire(ctx context.Context, key string, ttl time.Duration) error
+}
+
+type RateLimiter interface {
+	Wait(ctx context.Context) error
+}
+
+type RedisFixedWindowRateLimiter struct {
+	store     rateCounterStore
+	keyPrefix string
+	limit     int64
+	window    time.Duration
+}
+
+func NewRedisFixedWindowRateLimiter(store rateCounterStore, keyPrefix string, limit int64, window time.Duration) *RedisFixedWindowRateLimiter {
+	if keyPrefix == "" {
+		keyPrefix = "rl:av"
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+	if window <= 0 {
+		window = time.Minute
+	}
+	return &RedisFixedWindowRateLimiter{
+		store:     store,
+		keyPrefix: keyPrefix,
+		limit:     limit,
+		window:    window,
+	}
+}
+
+func (l *RedisFixedWindowRateLimiter) Wait(ctx context.Context) error {
+	if l == nil || l.store == nil {
+		return nil
+	}
+
+	for {
+		now := time.Now().UTC()
+		windowStart := now.Truncate(l.window)
+		key := fmt.Sprintf("%s:%d", l.keyPrefix, windowStart.Unix())
+
+		count, err := l.store.Incr(ctx, key)
+		if err != nil {
+			return err
+		}
+		if count == 1 {
+			_ = l.store.Expire(ctx, key, l.window+time.Second)
+		}
+		if count <= l.limit {
+			return nil
+		}
+
+		wait := windowStart.Add(l.window).Sub(now)
+		if wait <= 0 {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+}

--- a/exchange-service/internal/provider/redis_rate_limiter_test.go
+++ b/exchange-service/internal/provider/redis_rate_limiter_test.go
@@ -1,0 +1,79 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRedisFixedWindowRateLimiter_AllowsWithinLimit(t *testing.T) {
+	store := newFakeCounterStore()
+	limiter := NewRedisFixedWindowRateLimiter(store, "test:rl", 2, time.Minute)
+
+	if err := limiter.Wait(context.Background()); err != nil {
+		t.Fatalf("first wait failed: %v", err)
+	}
+	if err := limiter.Wait(context.Background()); err != nil {
+		t.Fatalf("second wait failed: %v", err)
+	}
+	if store.expireCalls == 0 {
+		t.Fatal("expected limiter to set key expiration")
+	}
+}
+
+func TestRedisFixedWindowRateLimiter_PropagatesRedisError(t *testing.T) {
+	limiter := NewRedisFixedWindowRateLimiter(failingCounterStore{}, "test:rl", 2, time.Minute)
+
+	if err := limiter.Wait(context.Background()); err == nil {
+		t.Fatal("expected Redis error")
+	}
+}
+
+func TestAlphaVantageRateLimit_FallsBackWhenRedisLimiterFails(t *testing.T) {
+	c := NewAlphaVantageClient("k").WithRateLimiter(failingLimiter{})
+	c.minInterval = 10 * time.Millisecond
+
+	start := time.Now()
+	c.rateLimit()
+	c.rateLimit()
+
+	if elapsed := time.Since(start); elapsed < 8*time.Millisecond {
+		t.Fatalf("expected local fallback limiter delay, got %v", elapsed)
+	}
+}
+
+type fakeCounterStore struct {
+	values      map[string]int64
+	expireCalls int
+}
+
+func newFakeCounterStore() *fakeCounterStore {
+	return &fakeCounterStore{values: make(map[string]int64)}
+}
+
+func (f *fakeCounterStore) Incr(_ context.Context, key string) (int64, error) {
+	f.values[key]++
+	return f.values[key], nil
+}
+
+func (f *fakeCounterStore) Expire(_ context.Context, _ string, _ time.Duration) error {
+	f.expireCalls++
+	return nil
+}
+
+type failingCounterStore struct{}
+
+func (failingCounterStore) Incr(context.Context, string) (int64, error) {
+	return 0, errors.New("redis unavailable")
+}
+
+func (failingCounterStore) Expire(context.Context, string, time.Duration) error {
+	return errors.New("redis unavailable")
+}
+
+type failingLimiter struct{}
+
+func (failingLimiter) Wait(context.Context) error {
+	return errors.New("redis unavailable")
+}


### PR DESCRIPTION
## Summary
- Adds Redis client wiring to exchange-service.
- Stores FX rates in shared Redis cache when Redis is available.
- Keeps local in-memory fallback when Redis is unavailable.
- Adds Redis fixed-window rate limiter foundation for AlphaVantage.
- Adds tests for Redis cache hit/miss/fallback and limiter fallback.

## Testing
- go test ./... in exchange-service
- git diff --cached --check