### PR TITLE
Add Kubernetes readiness endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,14 @@ The shared backend in [cmd/server/main.go](/C:/Dev/Projects/SI/EXBanka-3-Backend
 is no longer the business runtime. It now serves only:
 
 - `GET /health`
+- `GET /ready`
 - `GET /swagger.json`
 - `GET /swagger-ui`
+
+Each active Go microservice exposes:
+
+- `GET /health` as a lightweight liveness endpoint.
+- `GET /ready` as a readiness endpoint that checks PostgreSQL connectivity.
 
 All business API calls are exposed through the root nginx gateway in
 [C:\Dev\Projects\SI\EXBanka-3-Frontend\nginx.conf](/C:/Dev/Projects/SI/EXBanka-3-Frontend/nginx.conf).

--- a/account-service/cmd/server/main.go
+++ b/account-service/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"net"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	accountv1 "github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/gen/proto/account/v1"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/internal/config"
@@ -31,6 +33,11 @@ func main() {
 	db, err := database.Connect(cfg)
 	if err != nil {
 		slog.Error("DB connection failed", "error", err)
+		os.Exit(1)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		slog.Error("DB handle unavailable", "error", err)
 		os.Exit(1)
 	}
 	if err := database.Migrate(db); err != nil {
@@ -112,6 +119,7 @@ func main() {
 
 	httpMux := http.NewServeMux()
 	httpMux.HandleFunc("/health", healthCheck)
+	httpMux.HandleFunc("/ready", readinessCheck(sqlDB))
 	httpMux.Handle("/api/v1/firme", middleware.CORS(http.HandlerFunc(firmaH.Create)))
 	httpMux.Handle("/api/v1/sifre-delatnosti", middleware.CORS(http.HandlerFunc(firmaH.ListSifreDelatnosti)))
 	httpMux.Handle("/api/v1/accounts/create", middleware.CORS(createAccH))
@@ -151,4 +159,21 @@ func healthCheck(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, `{"status":"ok","service":"account-service"}`)
+}
+
+func readinessCheck(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), time.Second)
+		defer cancel()
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := db.PingContext(ctx); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, `{"status":"not_ready","service":"account-service","dependency":"database"}`)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ready","service":"account-service"}`)
+	}
 }

