### PR TITLE
Use shared Redis-backed FX rate provider

### DIFF
--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -139,7 +139,8 @@ func main() {
 	}()
 	defer cronScheduler.Stop()
 
-	exchangeH := handler.NewExchangeHandler()
+	exchangeSvc := service.NewExchangeServiceWithProvider(rateProvider)
+	exchangeH := handler.NewExchangeHandlerWithService(exchangeSvc)
 	marketProvider := provider.NewDatabaseMarketProvider(marketRepo)
 	marketSvc := service.NewMarketService(marketProvider)
 	marketH := handler.NewMarketHTTPHandler(cfg, marketSvc, marketRepo)


### PR DESCRIPTION
## Summary
- Wires the exchange rates API to the existing shared FX rate provider.
- Ensures `/api/v1/exchange/rates` uses the Redis-backed cache path when Redis is configured.
- Keeps the existing API contract unchanged.

## Testing
- Ran `go test ./...` in `exchange-service`.
- Verified runtime smoke with Redis:
  - cleared `fx:rates`
  - called `/api/v1/exchange/rates`
  - confirmed Redis was populated with cached FX pairs