### PR TITLE
saga: SG-01..08 test suite + fault-injection hooks + append-only log

### DIFF
--- a/exchange-service/internal/config/config.go
+++ b/exchange-service/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/joho/godotenv"
 )
@@ -37,6 +38,11 @@ type Config struct {
 	SMTPHost string
 	SMTPPort int
 	SMTPFrom string
+
+	// SagaFaultHooks enables the X-Saga-* fault-injection headers used by the
+	// SAGA test suite (files/SAGA.md). Test builds only — Load() refuses to
+	// start when this is set together with a release/production APP_ENV.
+	SagaFaultHooks bool
 }
 
 func Load() *Config {
@@ -68,6 +74,18 @@ func Load() *Config {
 		SMTPHost:           getEnv("SMTP_HOST", "mailhog"),
 		SMTPPort:           smtpPort,
 		SMTPFrom:           getEnv("SMTP_FROM", "noreply@bank.com"),
+		SagaFaultHooks:     getEnvBool("SAGA_FAULT_HOOKS"),
+	}
+
+	// The fault-injection hooks let a caller force saga phases to fail via
+	// request headers — safe in tests, dangerous in production. Refuse to boot
+	// if they are enabled in a release environment (files/SAGA.md).
+	if cfg.SagaFaultHooks {
+		if env := strings.ToLower(getEnv("APP_ENV", "")); env == "production" || env == "prod" || env == "release" {
+			slog.Error("SAGA_FAULT_HOOKS must not be enabled in release mode", "service", "exchange-service", "app_env", env)
+			os.Exit(1)
+		}
+		slog.Warn("SAGA fault-injection hooks ENABLED — test build only", "service", "exchange-service")
 	}
 
 	slog.Info("Exchange-service config loaded",
@@ -95,4 +113,12 @@ func getEnvInt(key string, defaultVal int) int {
 		slog.Warn("invalid int env var, using default", "key", key, "raw", v, "default", defaultVal)
 	}
 	return defaultVal
+}
+
+func getEnvBool(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }

--- a/exchange-service/internal/database/database.go
+++ b/exchange-service/internal/database/database.go
@@ -50,6 +50,7 @@ func Migrate(db *gorm.DB) error {
 			&models.TaxRecord{},
 			&models.SagaTransactionRecord{},
 			&models.SagaStepRecord{},
+			&models.SagaAttemptRecord{},
 			&models.InvestmentFundRecord{},
 			&models.ClientFundTransactionRecord{},
 			&models.ClientFundPositionRecord{},

--- a/exchange-service/internal/handler/otc_http_handler.go
+++ b/exchange-service/internal/handler/otc_http_handler.go
@@ -393,7 +393,11 @@ func (h *OtcHTTPHandler) exerciseContract(w http.ResponseWriter, r *http.Request
 	}
 
 	buyerID, buyerType := callerIdentity(claims)
-	result, err := h.svc.ExerciseContract(contractID, buyerID, buyerType)
+	var faults *service.SagaFaultConfig
+	if h.cfg != nil && h.cfg.SagaFaultHooks {
+		faults = parseSagaFaultConfig(r.Header)
+	}
+	result, err := h.svc.ExerciseContractWithFaults(contractID, buyerID, buyerType, faults)
 	if err != nil {
 		if errors.Is(err, service.ErrOtcContractNotFound) {
 			writeJSON(w, http.StatusNotFound, map[string]string{"message": "contract not found"})
@@ -685,6 +689,80 @@ func (e *badRequestError) Error() string {
 	return e.message
 }
 
+// parseSagaFaultConfig builds a fault-injection config from X-Saga-* request
+// headers. It is only ever called when SAGA_FAULT_HOOKS is enabled (test
+// builds); see files/SAGA.md. Returns nil when no fault headers are present.
+func parseSagaFaultConfig(hdr http.Header) *service.SagaFaultConfig {
+	fc := &service.SagaFaultConfig{}
+	set := false
+	if s := sagaStepNumber(hdr.Get("X-Saga-Force-Fail")); s > 0 {
+		fc.ForceFailStep = s
+		set = true
+	}
+	if strings.EqualFold(strings.TrimSpace(hdr.Get("X-Saga-Force-Fail-Kind")), "after") {
+		fc.ForceFailAfter = true
+	}
+	if s := sagaStepNumber(hdr.Get("X-Saga-Compensate-Fail")); s > 0 {
+		fc.CompensateFailStep = s
+		fc.CompensateFailTimes = 1 // default: fail once unless -Times overrides
+		set = true
+	}
+	if n, err := strconv.Atoi(strings.TrimSpace(hdr.Get("X-Saga-Compensate-Fail-Times"))); err == nil && n >= 0 {
+		fc.CompensateFailTimes = n
+	}
+	if delays := sagaInjectDelays(hdr.Get("X-Saga-Inject-Delay")); len(delays) > 0 {
+		fc.InjectDelays = delays
+		set = true
+	}
+	if !set {
+		return nil
+	}
+	return fc
+}
+
+// sagaStepNumber maps an "F3"/"C2" tag to its 1-based step number (3, 2),
+// returning 0 for anything it can't parse.
+func sagaStepNumber(tag string) int {
+	tag = strings.TrimSpace(tag)
+	if len(tag) < 2 {
+		return 0
+	}
+	switch tag[0] {
+	case 'F', 'f', 'C', 'c':
+		n, err := strconv.Atoi(tag[1:])
+		if err != nil || n < 1 {
+			return 0
+		}
+		return n
+	}
+	return 0
+}
+
+// sagaInjectDelays parses "F3:5000" (optionally comma-separated, optional "ms"
+// suffix) into a step-number -> delay map. Values are milliseconds.
+func sagaInjectDelays(raw string) map[int]time.Duration {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	out := make(map[int]time.Duration)
+	for _, part := range strings.Split(raw, ",") {
+		kv := strings.SplitN(strings.TrimSpace(part), ":", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		step := sagaStepNumber(kv[0])
+		ms, err := strconv.Atoi(strings.TrimSuffix(strings.TrimSpace(kv[1]), "ms"))
+		if step > 0 && err == nil && ms >= 0 {
+			out[step] = time.Duration(ms) * time.Millisecond
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 type sagaStepResponse struct {
 	StepNumber   int    `json:"stepNumber"`
 	Name         string `json:"name"`
@@ -693,16 +771,25 @@ type sagaStepResponse struct {
 	ErrorMessage string `json:"errorMessage,omitempty"`
 }
 
+// sagaLogEntryResponse is one entry of the append-only saga log (files/SAGA.md):
+// a forward or compensation attempt and its outcome, in execution order.
+type sagaLogEntryResponse struct {
+	Phase   string `json:"phase"`   // "F1".."F5" or "C1".."C5"
+	Outcome string `json:"outcome"` // "ok" | "err"
+	Error   string `json:"error,omitempty"`
+}
+
 type sagaTransactionResponse struct {
-	ID          uint               `json:"id"`
-	Type        string             `json:"type"`
-	Status      string             `json:"status"`
-	CurrentStep int                `json:"currentStep"`
-	RetryCount  int                `json:"retryCount"`
-	Error       string             `json:"error,omitempty"`
-	CreatedAt   string             `json:"createdAt"`
-	UpdatedAt   string             `json:"updatedAt"`
-	Steps       []sagaStepResponse `json:"steps"`
+	ID          uint                   `json:"id"`
+	Type        string                 `json:"type"`
+	Status      string                 `json:"status"`
+	CurrentStep int                    `json:"currentStep"`
+	RetryCount  int                    `json:"retryCount"`
+	Error       string                 `json:"error,omitempty"`
+	CreatedAt   string                 `json:"createdAt"`
+	UpdatedAt   string                 `json:"updatedAt"`
+	Steps       []sagaStepResponse     `json:"steps"`
+	Log         []sagaLogEntryResponse `json:"log"`
 }
 
 func sagaTransactionToResponse(saga models.SagaTransactionRecord) sagaTransactionResponse {
@@ -720,6 +807,14 @@ func sagaTransactionToResponse(saga models.SagaTransactionRecord) sagaTransactio
 			ErrorMessage: step.ErrorMessage,
 		})
 	}
+	logEntries := make([]sagaLogEntryResponse, 0, len(saga.Attempts))
+	for _, a := range saga.Attempts {
+		logEntries = append(logEntries, sagaLogEntryResponse{
+			Phase:   a.Phase,
+			Outcome: a.Outcome,
+			Error:   a.Error,
+		})
+	}
 	return sagaTransactionResponse{
 		ID:          saga.ID,
 		Type:        saga.Type,
@@ -730,5 +825,6 @@ func sagaTransactionToResponse(saga models.SagaTransactionRecord) sagaTransactio
 		CreatedAt:   saga.CreatedAt.UTC().Format(time.RFC3339),
 		UpdatedAt:   saga.UpdatedAt.UTC().Format(time.RFC3339),
 		Steps:       steps,
+		Log:         logEntries,
 	}
 }

--- a/exchange-service/internal/handler/saga_exercise_test.go
+++ b/exchange-service/internal/handler/saga_exercise_test.go
@@ -1,0 +1,608 @@
+package handler
+
+// SAGA test suite (files/SAGA.md). These drive the OTC option-exercise saga
+// end-to-end over HTTP: POST /api/v1/otc/contracts/{id}/exercise, then poll
+// GET /api/v1/otc/saga/{id}, asserting the saga log, participant state, and the
+// spec invariants I1-I6.
+//
+// Status-name mapping (our schema -> spec): in_progress=Running,
+// completed=Completed, rolling_back=Compensating, rolled_back=Compensated.
+//
+// SG-01..SG-04 need no product changes. SG-05..SG-08 (forced-failure paths) are
+// added once the X-Saga-* fault hooks land.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+	"gorm.io/gorm"
+)
+
+// =====================================================================
+// Harness
+// =====================================================================
+
+// setupSagaExerciseHandler builds an OTC handler with the saga orchestrator and
+// saga querier wired, mirroring cmd/server/main.go. Returns the saga repo too so
+// tests can drive the retry cron (RetryCompensations) directly.
+func setupSagaExerciseHandler(t *testing.T, db *gorm.DB) (*OtcHTTPHandler, *repository.SagaRepository) {
+	t.Helper()
+	cfg := &config.Config{JWTSecret: testJWTSecret, SagaFaultHooks: true}
+	sagaRepo := repository.NewSagaRepository(db)
+	orch := service.NewSagaOrchestrator(sagaRepo, db)
+	otcSvc := service.NewOtcService(
+		repository.NewPortfolioRepository(db),
+		repository.NewOtcRepository(db),
+	).WithOrchestrator(orch)
+	h := NewOtcHTTPHandler(cfg, otcSvc).WithSagaQuerier(sagaRepo)
+	return h, sagaRepo
+}
+
+// seedSagaAccountsSchema creates the reference tables the saga steps touch but
+// which are not gorm-migrated models in exchange-service (they live in other
+// services' migrations). Mirrors seedOtcHandlerAccounts.
+func seedSagaAccountsSchema(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS currencies (id integer primary key, kod text not null unique)`,
+		`CREATE TABLE IF NOT EXISTS accounts (
+			id integer primary key,
+			client_id integer, firma_id integer, zaposleni_id integer,
+			currency_id integer not null,
+			stanje real not null default 0,
+			raspolozivo_stanje real not null default 0,
+			dnevna_potrosnja real not null default 0,
+			mesecna_potrosnja real not null default 0,
+			status text not null default 'aktivan'
+		)`,
+		`INSERT OR IGNORE INTO currencies (id, kod) VALUES (1, 'USD')`,
+	}
+	for _, s := range stmts {
+		if err := db.Exec(s).Error; err != nil {
+			t.Fatalf("seed accounts schema: %v", err)
+		}
+	}
+}
+
+// exerciseSeed parameterises a ready-to-exercise contract. Defaults match the
+// SG-01 happy path (qty=10, strike=300, buyer 5000, seller 10 reserved).
+type exerciseSeed struct {
+	amount         float64
+	strike         float64
+	buyerStanje    float64
+	buyerAvail     float64
+	sellerQty      float64
+	sellerReserved float64
+	status         string
+	settlement     time.Time
+}
+
+func defaultExerciseSeed() exerciseSeed {
+	return exerciseSeed{
+		amount: 10, strike: 300,
+		buyerStanje: 5000, buyerAvail: 5000,
+		sellerQty: 10, sellerReserved: 10,
+		status:     models.OtcContractStatusValid,
+		settlement: time.Now().UTC().AddDate(0, 0, 1),
+	}
+}
+
+// seedExercisableContract creates a listing, buyer account (id=2, client 100 —
+// matches clientToken) and seller account (id=1, client 200), a reserved seller
+// holding, and a contract owned by buyer client-100. Returns the contract.
+func seedExercisableContract(t *testing.T, db *gorm.DB, s exerciseSeed) *models.OtcContractRecord {
+	t.Helper()
+	seedSagaAccountsSchema(t, db)
+	_, listingID := seedExchangeAndListing(t, db, "SAGA")
+
+	if err := db.Exec(`INSERT INTO accounts (id, client_id, currency_id, stanje, raspolozivo_stanje, status) VALUES
+		(1, 200, 1, ?, ?, 'aktivan'),
+		(2, 100, 1, ?, ?, 'aktivan')`,
+		0.0, 0.0, s.buyerStanje, s.buyerAvail).Error; err != nil {
+		t.Fatalf("seed accounts: %v", err)
+	}
+
+	now := time.Now().UTC()
+	holding := models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: listingID,
+		Quantity: s.sellerQty, ReservedQuantity: s.sellerReserved,
+		AvgBuyPrice: 90, AccountID: 1, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatalf("seed seller holding: %v", err)
+	}
+
+	contract := models.OtcContractRecord{
+		StockListingID:  listingID,
+		SellerHoldingID: holding.ID,
+		Amount:          s.amount,
+		StrikePrice:     s.strike,
+		Premium:         25,
+		SettlementDate:  s.settlement,
+		BuyerID:         100, BuyerType: "client", BuyerAccountID: 2,
+		SellerID: 200, SellerType: "client", SellerAccountID: 1,
+		Status:    s.status,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(&contract).Error; err != nil {
+		t.Fatalf("seed contract: %v", err)
+	}
+	return &contract
+}
+
+// =====================================================================
+// HTTP + assertion helpers
+// =====================================================================
+
+func exerciseContractHTTP(t *testing.T, h *OtcHTTPHandler, contractID uint, token string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/otc/contracts/%d/exercise", contractID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	h.OtcRoutes(rec, req)
+	return rec
+}
+
+func decodeSagaID(t *testing.T, rec *httptest.ResponseRecorder) uint {
+	t.Helper()
+	var body struct {
+		SagaID uint `json:"sagaId"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode exercise response: %v body=%s", err, rec.Body.String())
+	}
+	return body.SagaID
+}
+
+type sagaStepView struct {
+	StepNumber   int    `json:"stepNumber"`
+	Name         string `json:"name"`
+	Status       string `json:"status"`
+	ErrorMessage string `json:"errorMessage"`
+}
+
+type sagaAttemptView struct {
+	Phase   string `json:"phase"`
+	Outcome string `json:"outcome"`
+	Error   string `json:"error"`
+}
+
+type sagaView struct {
+	ID          uint              `json:"id"`
+	Status      string            `json:"status"`
+	CurrentStep int               `json:"currentStep"`
+	RetryCount  int               `json:"retryCount"`
+	Steps       []sagaStepView    `json:"steps"`
+	Log         []sagaAttemptView `json:"log"`
+}
+
+func getSagaHTTP(t *testing.T, h *OtcHTTPHandler, sagaID uint, token string) sagaView {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/otc/saga/%d", sagaID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	h.OtcRoutes(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get saga: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Saga sagaView `json:"saga"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode saga: %v body=%s", err, rec.Body.String())
+	}
+	return body.Saga
+}
+
+func stepsByNumber(saga sagaView) map[int]sagaStepView {
+	m := make(map[int]sagaStepView, len(saga.Steps))
+	for _, s := range saga.Steps {
+		m[s.StepNumber] = s
+	}
+	return m
+}
+
+// logShape renders the append-only saga log as ordered "F1 ok" / "C2 err"
+// strings, for spec-literal comparison (files/SAGA.md).
+func logShape(saga sagaView) []string {
+	out := make([]string, 0, len(saga.Log))
+	for _, a := range saga.Log {
+		out = append(out, a.Phase+" "+a.Outcome)
+	}
+	return out
+}
+
+func assertLog(t *testing.T, saga sagaView, want []string) {
+	t.Helper()
+	got := logShape(saga)
+	if len(got) != len(want) {
+		t.Fatalf("saga log = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("saga log[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func accountField(t *testing.T, db *gorm.DB, accountID uint, column string) float64 {
+	t.Helper()
+	var v float64
+	if err := db.Table("accounts").Select(column).Where("id = ?", accountID).Scan(&v).Error; err != nil {
+		t.Fatalf("read account %d.%s: %v", accountID, column, err)
+	}
+	return v
+}
+
+func assertAccount(t *testing.T, db *gorm.DB, accountID uint, wantStanje, wantAvail float64) {
+	t.Helper()
+	if got := accountField(t, db, accountID, "stanje"); got != wantStanje {
+		t.Fatalf("account %d stanje = %v, want %v", accountID, got, wantStanje)
+	}
+	if got := accountField(t, db, accountID, "raspolozivo_stanje"); got != wantAvail {
+		t.Fatalf("account %d raspolozivo = %v, want %v", accountID, got, wantAvail)
+	}
+}
+
+func countSagas(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+	var n int64
+	if err := db.Model(&models.SagaTransactionRecord{}).Count(&n).Error; err != nil {
+		t.Fatalf("count sagas: %v", err)
+	}
+	return n
+}
+
+// =====================================================================
+// SG-01: happy path
+// =====================================================================
+
+func TestSaga_SG01_HappyPath(t *testing.T) {
+	db := newTestDB(t, "saga_sg01")
+	h, _ := setupSagaExerciseHandler(t, db)
+	contract := seedExercisableContract(t, db, defaultExerciseSeed())
+
+	rec := exerciseContractHTTP(t, h, contract.ID, clientToken(t), nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("exercise: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	sagaID := decodeSagaID(t, rec)
+	if sagaID == 0 {
+		t.Fatal("expected non-zero sagaId")
+	}
+
+	saga := getSagaHTTP(t, h, sagaID, clientToken(t))
+	if saga.Status != models.SagaStatusCompleted {
+		t.Fatalf("expected saga completed, got %q", saga.Status)
+	}
+	if saga.CurrentStep != 5 {
+		t.Fatalf("expected current_step 5, got %d", saga.CurrentStep)
+	}
+	if len(saga.Steps) != 5 {
+		t.Fatalf("expected 5 steps, got %d", len(saga.Steps))
+	}
+	for _, s := range saga.Steps {
+		if s.Status != models.SagaStepStatusCompleted {
+			t.Fatalf("step %d (%s) not completed: %s", s.StepNumber, s.Name, s.Status)
+		}
+	}
+	// I4: the log records every phase attempted, in order — five clean forwards.
+	assertLog(t, saga, []string{"F1 ok", "F2 ok", "F3 ok", "F4 ok", "F5 ok"})
+
+	// I1 (money conserved) + balances: buyer 5000-3000=2000, seller 0+3000=3000.
+	// I3: no stranded reservation -> buyer raspolozivo == stanje.
+	assertAccount(t, db, 2, 2000, 2000) // buyer
+	assertAccount(t, db, 1, 3000, 3000) // seller
+
+	// I2 (shares conserved): buyer now holds 10, seller drained to 0/0.
+	var buyerHolding models.PortfolioHoldingRecord
+	if err := db.Where("user_id = ? AND user_type = ? AND asset_id = ?", 100, "client", contract.StockListingID).First(&buyerHolding).Error; err != nil {
+		t.Fatalf("buyer holding: %v", err)
+	}
+	if buyerHolding.Quantity != 10 {
+		t.Fatalf("expected buyer 10 shares, got %v", buyerHolding.Quantity)
+	}
+	var sellerHolding models.PortfolioHoldingRecord
+	if err := db.First(&sellerHolding, contract.SellerHoldingID).Error; err != nil {
+		t.Fatalf("seller holding: %v", err)
+	}
+	if sellerHolding.Quantity != 0 || sellerHolding.ReservedQuantity != 0 {
+		t.Fatalf("expected seller 0/0, got %v/%v", sellerHolding.Quantity, sellerHolding.ReservedQuantity)
+	}
+
+	// I6: contract consumed only because the saga completed.
+	var updated models.OtcContractRecord
+	if err := db.First(&updated, contract.ID).Error; err != nil {
+		t.Fatalf("contract: %v", err)
+	}
+	if updated.Status != models.OtcContractStatusExercised {
+		t.Fatalf("expected contract exercised, got %q", updated.Status)
+	}
+}
+
+// =====================================================================
+// SG-02: pre-saga validation (a-d) — 4xx, no saga log, no side effects
+// =====================================================================
+
+func TestSaga_SG02_PreSagaValidation(t *testing.T) {
+	t.Run("a_caller_not_buyer", func(t *testing.T) {
+		db := newTestDB(t, "saga_sg02a")
+		h, _ := setupSagaExerciseHandler(t, db)
+		contract := seedExercisableContract(t, db, defaultExerciseSeed())
+		// A different client (999) holding a valid trading token.
+		rec := exerciseContractHTTP(t, h, contract.ID, clientTradingToken(t, 999), nil)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		if n := countSagas(t, db); n != 0 {
+			t.Fatalf("expected no saga, got %d", n)
+		}
+		assertAccount(t, db, 2, 5000, 5000) // buyer untouched
+	})
+
+	t.Run("b_contract_missing", func(t *testing.T) {
+		db := newTestDB(t, "saga_sg02b")
+		h, _ := setupSagaExerciseHandler(t, db)
+		seedSagaAccountsSchema(t, db)
+		rec := exerciseContractHTTP(t, h, 99999, clientToken(t), nil)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		if n := countSagas(t, db); n != 0 {
+			t.Fatalf("expected no saga, got %d", n)
+		}
+	})
+
+	t.Run("c_status_not_valid", func(t *testing.T) {
+		db := newTestDB(t, "saga_sg02c")
+		h, _ := setupSagaExerciseHandler(t, db)
+		s := defaultExerciseSeed()
+		s.status = models.OtcContractStatusExercised
+		contract := seedExercisableContract(t, db, s)
+		rec := exerciseContractHTTP(t, h, contract.ID, clientToken(t), nil)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		if n := countSagas(t, db); n != 0 {
+			t.Fatalf("expected no saga, got %d", n)
+		}
+		assertAccount(t, db, 2, 5000, 5000)
+	})
+
+	t.Run("d_settlement_passed", func(t *testing.T) {
+		db := newTestDB(t, "saga_sg02d")
+		h, _ := setupSagaExerciseHandler(t, db)
+		s := defaultExerciseSeed()
+		s.settlement = time.Now().UTC().AddDate(0, 0, -2)
+		contract := seedExercisableContract(t, db, s)
+		rec := exerciseContractHTTP(t, h, contract.ID, clientToken(t), nil)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		if n := countSagas(t, db); n != 0 {
+			t.Fatalf("expected no saga, got %d", n)
+		}
+		assertAccount(t, db, 2, 5000, 5000)
+	})
+}
+
+// =====================================================================
+// SG-03: insufficient funds -> F1 fails, no prior steps to compensate
+// =====================================================================
+
+func TestSaga_SG03_InsufficientFunds_F1(t *testing.T) {
+	db := newTestDB(t, "saga_sg03")
+	h, _ := setupSagaExerciseHandler(t, db)
+	s := defaultExerciseSeed()
+	s.buyerStanje, s.buyerAvail = 500, 500 // cost is 3000
+	contract := seedExercisableContract(t, db, s)
+
+	rec := exerciseContractHTTP(t, h, contract.ID, clientToken(t), nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	sagaID := decodeSagaID(t, rec)
+	if sagaID == 0 {
+		t.Fatal("expected sagaId even on failure")
+	}
+
+	saga := getSagaHTTP(t, h, sagaID, clientToken(t))
+	if saga.Status != models.SagaStatusRolledBack {
+		t.Fatalf("expected rolled_back (Compensated), got %q", saga.Status)
+	}
+	if saga.CurrentStep != 1 {
+		t.Fatalf("expected current_step 1, got %d", saga.CurrentStep)
+	}
+	steps := stepsByNumber(saga)
+	if steps[1].Status != models.SagaStepStatusFailed {
+		t.Fatalf("step1 expected failed, got %s", steps[1].Status)
+	}
+	for n := 2; n <= 5; n++ {
+		if steps[n].Status != models.SagaStepStatusPending {
+			t.Fatalf("step%d expected pending (never attempted), got %s", n, steps[n].Status)
+		}
+	}
+	// Log contains only F1 with an error.
+	assertLog(t, saga, []string{"F1 err"})
+	// No side effects: balances unchanged.
+	assertAccount(t, db, 2, 500, 500)
+}
+
+// =====================================================================
+// SG-04: insufficient shares -> F2 fails, C1 releases the F1 reservation
+// =====================================================================
+
+func TestSaga_SG04_InsufficientShares_F2(t *testing.T) {
+	db := newTestDB(t, "saga_sg04")
+	h, _ := setupSagaExerciseHandler(t, db)
+	s := defaultExerciseSeed()
+	s.sellerQty, s.sellerReserved = 3, 3 // contract wants 10
+	contract := seedExercisableContract(t, db, s)
+
+	rec := exerciseContractHTTP(t, h, contract.ID, clientToken(t), nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	sagaID := decodeSagaID(t, rec)
+
+	saga := getSagaHTTP(t, h, sagaID, clientToken(t))
+	if saga.Status != models.SagaStatusRolledBack {
+		t.Fatalf("expected rolled_back (Compensated), got %q", saga.Status)
+	}
+	if saga.CurrentStep != 2 {
+		t.Fatalf("expected current_step 2, got %d", saga.CurrentStep)
+	}
+	steps := stepsByNumber(saga)
+	if steps[1].Status != models.SagaStepStatusCompensated {
+		t.Fatalf("step1 expected compensated (C1 ran), got %s", steps[1].Status)
+	}
+	if steps[2].Status != models.SagaStepStatusFailed {
+		t.Fatalf("step2 expected failed, got %s", steps[2].Status)
+	}
+	// Log: F1 ok, F2 err, C1 ok.
+	assertLog(t, saga, []string{"F1 ok", "F2 err", "C1 ok"})
+	// C1 released F1's reservation: buyer fully restored, no stranded reservation.
+	assertAccount(t, db, 2, 5000, 5000)
+}
+
+// assertExerciseFullyRolledBack checks the spec invariants common to SG-05/06/07
+// (and SG-08): money and shares are conserved back to the seeded pre-exercise
+// state, no reservations are stranded (I1/I3), shares are intact (I2), and the
+// contract is still valid because the saga did not complete (I6).
+func assertExerciseFullyRolledBack(t *testing.T, db *gorm.DB, contract *models.OtcContractRecord) {
+	t.Helper()
+	assertAccount(t, db, 2, 5000, 5000) // buyer restored
+	assertAccount(t, db, 1, 0, 0)       // seller restored
+
+	var sellerHolding models.PortfolioHoldingRecord
+	if err := db.First(&sellerHolding, contract.SellerHoldingID).Error; err != nil {
+		t.Fatalf("seller holding: %v", err)
+	}
+	if sellerHolding.Quantity != 10 || sellerHolding.ReservedQuantity != 10 {
+		t.Fatalf("seller holding not restored: qty=%v reserved=%v", sellerHolding.Quantity, sellerHolding.ReservedQuantity)
+	}
+
+	var buyerHolding models.PortfolioHoldingRecord
+	err := db.Where("user_id = ? AND user_type = ? AND asset_id = ?", 100, "client", contract.StockListingID).First(&buyerHolding).Error
+	if err == nil && buyerHolding.Quantity != 0 {
+		t.Fatalf("buyer should hold no net shares, got %v", buyerHolding.Quantity)
+	}
+
+	var updated models.OtcContractRecord
+	if err := db.First(&updated, contract.ID).Error; err != nil {
+		t.Fatalf("contract: %v", err)
+	}
+	if updated.Status != models.OtcContractStatusValid {
+		t.Fatalf("contract should remain valid (I6), got %q", updated.Status)
+	}
+}
+
+// =====================================================================
+// SG-05/06/07: forced forward-phase failures with full compensation
+// =====================================================================
+
+func TestSaga_SG05_06_07_ForcedForwardFailures(t *testing.T) {
+	cases := []struct {
+		name        string
+		forceFail   string // X-Saga-Force-Fail value
+		currentStep int
+		compensated []int // steps whose compensators must have run
+		failedStep  int
+		expectedLog []string
+	}{
+		{"SG05_F3", "F3", 3, []int{1, 2}, 3,
+			[]string{"F1 ok", "F2 ok", "F3 err", "C2 ok", "C1 ok"}},
+		{"SG06_F4", "F4", 4, []int{1, 2, 3}, 4,
+			[]string{"F1 ok", "F2 ok", "F3 ok", "F4 err", "C3 ok", "C2 ok", "C1 ok"}},
+		{"SG07_F5", "F5", 5, []int{1, 2, 3, 4}, 5,
+			[]string{"F1 ok", "F2 ok", "F3 ok", "F4 ok", "F5 err", "C4 ok", "C3 ok", "C2 ok", "C1 ok"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newTestDB(t, "saga_"+tc.name)
+			h, _ := setupSagaExerciseHandler(t, db)
+			contract := seedExercisableContract(t, db, defaultExerciseSeed())
+
+			rec := exerciseContractHTTP(t, h, contract.ID, clientToken(t), map[string]string{
+				"X-Saga-Force-Fail": tc.forceFail,
+			})
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+			}
+			sagaID := decodeSagaID(t, rec)
+
+			saga := getSagaHTTP(t, h, sagaID, clientToken(t))
+			if saga.Status != models.SagaStatusRolledBack {
+				t.Fatalf("expected rolled_back (Compensated), got %q", saga.Status)
+			}
+			if saga.CurrentStep != tc.currentStep {
+				t.Fatalf("expected current_step %d, got %d", tc.currentStep, saga.CurrentStep)
+			}
+			steps := stepsByNumber(saga)
+			for _, n := range tc.compensated {
+				if steps[n].Status != models.SagaStepStatusCompensated {
+					t.Fatalf("step%d expected compensated, got %s", n, steps[n].Status)
+				}
+			}
+			if steps[tc.failedStep].Status != models.SagaStepStatusFailed {
+				t.Fatalf("step%d expected failed, got %s", tc.failedStep, steps[tc.failedStep].Status)
+			}
+			assertLog(t, saga, tc.expectedLog)
+			assertExerciseFullyRolledBack(t, db, contract)
+		})
+	}
+}
+
+// =====================================================================
+// SG-08: a compensator fails once, then succeeds
+// =====================================================================
+//
+// X-Saga-Compensate-Fail makes C2 fail its first attempt. Bounded inline
+// compensation retry re-runs C2, which now succeeds, so the saga converges to
+// rolled_back within the single exercise request. The append-only log shows C2
+// twice (err then ok), matching the spec's six-entry example exactly:
+// F1 ok, F2 ok, F3 err, C2 err, C2 ok, C1 ok (files/SAGA.md).
+func TestSaga_SG08_CompensatorFailsThenSucceeds(t *testing.T) {
+	db := newTestDB(t, "saga_sg08")
+	h, _ := setupSagaExerciseHandler(t, db)
+	contract := seedExercisableContract(t, db, defaultExerciseSeed())
+
+	rec := exerciseContractHTTP(t, h, contract.ID, clientToken(t), map[string]string{
+		"X-Saga-Force-Fail":            "F3",
+		"X-Saga-Compensate-Fail":       "C2",
+		"X-Saga-Compensate-Fail-Times": "1",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	sagaID := decodeSagaID(t, rec)
+
+	saga := getSagaHTTP(t, h, sagaID, clientToken(t))
+	if saga.Status != models.SagaStatusRolledBack {
+		t.Fatalf("expected rolled_back after inline compensation retry, got %q", saga.Status)
+	}
+	if saga.CurrentStep != 3 {
+		t.Fatalf("expected current_step 3, got %d", saga.CurrentStep)
+	}
+	steps := stepsByNumber(saga)
+	if steps[1].Status != models.SagaStepStatusCompensated {
+		t.Fatalf("step1 (C1) expected compensated, got %s", steps[1].Status)
+	}
+	if steps[2].Status != models.SagaStepStatusCompensated {
+		t.Fatalf("step2 (C2) expected compensated after retry, got %s", steps[2].Status)
+	}
+	// The spec's six-entry log: C2 appears twice (err then ok).
+	assertLog(t, saga, []string{"F1 ok", "F2 ok", "F3 err", "C2 err", "C2 ok", "C1 ok"})
+	assertExerciseFullyRolledBack(t, db, contract)
+}

--- a/exchange-service/internal/models/saga.go
+++ b/exchange-service/internal/models/saga.go
@@ -17,19 +17,26 @@ const (
 	SagaStepStatusCompleted   = "completed"
 	SagaStepStatusFailed      = "failed"
 	SagaStepStatusCompensated = "compensated"
+
+	// Outcomes recorded in the append-only attempt log (SagaAttemptRecord).
+	SagaAttemptOutcomeOK  = "ok"
+	SagaAttemptOutcomeErr = "err"
 )
 
 type SagaTransactionRecord struct {
-	ID          uint              `gorm:"primaryKey"`
-	Type        string            `gorm:"not null;index"`
-	Status      string            `gorm:"not null;default:'in_progress';index"`
-	CurrentStep int               `gorm:"column:current_step;not null;default:0"`
-	Payload     string            `gorm:"type:text"`
-	Error       string            `gorm:"type:text"`
-	RetryCount  int               `gorm:"column:retry_count;not null;default:0"`
-	CreatedAt   time.Time         `gorm:"not null"`
-	UpdatedAt   time.Time         `gorm:"not null"`
-	Steps       []SagaStepRecord  `gorm:"foreignKey:SagaID"`
+	ID          uint             `gorm:"primaryKey"`
+	Type        string           `gorm:"not null;index"`
+	Status      string           `gorm:"not null;default:'in_progress';index"`
+	CurrentStep int              `gorm:"column:current_step;not null;default:0"`
+	Payload     string           `gorm:"type:text"`
+	Error       string           `gorm:"type:text"`
+	RetryCount  int              `gorm:"column:retry_count;not null;default:0"`
+	CreatedAt   time.Time        `gorm:"not null"`
+	UpdatedAt   time.Time        `gorm:"not null"`
+	Steps       []SagaStepRecord `gorm:"foreignKey:SagaID"`
+	// Attempts is the append-only log: one row per forward/compensation attempt,
+	// in execution order. See SagaAttemptRecord.
+	Attempts []SagaAttemptRecord `gorm:"foreignKey:SagaID"`
 }
 
 func (SagaTransactionRecord) TableName() string { return "saga_transactions" }
@@ -48,3 +55,19 @@ type SagaStepRecord struct {
 }
 
 func (SagaStepRecord) TableName() string { return "saga_steps" }
+
+// SagaAttemptRecord is one entry in the saga's append-only log: a single forward
+// or compensation attempt and its outcome. Unlike SagaStepRecord (one mutable
+// row per step), this table grows by one row per attempt, so a compensator that
+// fails then succeeds appears as two rows ({C2: err} then {C2: ok}). This is the
+// "log" the SAGA spec asserts on (files/SAGA.md). Ordered by ID (insertion).
+type SagaAttemptRecord struct {
+	ID        uint      `gorm:"primaryKey"`
+	SagaID    uint      `gorm:"column:saga_id;not null;index"`
+	Phase     string    `gorm:"column:phase;not null"`   // "F1".."F5" (forward) or "C1".."C5" (compensation)
+	Outcome   string    `gorm:"column:outcome;not null"` // "ok" | "err"
+	Error     string    `gorm:"column:error;type:text"`
+	CreatedAt time.Time `gorm:"not null"`
+}
+
+func (SagaAttemptRecord) TableName() string { return "saga_step_attempts" }

--- a/exchange-service/internal/repository/saga_repository.go
+++ b/exchange-service/internal/repository/saga_repository.go
@@ -44,6 +44,18 @@ func (r *SagaRepository) AppendStep(sagaID uint, stepNumber int, name string) (*
 	return step, nil
 }
 
+// AppendAttempt adds one entry to the saga's append-only log (files/SAGA.md).
+// Phase is "F1".."F5" or "C1".."C5"; outcome is models.SagaAttemptOutcome*.
+func (r *SagaRepository) AppendAttempt(sagaID uint, phase, outcome, errMsg string) error {
+	return r.db.Create(&models.SagaAttemptRecord{
+		SagaID:    sagaID,
+		Phase:     phase,
+		Outcome:   outcome,
+		Error:     errMsg,
+		CreatedAt: time.Now().UTC(),
+	}).Error
+}
+
 func (r *SagaRepository) UpdateStep(stepID uint, fields map[string]interface{}) error {
 	fields["updated_at"] = time.Now().UTC()
 	return r.db.Model(&models.SagaStepRecord{}).Where("id = ?", stepID).Updates(fields).Error
@@ -107,9 +119,14 @@ func (r *SagaRepository) IncrementRetry(sagaID uint) error {
 
 func (r *SagaRepository) GetTransaction(sagaID uint) (*models.SagaTransactionRecord, error) {
 	var saga models.SagaTransactionRecord
-	if err := r.db.Preload("Steps", func(tx *gorm.DB) *gorm.DB {
-		return tx.Order("step_number ASC, id ASC")
-	}).First(&saga, sagaID).Error; err != nil {
+	if err := r.db.
+		Preload("Steps", func(tx *gorm.DB) *gorm.DB {
+			return tx.Order("step_number ASC, id ASC")
+		}).
+		Preload("Attempts", func(tx *gorm.DB) *gorm.DB {
+			return tx.Order("id ASC")
+		}).
+		First(&saga, sagaID).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}

--- a/exchange-service/internal/service/otc_service.go
+++ b/exchange-service/internal/service/otc_service.go
@@ -323,6 +323,13 @@ type ExerciseContractResult struct {
 // not-yet-expired OTC contract and runs the 5-step exercise saga. Returns the
 // saga ID so the caller can poll progress.
 func (s *OtcService) ExerciseContract(contractID, buyerID uint, buyerType string) (*ExerciseContractResult, error) {
+	return s.ExerciseContractWithFaults(contractID, buyerID, buyerType, nil)
+}
+
+// ExerciseContractWithFaults is ExerciseContract with an optional fault-injection
+// config threaded into the saga orchestrator. faults is nil in production; it is
+// only non-nil in the SAGA test suite (SAGA_FAULT_HOOKS, see files/SAGA.md).
+func (s *OtcService) ExerciseContractWithFaults(contractID, buyerID uint, buyerType string, faults *SagaFaultConfig) (*ExerciseContractResult, error) {
 	if s.orchestrator == nil {
 		return nil, fmt.Errorf("saga orchestrator is not configured")
 	}
@@ -358,7 +365,7 @@ func (s *OtcService) ExerciseContract(contractID, buyerID uint, buyerType string
 	}
 
 	steps := BuildOtcExerciseSteps(contract)
-	sagaID, runErr := s.orchestrator.Run(models.SagaTypeOtcExercise, payload, steps)
+	sagaID, runErr := s.orchestrator.RunWithFaults(models.SagaTypeOtcExercise, payload, steps, faults)
 	if runErr != nil {
 		return &ExerciseContractResult{SagaID: sagaID, Contract: contract}, runErr
 	}

--- a/exchange-service/internal/service/saga_faults.go
+++ b/exchange-service/internal/service/saga_faults.go
@@ -1,0 +1,61 @@
+package service
+
+import "time"
+
+// SagaFaultConfig drives deterministic fault injection for the SAGA test suite
+// (files/SAGA.md). It is ONLY constructed when the SAGA_FAULT_HOOKS env flag is
+// set; cmd/server refuses to boot with the flag enabled in release mode. Step
+// numbers are 1-based forward steps (F1..F5); compensators share the number
+// (C1..C5).
+//
+// All methods are nil-safe: a nil *SagaFaultConfig injects nothing, so the
+// production path (Run -> RunWithFaults(nil)) is byte-for-byte unaffected.
+type SagaFaultConfig struct {
+	// ForceFailStep is the 1-based forward step to fail (0 = none).
+	ForceFailStep int
+	// ForceFailAfter fails the step AFTER its side effects commit (default is
+	// before, i.e. the step is a no-op that errors).
+	ForceFailAfter bool
+	// CompensateFailStep is the 1-based compensator to fail (0 = none).
+	CompensateFailStep int
+	// CompensateFailTimes is how many consecutive compensator attempts fail
+	// before one is allowed to succeed.
+	CompensateFailTimes int
+	// InjectDelays maps a forward step number to a sleep applied before it runs.
+	InjectDelays map[int]time.Duration
+
+	// compensateAttempts counts forced compensator failures consumed so far.
+	compensateAttempts map[int]int
+}
+
+func (f *SagaFaultConfig) delayFor(step int) time.Duration {
+	if f == nil {
+		return 0
+	}
+	return f.InjectDelays[step]
+}
+
+func (f *SagaFaultConfig) shouldFailForward(step int) bool {
+	return f != nil && f.ForceFailStep == step
+}
+
+func (f *SagaFaultConfig) forceFailAfter() bool {
+	return f != nil && f.ForceFailAfter
+}
+
+// shouldFailCompensation reports whether the compensator for step must be forced
+// to fail on this attempt, consuming one configured failure. After
+// CompensateFailTimes calls it returns false so a later retry can succeed.
+func (f *SagaFaultConfig) shouldFailCompensation(step int) bool {
+	if f == nil || f.CompensateFailStep != step || f.CompensateFailTimes <= 0 {
+		return false
+	}
+	if f.compensateAttempts == nil {
+		f.compensateAttempts = make(map[int]int)
+	}
+	if f.compensateAttempts[step] >= f.CompensateFailTimes {
+		return false
+	}
+	f.compensateAttempts[step]++
+	return true
+}

--- a/exchange-service/internal/service/saga_orchestrator.go
+++ b/exchange-service/internal/service/saga_orchestrator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
@@ -28,12 +29,42 @@ func NewSagaOrchestrator(sagaRepo *repository.SagaRepository, db *gorm.DB) *Saga
 	return &SagaOrchestrator{sagaRepo: sagaRepo, db: db}
 }
 
+// maxInlineCompensateAttempts bounds how many times a single compensator is
+// retried inline (within the request) before the saga is left in rolling_back
+// for the retry cron. Compensators are idempotent and transactional, so an
+// immediate retry is safe; this lets a transient compensation failure self-heal
+// without waiting for the cron, and gives the SAGA spec's in-request convergence
+// (files/SAGA.md).
+const maxInlineCompensateAttempts = 3
+
+// logAttempt appends one entry to the saga's append-only log. It is called
+// outside the step's own transaction so an "err" entry survives even though the
+// failed step's side effects rolled back. Best-effort: a logging failure must
+// not abort the saga.
+func (o *SagaOrchestrator) logAttempt(sagaID uint, phase string, cause error) {
+	outcome := models.SagaAttemptOutcomeOK
+	msg := ""
+	if cause != nil {
+		outcome = models.SagaAttemptOutcomeErr
+		msg = cause.Error()
+	}
+	_ = o.sagaRepo.AppendAttempt(sagaID, phase, outcome, msg)
+}
+
 // Run starts a fresh saga: creates the transaction record, persists per-step
 // records, then executes Forward functions sequentially. On any failure it
 // rolls back compensations from the last completed step backward.
 // Returns the saga ID and a non-nil error if the saga (including compensations)
 // did not finish cleanly.
 func (o *SagaOrchestrator) Run(sagaType, payload string, steps []SagaStep) (uint, error) {
+	return o.RunWithFaults(sagaType, payload, steps, nil)
+}
+
+// RunWithFaults is Run with an optional fault-injection config. faults is nil in
+// production (Run delegates here with nil); it is only ever non-nil in the SAGA
+// test suite, behind the SAGA_FAULT_HOOKS env flag (files/SAGA.md). With faults
+// == nil the behavior is identical to the original Run.
+func (o *SagaOrchestrator) RunWithFaults(sagaType, payload string, steps []SagaStep, faults *SagaFaultConfig) (uint, error) {
 	saga := &models.SagaTransactionRecord{
 		Type:    sagaType,
 		Status:  models.SagaStatusInProgress,
@@ -58,15 +89,26 @@ func (o *SagaOrchestrator) Run(sagaType, payload string, steps []SagaStep) (uint
 		_ = o.sagaRepo.MarkStepInProgress(rec.ID)
 		_ = o.sagaRepo.SetCurrentStep(saga.ID, i+1)
 
-		err := o.db.Transaction(func(tx *gorm.DB) error {
-			return step.Forward(tx)
-		})
+		if d := faults.delayFor(i + 1); d > 0 {
+			time.Sleep(d)
+		}
+
+		sideEffectsApplied, err := o.runForward(step, i+1, faults)
+		o.logAttempt(saga.ID, fmt.Sprintf("F%d", i+1), err)
 		if err != nil {
 			slog.Error("saga step failed", "saga_id", saga.ID, "step", step.Name, "error", err)
 			_ = o.sagaRepo.MarkStepFailed(rec.ID, err.Error())
 			_ = o.sagaRepo.SetStatusWithError(saga.ID, models.SagaStatusRollingBack, err.Error())
 
-			compErr := o.compensateBackward(saga.ID, steps, stepRecords, i-1)
+			// A normal/"before" failure applied no side effects, so compensation
+			// starts at the previous step (i-1). A forced "after" failure
+			// committed the step's side effects, so its own compensator must run
+			// too (start at i).
+			from := i - 1
+			if sideEffectsApplied {
+				from = i
+			}
+			compErr := o.compensateBackward(saga.ID, steps, stepRecords, from, faults)
 			if compErr != nil {
 				_ = o.sagaRepo.SetStatusWithError(saga.ID, models.SagaStatusRollingBack, compErr.Error())
 				return saga.ID, fmt.Errorf("step %s failed: %w; compensation error: %v", step.Name, err, compErr)
@@ -81,11 +123,30 @@ func (o *SagaOrchestrator) Run(sagaType, payload string, steps []SagaStep) (uint
 	return saga.ID, nil
 }
 
-// compensateBackward runs Compensate for every step from index `from` down to 0
-// whose record is currently in completed (or in_progress) state. Compensations
-// run in reverse order. Returns the first compensation error, after attempting
-// the rest.
-func (o *SagaOrchestrator) compensateBackward(sagaID uint, steps []SagaStep, recs []*models.SagaStepRecord, from int) error {
+// runForward executes one forward action, honoring fault injection. It returns
+// whether the step's side effects were applied before the failure (true only for
+// a forced "after" failure) and the error, if any.
+func (o *SagaOrchestrator) runForward(step SagaStep, stepNum int, faults *SagaFaultConfig) (bool, error) {
+	if faults.shouldFailForward(stepNum) && !faults.forceFailAfter() {
+		return false, fmt.Errorf("forced fault: forward F%d failed before side effects", stepNum)
+	}
+	if err := o.db.Transaction(func(tx *gorm.DB) error {
+		return step.Forward(tx)
+	}); err != nil {
+		return false, err
+	}
+	if faults.shouldFailForward(stepNum) && faults.forceFailAfter() {
+		return true, fmt.Errorf("forced fault: forward F%d failed after side effects", stepNum)
+	}
+	return false, nil
+}
+
+// compensateBackward runs Compensate for every step from index `from` down to 0,
+// in reverse order. Each compensator is retried up to maxInlineCompensateAttempts
+// times inline; one that still fails is left marked failed for the retry cron.
+// Every attempt is recorded in the append-only log. Returns the first unrecovered
+// compensation error, after attempting the rest.
+func (o *SagaOrchestrator) compensateBackward(sagaID uint, steps []SagaStep, recs []*models.SagaStepRecord, from int, faults *SagaFaultConfig) error {
 	var firstErr error
 	for i := from; i >= 0; i-- {
 		step := steps[i]
@@ -93,20 +154,41 @@ func (o *SagaOrchestrator) compensateBackward(sagaID uint, steps []SagaStep, rec
 		if step.Compensate == nil {
 			continue
 		}
-		err := o.db.Transaction(func(tx *gorm.DB) error {
-			return step.Compensate(tx)
-		})
-		if err != nil {
-			slog.Error("saga compensation failed", "saga_id", sagaID, "step", step.Name, "error", err)
-			_ = o.sagaRepo.MarkStepFailed(rec.ID, "compensation: "+err.Error())
-			if firstErr == nil {
-				firstErr = err
+		phase := fmt.Sprintf("C%d", i+1)
+
+		var lastErr error
+		compensated := false
+		for attempt := 1; attempt <= maxInlineCompensateAttempts; attempt++ {
+			err := o.runCompensation(step, i+1, faults)
+			o.logAttempt(sagaID, phase, err)
+			if err != nil {
+				lastErr = err
+				slog.Error("saga compensation failed", "saga_id", sagaID, "step", step.Name, "attempt", attempt, "error", err)
+				continue
 			}
-			continue
+			_ = o.sagaRepo.MarkStepCompensated(rec.ID)
+			compensated = true
+			break
 		}
-		_ = o.sagaRepo.MarkStepCompensated(rec.ID)
+		if !compensated {
+			_ = o.sagaRepo.MarkStepFailed(rec.ID, "compensation: "+lastErr.Error())
+			if firstErr == nil {
+				firstErr = lastErr
+			}
+		}
 	}
 	return firstErr
+}
+
+// runCompensation executes one compensator, honoring fault injection. faults is
+// nil outside the test suite, in which case it simply runs the compensator.
+func (o *SagaOrchestrator) runCompensation(step SagaStep, stepNum int, faults *SagaFaultConfig) error {
+	if faults.shouldFailCompensation(stepNum) {
+		return fmt.Errorf("forced fault: compensation C%d failed", stepNum)
+	}
+	return o.db.Transaction(func(tx *gorm.DB) error {
+		return step.Compensate(tx)
+	})
 }
 
 // RetryCompensations re-attempts compensations for a saga stuck in
@@ -142,9 +224,8 @@ func (o *SagaOrchestrator) RetryCompensations(saga *models.SagaTransactionRecord
 			_ = o.sagaRepo.MarkStepCompensated(rec.ID)
 			continue
 		}
-		err := o.db.Transaction(func(tx *gorm.DB) error {
-			return step.Compensate(tx)
-		})
+		err := o.runCompensation(step, i+1, nil)
+		o.logAttempt(saga.ID, fmt.Sprintf("C%d", i+1), err)
 		if err != nil {
 			slog.Error("saga retry compensation failed", "saga_id", saga.ID, "step", step.Name, "error", err)
 			_ = o.sagaRepo.MarkStepFailed(rec.ID, "retry compensation: "+err.Error())


### PR DESCRIPTION
Implements the SAGA.md test spec for the OTC option-exercise saga.

Tests (internal/handler/saga_exercise_test.go), all HTTP-level:
- SG-01 happy path; SG-02 a-d pre-saga validation; SG-03/04 F1/F2 resource failures; SG-05/06/07 forced F3/F4/F5 failures; SG-08 compensator fail-then-succeed. Each asserts invariants I1-I6 and the literal log shape.

Product changes:
- X-Saga-* fault-injection hooks, gated by SAGA_FAULT_HOOKS; the service refuses to boot with the flag set in a release APP_ENV.
- Append-only saga attempt log (saga_step_attempts), exposed as `log` in the saga GET response, giving the spec's {phase: outcome} sequence.
- Bounded inline compensation retry so a transient compensator failure heals within the request; the retry cron remains the backstop.

The production path is unchanged when faults are nil. SG-09/10/11 are out of scope (need Toxiproxy / docker pause-kill against a separate bank service).