--- a/auth-service/cmd/server/main.go
+++ b/auth-service/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"net"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	authv1 "github.com/RAF-SI-2025/EXBanka-3-Backend/auth-service/gen/proto/auth/v1"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/auth-service/internal/config"
@@ -32,6 +34,11 @@ func main() {
 	db, err := database.Connect(cfg)
 	if err != nil {
 		slog.Error("DB connection failed", "error", err)
+		os.Exit(1)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		slog.Error("DB handle unavailable", "error", err)
 		os.Exit(1)
 	}
 	if err := database.Migrate(db); err != nil {
@@ -90,6 +97,7 @@ func main() {
 
 	httpMux := http.NewServeMux()
 	httpMux.HandleFunc("/health", healthCheck)
+	httpMux.HandleFunc("/ready", readinessCheck(sqlDB))
 	httpMux.Handle("/api/v1/auth/client/login", middleware.CORS(http.HandlerFunc(clientAuthH.Login)))
 	httpMux.Handle("/api/v1/auth/client/activate", middleware.CORS(http.HandlerFunc(clientAuthH.Activate)))
 	httpMux.Handle("/", middleware.CORS(gwMux))
@@ -123,6 +131,23 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, `{"status":"ok","service":"auth-service"}`)
+}
+
+func readinessCheck(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), time.Second)
+		defer cancel()
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := db.PingContext(ctx); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, `{"status":"not_ready","service":"auth-service","dependency":"database"}`)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ready","service":"auth-service"}`)
+	}
 }
 
 func envOrDefault(key, defaultVal string) string {

--- a/client-service/cmd/server/main.go
+++ b/client-service/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"net"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	clientv1 "github.com/RAF-SI-2025/EXBanka-3-Backend/client-service/gen/proto/client/v1"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/client-service/internal/config"
@@ -31,6 +33,11 @@ func main() {
 	db, err := database.Connect(cfg)
 	if err != nil {
 		slog.Error("DB connection failed", "error", err)
+		os.Exit(1)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		slog.Error("DB handle unavailable", "error", err)
 		os.Exit(1)
 	}
 	if err := database.Migrate(db); err != nil {
@@ -88,6 +95,7 @@ func main() {
 
 	httpMux := http.NewServeMux()
 	httpMux.HandleFunc("/health", healthCheck)
+	httpMux.HandleFunc("/ready", readinessCheck(sqlDB))
 	httpMux.Handle("/", middleware.CORS(gwMux))
 
 	httpServer := &http.Server{
@@ -119,6 +127,23 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, `{"status":"ok","service":"client-service"}`)
+}
+
+func readinessCheck(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), time.Second)
+		defer cancel()
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := db.PingContext(ctx); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, `{"status":"not_ready","service":"client-service","dependency":"database"}`)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ready","service":"client-service"}`)
+	}
 }
 
 func envOrDefault(key, defaultVal string) string {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,6 +18,7 @@ func main() {
 	httpMux.HandleFunc("/swagger.json", swagger.HandlerJSON)
 	httpMux.HandleFunc("/swagger-ui", swagger.HandlerUI)
 	httpMux.HandleFunc("/health", healthCheck)
+	httpMux.HandleFunc("/ready", readinessCheck)
 
 	httpServer := &http.Server{
 		Addr:    ":" + httpPort,
@@ -47,6 +48,12 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, `{"status":"ok","service":"EXBanka"}`)
+}
+
+func readinessCheck(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, `{"status":"ready","service":"EXBanka"}`)
 }
 
 func envOrDefault(key, defaultVal string) string {

--- a/employee-service/cmd/server/main.go
+++ b/employee-service/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"net"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	employeev1 "github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/gen/proto/employee/v1"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/employee-service/internal/config"
@@ -32,6 +34,11 @@ func main() {
 	db, err := database.Connect(cfg)
 	if err != nil {
 		slog.Error("DB connection failed", "error", err)
+		os.Exit(1)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		slog.Error("DB handle unavailable", "error", err)
 		os.Exit(1)
 	}
 	if err := database.Migrate(db); err != nil {
@@ -87,6 +94,7 @@ func main() {
 
 	httpMux := http.NewServeMux()
 	httpMux.HandleFunc("/health", healthCheck)
+	httpMux.HandleFunc("/ready", readinessCheck(sqlDB))
 	httpMux.Handle("/api/v1/actuaries", middleware.CORS(http.HandlerFunc(actuaryHTTPHandler.ListActuaries)))
 	httpMux.Handle("/api/v1/actuaries/", middleware.CORS(http.HandlerFunc(actuaryHTTPHandler.ActuaryRoutes)))
 	httpMux.Handle("/", middleware.CORS(gwMux))
@@ -120,6 +128,23 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, `{"status":"ok","service":"employee-service"}`)
+}
+
+func readinessCheck(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), time.Second)
+		defer cancel()
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := db.PingContext(ctx); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, `{"status":"not_ready","service":"employee-service","dependency":"database"}`)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ready","service":"employee-service"}`)
+	}
 }
 
 func envOrDefault(key, defaultVal string) string {

--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"net"
@@ -35,6 +36,11 @@ func main() {
 	db, err := database.Connect(cfg)
 	if err != nil {
 		slog.Error("DB connection failed", "error", err)
+		os.Exit(1)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		slog.Error("DB handle unavailable", "error", err)
 		os.Exit(1)
 	}
 	if err := database.Migrate(db); err != nil {
@@ -188,6 +194,7 @@ func main() {
 
 	httpMux := http.NewServeMux()
 	httpMux.HandleFunc("/health", healthCheck)
+	httpMux.HandleFunc("/ready", readinessCheck(sqlDB))
 	httpMux.Handle("/api/v1/exchanges", middleware.CORS(http.HandlerFunc(marketH.ListExchanges)))
 	httpMux.Handle("/api/v1/exchanges/", middleware.CORS(http.HandlerFunc(marketH.ExchangeRoutes)))
 	httpMux.Handle("/api/v1/listings", middleware.CORS(http.HandlerFunc(marketH.ListListings)))
@@ -240,4 +247,21 @@ func healthCheck(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, `{"status":"ok","service":"exchange-service"}`)
+}
+
+func readinessCheck(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), time.Second)
+		defer cancel()
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := db.PingContext(ctx); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, `{"status":"not_ready","service":"exchange-service","dependency":"database"}`)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ready","service":"exchange-service"}`)
+	}
 }

