### PR TITLE
chore(k8s): env-driven backend config + publish images to org registry

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         service:
+          - backend
           - auth-service
           - employee-service
           - client-service
@@ -37,11 +38,22 @@ jobs:
 
       - name: Build and push
         run: |
-          TAG="ghcr.io/iplucki/exbanka-3-${{ matrix.service }}:latest"
+          # Publish under the org/owner the workflow runs in (raf-si-2025 on the
+          # shared upstream repo). GHCR namespaces must be lowercase.
+          OWNER="${{ github.repository_owner }}"
+          OWNER="${OWNER,,}"
+          TAG="ghcr.io/${OWNER}/exbanka-3-${{ matrix.service }}:latest"
           # Build context mirrors ci.yml: transfer/payment/exchange/loan build
           # from their own dir; auth/employee/client/account copy paths rooted at
           # EXBanka-3-Backend/ and need the repo's parent as context.
           case "${{ matrix.service }}" in
+            backend)
+              # Shared runtime (Swagger UI + health). Its Dockerfile lives at the
+              # repo root, not under a service subdir, but uses the same
+              # root-relative COPY, so it needs the repo's parent as context.
+              cd ..
+              docker build -f "EXBanka-3-Backend/Dockerfile" -t "$TAG" .
+              ;;
             transfer-service|payment-service|exchange-service|loan-service)
               docker build -f "${{ matrix.service }}/Dockerfile" -t "$TAG" "${{ matrix.service }}"
               ;;