--- a/loan-service/cmd/server/main.go
+++ b/loan-service/cmd/server/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -28,6 +30,11 @@ func main() {
 		slog.Error("DB connection failed", "error", err)
 		os.Exit(1)
 	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		slog.Error("DB handle unavailable", "error", err)
+		os.Exit(1)
+	}
 	if err := database.Migrate(db); err != nil {
 		slog.Error("DB migration failed", "error", err)
 		os.Exit(1)
@@ -50,6 +57,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", healthCheck)
+	mux.HandleFunc("/ready", readinessCheck(sqlDB))
 	mux.Handle("/api/v1/loans/", middleware.CORS(loanH))
 
 	httpServer := &http.Server{
@@ -104,4 +112,21 @@ func healthCheck(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, `{"status":"ok","service":"loan-service"}`)
+}
+
+func readinessCheck(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), time.Second)
+		defer cancel()
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := db.PingContext(ctx); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, `{"status":"not_ready","service":"loan-service","dependency":"database"}`)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ready","service":"loan-service"}`)
+	}
 }

--- a/payment-service/cmd/server/main.go
+++ b/payment-service/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"net"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	paymentv1 "github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/gen/proto/payment/v1"
 	prv1 "github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/gen/proto/payment_recipient/v1"
@@ -30,6 +32,11 @@ func main() {
 	db, err := database.Connect(cfg)
 	if err != nil {
 		slog.Error("DB connection failed", "error", err)
+		os.Exit(1)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		slog.Error("DB handle unavailable", "error", err)
 		os.Exit(1)
 	}
 	if err := database.Migrate(db); err != nil {
@@ -88,6 +95,7 @@ func main() {
 
 	httpMux := http.NewServeMux()
 	httpMux.HandleFunc("/health", healthCheck)
+	httpMux.HandleFunc("/ready", readinessCheck(sqlDB))
 	combinedPaymentHandler := handler.NewCombinedPaymentHandler(createPaymentHTTPH, mobileVerificationH, gwMux)
 	httpMux.Handle("/api/v1/payments", middleware.CORS(combinedPaymentHandler))
 	httpMux.Handle("/api/v1/payments/", middleware.CORS(combinedPaymentHandler))
@@ -124,4 +132,21 @@ func healthCheck(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, `{"status":"ok","service":"payment-service"}`)
+}
+
+func readinessCheck(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), time.Second)
+		defer cancel()
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := db.PingContext(ctx); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, `{"status":"not_ready","service":"payment-service","dependency":"database"}`)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ready","service":"payment-service"}`)
+	}
 }

--- a/transfer-service/cmd/server/main.go
+++ b/transfer-service/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"net"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	transferv1 "github.com/RAF-SI-2025/EXBanka-3-Backend/transfer-service/gen/proto/transfer/v1"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/transfer-service/internal/config"
@@ -29,6 +31,11 @@ func main() {
 	db, err := database.Connect(cfg)
 	if err != nil {
 		slog.Error("DB connection failed", "error", err)
+		os.Exit(1)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		slog.Error("DB handle unavailable", "error", err)
 		os.Exit(1)
 	}
 	if err := database.Migrate(db); err != nil {
@@ -77,6 +84,7 @@ func main() {
 
 	httpMux := http.NewServeMux()
 	httpMux.HandleFunc("/health", healthCheck)
+	httpMux.HandleFunc("/ready", readinessCheck(sqlDB))
 	// Route all transfers through a combined handler: verify requests go to custom handler, rest to gwMux
 	combinedTransferHandler := handler.NewCombinedTransferHandler(transferHTTPH, mobileVerificationH, gwMux)
 	httpMux.Handle("/api/v1/transfers", middleware.CORS(combinedTransferHandler))
@@ -119,4 +127,21 @@ func healthCheck(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, `{"status":"ok","service":"transfer-service"}`)
+}
+
+func readinessCheck(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), time.Second)
+		defer cancel()
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := db.PingContext(ctx); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprint(w, `{"status":"not_ready","service":"transfer-service","dependency":"database"}`)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ready","service":"transfer-service"}`)
+	}
 }


### PR DESCRIPTION
## Summary
- Adds `/ready` endpoint to all backend Go services.
- Keeps `/health` as lightweight liveness.
- Makes readiness check PostgreSQL connectivity with a short timeout.
- Documents `/health` vs `/ready` behavior.

## Details
- `/ready` returns 200 only when the service can reach PostgreSQL.
- `/health` does not depend on PostgreSQL or Redis, so liveness stays stable during dependency blips.
- Legacy backend exposes `/ready` without DB check because it only serves docs/swagger/health.

## Testing
- go test ./... in all backend services
- go test ./... in root backend module
- git diff --check