--- a/account-service/internal/config/config.go
+++ b/account-service/internal/config/config.go
@@ -31,6 +31,11 @@ type Config struct {
 func Load() *Config {
 	_ = godotenv.Load()
 
+	if os.Getenv("JWT_SECRET") == "" {
+		slog.Error("JWT_SECRET is required and must not be empty", "service", "account-service")
+		os.Exit(1)
+	}
+
 	jwtAccessDur, _ := strconv.Atoi(getEnv("JWT_ACCESS_DURATION_MINUTES", "15"))
 	jwtRefreshDur, _ := strconv.Atoi(getEnv("JWT_REFRESH_DURATION_HOURS", "24"))
 	smtpPort, _ := strconv.Atoi(getEnv("SMTP_PORT", "1025"))
@@ -44,7 +49,7 @@ func Load() *Config {
 		DBSSLMode:          getEnv("DB_SSL_MODE", "disable"),
 		GRPCPort:           getEnv("GRPC_PORT", "9094"),
 		HTTPPort:           getEnv("HTTP_PORT", "8084"),
-		JWTSecret:          getEnv("JWT_SECRET", "super-secret-jwt-key-change-in-production"),
+		JWTSecret:          os.Getenv("JWT_SECRET"),
 		JWTAccessDuration:  jwtAccessDur,
 		JWTRefreshDuration: jwtRefreshDur,
 		SMTPHost:           getEnv("SMTP_HOST", "mailhog"),

--- a/auth-service/internal/config/config.go
+++ b/auth-service/internal/config/config.go
@@ -35,6 +35,11 @@ type Config struct {
 func Load() *Config {
 	_ = godotenv.Load()
 
+	if os.Getenv("JWT_SECRET") == "" {
+		slog.Error("JWT_SECRET is required and must not be empty", "service", "auth-service")
+		os.Exit(1)
+	}
+
 	smtpPort, _ := strconv.Atoi(getEnv("SMTP_PORT", "1025"))
 	jwtAccessDur, _ := strconv.Atoi(getEnv("JWT_ACCESS_DURATION_MINUTES", "15"))
 	jwtRefreshDur, _ := strconv.Atoi(getEnv("JWT_REFRESH_DURATION_HOURS", "24"))
@@ -49,7 +54,7 @@ func Load() *Config {
 		GRPCPort:   getEnv("GRPC_PORT", "9090"),
 		HTTPPort:   getEnv("HTTP_PORT", "8080"),
 
-		JWTSecret:          getEnv("JWT_SECRET", "super-secret-jwt-key-change-in-production"),
+		JWTSecret:          os.Getenv("JWT_SECRET"),
 		JWTAccessDuration:  jwtAccessDur,
 		JWTRefreshDuration: jwtRefreshDur,
 

--- a/auth-service/internal/config/config_test.go
+++ b/auth-service/internal/config/config_test.go
@@ -30,13 +30,15 @@ func TestLoad_ReturnsDefaults(t *testing.T) {
 	// Unset everything our code reads
 	for _, k := range []string{
 		"DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME", "DB_SSL_MODE",
-		"GRPC_PORT", "HTTP_PORT", "JWT_SECRET",
+		"GRPC_PORT", "HTTP_PORT",
 		"JWT_ACCESS_DURATION_MINUTES", "JWT_REFRESH_DURATION_HOURS",
 		"SMTP_HOST", "SMTP_PORT", "SMTP_USER", "SMTP_PASSWORD", "SMTP_FROM",
 		"FRONTEND_URL",
 	} {
 		os.Unsetenv(k)
 	}
+	// JWT_SECRET has no default by design (required at startup); supply a test value.
+	t.Setenv("JWT_SECRET", "test-secret")
 
 	cfg := Load()
 	if cfg == nil {
@@ -60,6 +62,7 @@ func TestLoad_ReturnsDefaults(t *testing.T) {
 }
 
 func TestLoad_ReadsEnvOverrides(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
 	t.Setenv("DB_HOST", "db.example.com")
 	t.Setenv("HTTP_PORT", "9999")
 	t.Setenv("JWT_ACCESS_DURATION_MINUTES", "30")

--- a/client-service/internal/config/config.go
+++ b/client-service/internal/config/config.go
@@ -35,6 +35,11 @@ type Config struct {
 func Load() *Config {
 	_ = godotenv.Load()
 
+	if os.Getenv("JWT_SECRET") == "" {
+		slog.Error("JWT_SECRET is required and must not be empty", "service", "client-service")
+		os.Exit(1)
+	}
+
 	smtpPort, _ := strconv.Atoi(getEnv("SMTP_PORT", "1025"))
 	jwtAccessDur, _ := strconv.Atoi(getEnv("JWT_ACCESS_DURATION_MINUTES", "15"))
 	jwtRefreshDur, _ := strconv.Atoi(getEnv("JWT_REFRESH_DURATION_HOURS", "24"))
@@ -49,7 +54,7 @@ func Load() *Config {
 		GRPCPort:   getEnv("GRPC_PORT", "9090"),
 		HTTPPort:   getEnv("HTTP_PORT", "8080"),
 
-		JWTSecret:          getEnv("JWT_SECRET", "super-secret-jwt-key-change-in-production"),
+		JWTSecret:          os.Getenv("JWT_SECRET"),
 		JWTAccessDuration:  jwtAccessDur,
 		JWTRefreshDuration: jwtRefreshDur,
 

--- a/employee-service/internal/config/config.go
+++ b/employee-service/internal/config/config.go
@@ -35,6 +35,11 @@ type Config struct {
 func Load() *Config {
 	_ = godotenv.Load()
 
+	if os.Getenv("JWT_SECRET") == "" {
+		slog.Error("JWT_SECRET is required and must not be empty", "service", "employee-service")
+		os.Exit(1)
+	}
+
 	smtpPort, _ := strconv.Atoi(getEnv("SMTP_PORT", "1025"))
 	jwtAccessDur, _ := strconv.Atoi(getEnv("JWT_ACCESS_DURATION_MINUTES", "15"))
 	jwtRefreshDur, _ := strconv.Atoi(getEnv("JWT_REFRESH_DURATION_HOURS", "24"))
@@ -49,7 +54,7 @@ func Load() *Config {
 		GRPCPort:   getEnv("GRPC_PORT", "9090"),
 		HTTPPort:   getEnv("HTTP_PORT", "8080"),
 
-		JWTSecret:          getEnv("JWT_SECRET", "super-secret-jwt-key-change-in-production"),
+		JWTSecret:          os.Getenv("JWT_SECRET"),
 		JWTAccessDuration:  jwtAccessDur,
 		JWTRefreshDuration: jwtRefreshDur,
 

--- a/exchange-service/internal/config/config.go
+++ b/exchange-service/internal/config/config.go
@@ -37,6 +37,11 @@ type Config struct {
 func Load() *Config {
 	_ = godotenv.Load()
 
+	if os.Getenv("JWT_SECRET") == "" {
+		slog.Error("JWT_SECRET is required and must not be empty", "service", "exchange-service")
+		os.Exit(1)
+	}
+
 	cfg := &Config{
 		DBHost:             getEnv("DB_HOST", "localhost"),
 		DBPort:             getEnv("DB_PORT", "5432"),
@@ -46,7 +51,7 @@ func Load() *Config {
 		DBSSLMode:          getEnv("DB_SSL_MODE", "disable"),
 		GRPCPort:           getEnv("GRPC_PORT", "9098"),
 		HTTPPort:           getEnv("HTTP_PORT", "8088"),
-		JWTSecret:          getEnv("JWT_SECRET", "super-secret-jwt-key-change-in-production"),
+		JWTSecret:          os.Getenv("JWT_SECRET"),
 		AlphaVantageAPIKey: getEnv("ALPHA_VANTAGE_API_KEY", "demo"),
 		RedisAddr:          getEnv("REDIS_ADDR", ""),
 		RedisPassword:      getEnv("REDIS_PASSWORD", ""),

--- a/exchange-service/internal/provider/alphavantage_client.go
+++ b/exchange-service/internal/provider/alphavantage_client.go
@@ -7,11 +7,14 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 )
+
+const defaultAlphaVantageBaseURL = "https://www.alphavantage.co/query"
 
 // AlphaVantageClient is an HTTP client for the Alpha Vantage API with rate limiting and retry logic.
 type AlphaVantageClient struct {
@@ -26,9 +29,13 @@ type AlphaVantageClient struct {
 }
 
 func NewAlphaVantageClient(apiKey string) *AlphaVantageClient {
+	baseURL := defaultAlphaVantageBaseURL
+	if v := os.Getenv("ALPHA_VANTAGE_BASE_URL"); v != "" {
+		baseURL = v
+	}
 	return &AlphaVantageClient{
 		apiKey:  apiKey,
-		baseURL: "https://www.alphavantage.co/query",
+		baseURL: baseURL,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},

--- a/loan-service/internal/config/config.go
+++ b/loan-service/internal/config/config.go
@@ -28,6 +28,11 @@ type Config struct {
 func Load() *Config {
 	_ = godotenv.Load()
 
+	if os.Getenv("JWT_SECRET") == "" {
+		slog.Error("JWT_SECRET is required and must not be empty", "service", "loan-service")
+		os.Exit(1)
+	}
+
 	smtpPort, _ := strconv.Atoi(getEnv("SMTP_PORT", "1025"))
 
 	cfg := &Config{
@@ -38,7 +43,7 @@ func Load() *Config {
 		DBName:     getEnv("DB_NAME", "bankdb"),
 		DBSSLMode:  getEnv("DB_SSL_MODE", "disable"),
 		HTTPPort:   getEnv("HTTP_PORT", "8089"),
-		JWTSecret:  getEnv("JWT_SECRET", "super-secret-jwt-key-change-in-production"),
+		JWTSecret:  os.Getenv("JWT_SECRET"),
 		SMTPHost:   getEnv("SMTP_HOST", "mailhog"),
 		SMTPPort:   smtpPort,
 		SMTPFrom:   getEnv("SMTP_FROM", "noreply@bank.com"),

--- a/payment-service/internal/config/config.go
+++ b/payment-service/internal/config/config.go
@@ -31,6 +31,11 @@ type Config struct {
 func Load() *Config {
 	_ = godotenv.Load()
 
+	if os.Getenv("JWT_SECRET") == "" {
+		slog.Error("JWT_SECRET is required and must not be empty", "service", "payment-service")
+		os.Exit(1)
+	}
+
 	jwtAccessDur, _ := strconv.Atoi(getEnv("JWT_ACCESS_DURATION_MINUTES", "15"))
 	jwtRefreshDur, _ := strconv.Atoi(getEnv("JWT_REFRESH_DURATION_HOURS", "24"))
 	smtpPort, _ := strconv.Atoi(getEnv("SMTP_PORT", "1025"))
@@ -44,7 +49,7 @@ func Load() *Config {
 		DBSSLMode:          getEnv("DB_SSL_MODE", "disable"),
 		GRPCPort:           getEnv("GRPC_PORT", "9097"),
 		HTTPPort:           getEnv("HTTP_PORT", "8087"),
-		JWTSecret:          getEnv("JWT_SECRET", "super-secret-jwt-key-change-in-production"),
+		JWTSecret:          os.Getenv("JWT_SECRET"),
 		JWTAccessDuration:  jwtAccessDur,
 		JWTRefreshDuration: jwtRefreshDur,
 		SMTPHost:           getEnv("SMTP_HOST", "mailhog"),

--- a/transfer-service/internal/config/config.go
+++ b/transfer-service/internal/config/config.go
@@ -31,6 +31,11 @@ type Config struct {
 func Load() *Config {
 	_ = godotenv.Load()
 
+	if os.Getenv("JWT_SECRET") == "" {
+		slog.Error("JWT_SECRET is required and must not be empty", "service", "transfer-service")
+		os.Exit(1)
+	}
+
 	jwtAccessDur, _ := strconv.Atoi(getEnv("JWT_ACCESS_DURATION_MINUTES", "15"))
 	jwtRefreshDur, _ := strconv.Atoi(getEnv("JWT_REFRESH_DURATION_HOURS", "24"))
 	smtpPort, _ := strconv.Atoi(getEnv("SMTP_PORT", "1025"))
@@ -44,7 +49,7 @@ func Load() *Config {
 		DBSSLMode:          getEnv("DB_SSL_MODE", "disable"),
 		GRPCPort:           getEnv("GRPC_PORT", "9096"),
 		HTTPPort:           getEnv("HTTP_PORT", "8086"),
-		JWTSecret:          getEnv("JWT_SECRET", "super-secret-jwt-key-change-in-production"),
+		JWTSecret:          os.Getenv("JWT_SECRET"),
 		JWTAccessDuration:  jwtAccessDur,
 		JWTRefreshDuration: jwtRefreshDur,
 		SMTPHost:           getEnv("SMTP_HOST", "mailhog"),


### PR DESCRIPTION
- Require JWT_SECRET at startup (fail-fast, no source-tree default) in all 8 services

- Make AlphaVantage base URL configurable via ALPHA_VANTAGE_BASE_URL

- CD: publish under the running org (raf-si-2025 on upstream) and add the shared backend runtime to the build matrix