### PR TITLE
exchange: allow buyer-coordinated OTC accept (spec §3.6)

### DIFF
--- a/exchange-service/internal/interbank/negotiations_accept.go
+++ b/exchange-service/internal/interbank/negotiations_accept.go
@@ -2,6 +2,7 @@ package interbank
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -69,9 +70,16 @@ func (h *NegotiationsHandler) accept(w http.ResponseWriter, r *http.Request, rou
 		writeProblemJSON(w, http.StatusConflict, "negotiation is no longer ongoing")
 		return
 	}
-	if neg.LocalRole != models.InterbankNegotiationRoleSeller {
-		writeProblemJSON(w, http.StatusForbidden,
-			"only the seller's bank may accept — the buyer's bank cannot self-accept")
+	// Per spec §3.6 the party "whose negotiation term it is" may accept the
+	// other side's offer — and that can be the buyer OR the seller,
+	// alternating by turn (§3.3). The accepting bank sends us this GET
+	// /accept, so the CALLER is the acceptor. Authorise by turn (the
+	// acceptor must not have made the last move), NOT by role. Whichever
+	// side WE are, runAcceptDispatch coordinates the settlement as "the
+	// other bank" the spec hands the transaction to.
+	if !callerMayCounter(neg, partner) {
+		writeProblemJSON(w, http.StatusConflict,
+			"not your turn to accept — the other party moves next")
 		return
 	}
 
@@ -142,28 +150,48 @@ func (h *NegotiationsHandler) runAcceptDispatch(ctx context.Context, neg *models
 	// second accept from double-dispatching. If the seller can't back the
 	// option, we abort before dispatch — the negotiation stays open so the
 	// participants can renegotiate.
-	reservedHoldingID, err := h.closeAndReserveSeller(neg)
+	// Close the negotiation AND reserve OUR side's resource backing the
+	// option, atomically. Which resource depends on the role WE play —
+	// §3.6 lets either party accept, so the coordinator (us, "the other
+	// bank") can be the seller OR the buyer:
+	//   - seller: reserve the seller's stock (§2.7.2)
+	//   - buyer:  reserve the buyer's cash premium
+	// Closing first stops a concurrent second accept from
+	// double-dispatching. If we can't back our side, abort before
+	// dispatch — the negotiation stays open for renegotiation.
+	isSeller := neg.LocalRole == models.InterbankNegotiationRoleSeller
+	var reservedHoldingID *uint
+	var err error
+	if isSeller {
+		reservedHoldingID, err = h.closeAndReserveSeller(neg)
+	} else {
+		err = h.closeAndReserveBuyerPremium(neg)
+	}
 	if err != nil {
-		slog.Warn("interbank: accept aborted — could not reserve seller stock",
-			"err", err, "negotiation", neg.NegotiationID)
-		return AcceptOutcome{DispatchErr: fmt.Errorf("reserving seller stock: %w", err)}
+		slog.Warn("interbank: accept aborted — could not reserve local resource",
+			"err", err, "role", neg.LocalRole, "negotiation", neg.NegotiationID)
+		return AcceptOutcome{DispatchErr: fmt.Errorf("reserving local resource: %w", err)}
 	}
 
 	tx := buildOptionAcceptanceTx(h.registry.OwnRoutingNumber(), neg)
 	txKey := h.client.NewIdempotenceKey()
-	buyerCode := RoutingNumber(neg.BuyerRoutingNumber)
+	// NEW_TX always goes to the OTHER bank in the negotiation.
+	// CounterpartyRoutingNumber captures "the other bank" for both roles
+	// (and equals BuyerRoutingNumber on seller-role rows, so this is
+	// behaviour-preserving for the pre-existing seller path).
+	counterpartyCode := RoutingNumber(neg.CounterpartyRoutingNumber)
 
-	vote, err := h.client.SendNewTx(ctx, buyerCode, txKey, &tx)
+	vote, err := h.client.SendNewTx(ctx, counterpartyCode, txKey, &tx)
 	if err != nil {
 		slog.Error("interbank: NEW_TX dispatch failed during accept",
-			"err", err, "negotiation", neg.NegotiationID, "buyer", buyerCode)
-		// We don't know whether the buyer processed the NEW_TX and voted
-		// YES (reserving the premium) before the response was lost. Send a
-		// best-effort ROLLBACK_TX so any premium the buyer reserved is
-		// released — it's a no-op at the buyer if they never saw the
-		// NEW_TX. Then release our own reservation and reopen.
-		h.bestEffortRollback(buyerCode, tx.TransactionID, neg.NegotiationID)
-		h.releaseSellerReservation(neg, reservedHoldingID)
+			"err", err, "negotiation", neg.NegotiationID, "counterparty", counterpartyCode)
+		// We don't know whether the counterparty processed the NEW_TX and
+		// voted YES (reserving its resources) before the response was lost.
+		// Send a best-effort ROLLBACK_TX so anything it reserved is
+		// released — it's a no-op there if they never saw the NEW_TX. Then
+		// release our own reservation and reopen.
+		h.bestEffortRollback(counterpartyCode, tx.TransactionID, neg.NegotiationID)
+		h.releaseLocalReservation(neg, isSeller, reservedHoldingID)
 		h.reopenAfterDispatchFailure(neg.NegotiationRoutingNumber, neg.NegotiationID,
 			neg.LastModifiedByRoutingNumber, neg.LastModifiedByID)
 		return AcceptOutcome{DispatchErr: err}
@@ -175,8 +203,8 @@ func (h *NegotiationsHandler) runAcceptDispatch(ctx context.Context, neg *models
 		// bank holds no resources after a NO. Release our reservation
 		// and reopen so participants can keep going.
 		slog.Info("interbank: NEW_TX received NO vote during accept",
-			"negotiation", neg.NegotiationID, "buyer", buyerCode, "reasons", vote.Reasons)
-		h.releaseSellerReservation(neg, reservedHoldingID)
+			"negotiation", neg.NegotiationID, "counterparty", counterpartyCode, "reasons", vote.Reasons)
+		h.releaseLocalReservation(neg, isSeller, reservedHoldingID)
 		h.reopenAfterDispatchFailure(neg.NegotiationRoutingNumber, neg.NegotiationID,
 			neg.LastModifiedByRoutingNumber, neg.LastModifiedByID)
 		return AcceptOutcome{Vote: vote}
@@ -195,21 +223,29 @@ func (h *NegotiationsHandler) runAcceptDispatch(ctx context.Context, neg *models
 	}
 
 	commitKey := h.client.NewIdempotenceKey()
-	if err := h.client.SendCommitTx(ctx, buyerCode, commitKey, tx.TransactionID); err != nil {
+	if err := h.client.SendCommitTx(ctx, counterpartyCode, commitKey, tx.TransactionID); err != nil {
 		slog.Error("interbank: COMMIT_TX dispatch failed after YES vote; reconcile cron will resend",
-			"err", err, "negotiation", neg.NegotiationID, "transaction", tx.TransactionID.ID, "buyer", buyerCode)
+			"err", err, "negotiation", neg.NegotiationID, "transaction", tx.TransactionID.ID, "counterparty", counterpartyCode)
 		return AcceptOutcome{Vote: vote, CommitErr: err}
 	}
 
-	// COMMIT_TX succeeded — credit our seller and stamp the accept as
-	// finalised in one transaction so the credit lands exactly once even
+	// COMMIT_TX succeeded — apply OUR side's local effect and stamp the
+	// accept as finalised in one transaction so it lands exactly once even
 	// if the cron also runs. A failure here is reported via CommitErr; the
-	// cron retries (idempotent COMMIT_TX + CAS-guarded credit).
-	if err := FinaliseAcceptCommit(h.db, h.walletRepo, h.repo, neg); err != nil {
-		slog.Error("interbank: seller credit / finalise failed after COMMIT_TX; cron will retry",
-			"err", err, "negotiation", neg.NegotiationID, "transaction", tx.TransactionID.ID,
-			"seller", neg.SellerID, "currency", neg.PremiumCurrency, "amount", neg.PremiumAmount)
-		return AcceptOutcome{Vote: vote, CommitErr: fmt.Errorf("local seller credit failed after commit: %w", err)}
+	// cron retries (idempotent COMMIT_TX + CAS-guarded finalise).
+	//   - seller: credit the seller's premium
+	//   - buyer:  debit the buyer's premium + materialise the option contract
+	var finErr error
+	if isSeller {
+		finErr = FinaliseAcceptCommit(h.db, h.walletRepo, h.repo, neg)
+	} else {
+		finErr = FinaliseBuyerAcceptCommit(h.db, h.walletRepo, h.repo, neg)
+	}
+	if finErr != nil {
+		slog.Error("interbank: local credit / finalise failed after COMMIT_TX; cron will retry",
+			"err", finErr, "role", neg.LocalRole, "negotiation", neg.NegotiationID, "transaction", tx.TransactionID.ID,
+			"currency", neg.PremiumCurrency, "amount", neg.PremiumAmount)
+		return AcceptOutcome{Vote: vote, CommitErr: fmt.Errorf("local finalise failed after commit: %w", finErr)}
 	}
 
 	return AcceptOutcome{Vote: vote}
@@ -249,6 +285,77 @@ func FinaliseAcceptCommit(
 			return nil
 		}
 		return walletRepo.Credit(tx, neg.SellerID, neg.PremiumCurrency, neg.PremiumAmount)
+	})
+}
+
+// FinaliseBuyerAcceptCommit is the buyer-coordinator analogue of
+// FinaliseAcceptCommit. After our buyer-side accept dispatched a NEW_TX to
+// the seller's bank and COMMIT_TX landed, it debits the buyer's reserved
+// premium and materialises the local option contract (the buyer holds the
+// option), atomically and exactly-once. The CAS on AcceptCommitFinalisedAt
+// guards against double-apply across the inline accept path and the
+// reconcile cron. For bank-side buyers (no client wallet) the premium
+// debit is skipped but the contract + stamp still land. A nil db/negRepo
+// is a silent no-op (older test wiring). Shared by negotiations_accept.go
+// and the reconcile cron, mirroring FinaliseAcceptCommit.
+func FinaliseBuyerAcceptCommit(
+	db *gorm.DB,
+	walletRepo *repository.InterbankWalletRepository,
+	negRepo *repository.InterbankOtcRepository,
+	neg *models.InterbankOtcNegotiation,
+) error {
+	if db == nil || negRepo == nil {
+		return nil
+	}
+	return db.Transaction(func(tx *gorm.DB) error {
+		won, err := negRepo.MarkAcceptCommitFinalisedCASTx(tx, neg.NegotiationRoutingNumber, neg.NegotiationID)
+		if err != nil {
+			return err
+		}
+		if won == 0 {
+			// Already finalised by a concurrent caller — don't re-apply.
+			return nil
+		}
+		// Materialise the local option contract (we, the buyer, hold it)
+		// idempotently — the CAS above serialises, but the row may already
+		// exist from a partially-applied earlier attempt.
+		var existing models.InterbankOptionContract
+		err = tx.Where("negotiation_routing_number = ? AND negotiation_id = ?",
+			neg.NegotiationRoutingNumber, neg.NegotiationID).First(&existing).Error
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			now := time.Now().UTC()
+			if err := tx.Create(&models.InterbankOptionContract{
+				NegotiationRoutingNumber: neg.NegotiationRoutingNumber,
+				NegotiationID:            neg.NegotiationID,
+				BuyerLocalID:             neg.BuyerID,
+				SellerRoutingNumber:      neg.SellerRoutingNumber,
+				SellerID:                 neg.SellerID,
+				StockTicker:              neg.StockTicker,
+				Amount:                   neg.Amount,
+				PricePerUnitCurrency:     neg.PricePerUnitCurrency,
+				PricePerUnitAmount:       neg.PricePerUnitAmount,
+				PremiumCurrency:          neg.PremiumCurrency,
+				PremiumAmount:            neg.PremiumAmount,
+				SettlementDate:           neg.SettlementDate,
+				Status:                   models.InterbankOptionContractStatusValid,
+				CreatedAt:                now,
+				UpdatedAt:                now,
+			}).Error; err != nil {
+				return err
+			}
+		}
+		// Debit the buyer's reserved premium (only client buyers hold a
+		// local wallet; bank-side buyers reserved nothing).
+		if walletRepo == nil {
+			return nil
+		}
+		if buyerType, _, derr := DecodeLocalParticipantID(neg.BuyerID); derr != nil || buyerType != LocalParticipantClient {
+			return nil
+		}
+		return walletRepo.Debit(tx, neg.BuyerID, neg.PremiumCurrency, neg.PremiumAmount)
 	})
 }
 
@@ -343,6 +450,66 @@ func (h *NegotiationsHandler) releaseSellerReservation(neg *models.InterbankOtcN
 	}); err != nil {
 		slog.Error("interbank: releasing seller reservation after failed accept",
 			"err", err, "negotiation", neg.NegotiationID, "holding", *holdingID)
+	}
+}
+
+// releaseLocalReservation undoes whatever closeAndReserve* took, branching
+// on the role we coordinated as. Best-effort; failures are logged by the
+// underlying release.
+func (h *NegotiationsHandler) releaseLocalReservation(neg *models.InterbankOtcNegotiation, isSeller bool, holdingID *uint) {
+	if isSeller {
+		h.releaseSellerReservation(neg, holdingID)
+		return
+	}
+	h.releaseBuyerPremium(neg)
+}
+
+// closeAndReserveBuyerPremium is the buyer-coordinator analogue of
+// closeAndReserveSeller: it closes the negotiation and reserves the
+// buyer's cash premium (raspolozivo_stanje) atomically, so the option
+// contract we're about to form is backed by held funds. A non-nil error
+// (e.g. insufficient funds) means the caller must NOT dispatch and the
+// negotiation stays open. For bank-side buyers (no client wallet) or test
+// wiring without a wallet repo, it just closes without reserving.
+func (h *NegotiationsHandler) closeAndReserveBuyerPremium(neg *models.InterbankOtcNegotiation) error {
+	if h.db == nil || h.walletRepo == nil {
+		return h.repo.MarkClosed(neg.NegotiationRoutingNumber, neg.NegotiationID)
+	}
+	buyerType, _, err := DecodeLocalParticipantID(neg.BuyerID)
+	if err != nil || buyerType != LocalParticipantClient {
+		return h.repo.MarkClosed(neg.NegotiationRoutingNumber, neg.NegotiationID)
+	}
+	return h.db.Transaction(func(dbtx *gorm.DB) error {
+		if err := h.walletRepo.Reserve(dbtx, neg.BuyerID, neg.PremiumCurrency, neg.PremiumAmount); err != nil {
+			return err
+		}
+		return dbtx.Model(&models.InterbankOtcNegotiation{}).
+			Where("negotiation_routing_number = ? AND negotiation_id = ?",
+				neg.NegotiationRoutingNumber, neg.NegotiationID).
+			Updates(map[string]interface{}{
+				"is_ongoing": false,
+				"updated_at": time.Now().UTC(),
+			}).Error
+	})
+}
+
+// releaseBuyerPremium refunds the reservation taken by
+// closeAndReserveBuyerPremium when a buyer-coordinated dispatch fails or
+// the seller's bank votes NO. Best-effort: a failure here is logged, not
+// surfaced — the settlement-expiry sweep is the backstop.
+func (h *NegotiationsHandler) releaseBuyerPremium(neg *models.InterbankOtcNegotiation) {
+	if h.db == nil || h.walletRepo == nil {
+		return
+	}
+	buyerType, _, err := DecodeLocalParticipantID(neg.BuyerID)
+	if err != nil || buyerType != LocalParticipantClient {
+		return
+	}
+	if err := h.db.Transaction(func(dbtx *gorm.DB) error {
+		return h.walletRepo.Release(dbtx, neg.BuyerID, neg.PremiumCurrency, neg.PremiumAmount)
+	}); err != nil {
+		slog.Error("interbank: releasing buyer premium after failed accept",
+			"err", err, "negotiation", neg.NegotiationID)
 	}
 }
 

--- a/exchange-service/internal/service/interbank_reconcile.go
+++ b/exchange-service/internal/service/interbank_reconcile.go
@@ -150,21 +150,34 @@ func (r *InterbankReconcileRunner) runAcceptCommits(ctx context.Context, thresho
 }
 
 func (r *InterbankReconcileRunner) reconcileAcceptCommit(ctx context.Context, neg *models.InterbankOtcNegotiation) {
-	buyerCode := interbank.RoutingNumber(neg.BuyerRoutingNumber)
+	// COMMIT_TX goes to the OTHER bank. CounterpartyRoutingNumber is "the
+	// other bank" for both seller- and buyer-coordinated accepts (and
+	// equals BuyerRoutingNumber on seller-role rows, so this is
+	// behaviour-preserving for the pre-existing seller path).
+	counterpartyCode := interbank.RoutingNumber(neg.CounterpartyRoutingNumber)
 	txID := interbank.ForeignBankId{
 		RoutingNumber: interbank.RoutingNumber(neg.AcceptTxRoutingNumber),
 		ID:            neg.AcceptTxID,
 	}
 	key := r.client.NewIdempotenceKey()
-	if err := r.client.SendCommitTx(ctx, buyerCode, key, txID); err != nil {
+	if err := r.client.SendCommitTx(ctx, counterpartyCode, key, txID); err != nil {
 		slog.Info("interbank reconcile: accept COMMIT_TX resend transient failure",
 			"err", err, "negotiation", neg.NegotiationID, "tx_id", neg.AcceptTxID)
 		r.bumpNegotiationUpdatedAt(neg)
 		return
 	}
-	if err := interbank.FinaliseAcceptCommit(r.db, r.otcWalletRepo, r.negRepo, neg); err != nil {
-		slog.Error("interbank reconcile: seller credit / finalise failed after accept COMMIT_TX resend",
-			"err", err, "negotiation", neg.NegotiationID, "tx_id", neg.AcceptTxID)
+	// Apply OUR side's local effect, branching on the role we coordinated
+	// as: seller credit, or buyer debit + option-contract creation. Both
+	// are CAS-guarded so this is safe alongside the inline accept path.
+	var finErr error
+	if neg.LocalRole == models.InterbankNegotiationRoleSeller {
+		finErr = interbank.FinaliseAcceptCommit(r.db, r.otcWalletRepo, r.negRepo, neg)
+	} else {
+		finErr = interbank.FinaliseBuyerAcceptCommit(r.db, r.otcWalletRepo, r.negRepo, neg)
+	}
+	if finErr != nil {
+		slog.Error("interbank reconcile: local credit / finalise failed after accept COMMIT_TX resend",
+			"err", finErr, "role", neg.LocalRole, "negotiation", neg.NegotiationID, "tx_id", neg.AcceptTxID)
 		return
 	}
 	slog.Info("interbank reconcile: accept COMMIT_TX resent and finalised",

--- a/exchange-service/internal/service/interbank_reconcile_accept_buyer_test.go
+++ b/exchange-service/internal/service/interbank_reconcile_accept_buyer_test.go
@@ -1,0 +1,151 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// TestReconcileAcceptCommit_BuyerCoordinator covers the buyer-coordinated
+// accept crash-recovery path added for spec §3.6 ("the party whose turn it
+// is may accept" — that can be the buyer). A buyer-role negotiation that
+// got a YES vote but never confirmed its COMMIT_TX must, on reconcile:
+//   - resend COMMIT_TX to the SELLER's bank (the counterparty), and
+//   - debit the buyer's reserved premium + materialise the local option
+//     contract (the buyer holds the option), exactly once.
+//
+// It is the mirror of TestReconcileAcceptCommit_ResendsAndCredits, which
+// covers the seller-coordinated direction.
+func TestReconcileAcceptCommit_BuyerCoordinator(t *testing.T) {
+	db := openSagaTestDB(t, "ib_recon_accept_commit_buyer")
+
+	// Buyer client-1 (ours) has an RSD account holding 100, with 50 already
+	// reserved (raspolozivo decremented) at accept time. COMMIT debits the
+	// 50 premium from stanje, leaving (stanje 50, raspolozivo 50).
+	if err := db.Exec(`INSERT INTO accounts (id, broj_racuna, currency_id, status, stanje, raspolozivo_stanje, client_id)
+		VALUES (1, '333000000000000001', 1, 'aktivan', 100, 50, 1)`).Error; err != nil {
+		t.Fatalf("seed account: %v", err)
+	}
+
+	// Stub seller's bank (the counterparty, routing 555): any POST
+	// /interbank (the COMMIT_TX) → 204.
+	var commitHits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&commitHits, 1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	partnersJSON := fmt.Sprintf(
+		`[{"code":555,"baseUrl":"%s","outboundKey":"out-key","inboundKey":"in-key","displayName":"Seller Bank"}]`,
+		srv.URL)
+	registry, err := interbank.NewRegistryFromJSON(333, partnersJSON)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	client := interbank.NewClient(registry)
+	negRepo := repository.NewInterbankOtcRepository(db)
+
+	// Buyer-role negotiation: we (333) are the buyer, partner 555 the seller.
+	// The negotiation key is the seller's coordinates (555/neg-buy-1). YES
+	// vote recorded, commit never finalised.
+	neg := &models.InterbankOtcNegotiation{
+		NegotiationRoutingNumber:    555,
+		NegotiationID:               "neg-buy-1",
+		LocalRole:                   models.InterbankNegotiationRoleBuyer,
+		CounterpartyRoutingNumber:   555,
+		BuyerRoutingNumber:          333,
+		BuyerID:                     "client-1",
+		SellerRoutingNumber:         555,
+		SellerID:                    "client-7",
+		StockTicker:                 "ACME",
+		Amount:                      3,
+		PricePerUnitCurrency:        "RSD",
+		PricePerUnitAmount:          10,
+		PremiumCurrency:             "RSD",
+		PremiumAmount:               50,
+		SettlementDate:              time.Now().UTC().Format(time.RFC3339),
+		LastModifiedByRoutingNumber: 555,
+		LastModifiedByID:            "client-7",
+		IsOngoing:                   false,
+		AcceptTxRoutingNumber:       333,
+		AcceptTxID:                  "acc-tx-buy-1",
+	}
+	if err := negRepo.Create(neg); err != nil {
+		t.Fatalf("create negotiation: %v", err)
+	}
+	past := time.Now().UTC().Add(-time.Hour)
+	if err := db.Model(&models.InterbankOtcNegotiation{}).Where("id = ?", neg.ID).
+		Update("updated_at", past).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewInterbankReconcileRunner(
+		db, registry, client,
+		repository.NewInterbankPaymentRepository(db),
+		repository.NewInterbankPaymentWalletRepository(db),
+		repository.NewInterbankExerciseRepository(db),
+		repository.NewInterbankWalletRepository(db),
+		negRepo,
+	).WithStaleness(time.Minute)
+
+	r.Run()
+
+	// COMMIT_TX resent to the seller's bank exactly once.
+	if got := atomic.LoadInt32(&commitHits); got != 1 {
+		t.Fatalf("COMMIT_TX sent %d times, want 1", got)
+	}
+
+	// Negotiation finalised.
+	got, _ := negRepo.Get(555, "neg-buy-1")
+	if got.AcceptCommitFinalisedAt == nil {
+		t.Fatal("accept_commit_finalised_at not stamped")
+	}
+
+	// Buyer debited the 50 premium from stanje only (raspolozivo was already
+	// decremented at reserve time, so it is unchanged at 50).
+	var acc struct {
+		Stanje      float64 `gorm:"column:stanje"`
+		Raspolozivo float64 `gorm:"column:raspolozivo_stanje"`
+	}
+	if err := db.Table("accounts").Select("stanje, raspolozivo_stanje").Where("id = 1").Scan(&acc).Error; err != nil {
+		t.Fatal(err)
+	}
+	if acc.Stanje != 50 || acc.Raspolozivo != 50 {
+		t.Fatalf("buyer account = (stanje %v, raspolozivo %v), want (50, 50)", acc.Stanje, acc.Raspolozivo)
+	}
+
+	// Local option contract materialised with us on the buyer side.
+	var contract models.InterbankOptionContract
+	if err := db.Where("negotiation_routing_number = ? AND negotiation_id = ?", 555, "neg-buy-1").
+		First(&contract).Error; err != nil {
+		t.Fatalf("option contract not created: %v", err)
+	}
+	if contract.BuyerLocalID != "client-1" {
+		t.Fatalf("option contract BuyerLocalID = %q, want client-1", contract.BuyerLocalID)
+	}
+	if contract.Amount != 3 || contract.PremiumAmount != 50 || contract.Status != models.InterbankOptionContractStatusValid {
+		t.Fatalf("option contract terms = (amount %v, premium %v, status %q), want (3, 50, valid)",
+			contract.Amount, contract.PremiumAmount, contract.Status)
+	}
+
+	// Second run is a no-op: already finalised, no further COMMIT_TX and no
+	// double-debit.
+	r.Run()
+	if got := atomic.LoadInt32(&commitHits); got != 1 {
+		t.Fatalf("COMMIT_TX re-sent after finalise; total %d, want 1", got)
+	}
+	if err := db.Table("accounts").Select("stanje, raspolozivo_stanje").Where("id = 1").Scan(&acc).Error; err != nil {
+		t.Fatal(err)
+	}
+	if acc.Stanje != 50 {
+		t.Fatalf("buyer stanje double-debited on second run: %v, want 50", acc.Stanje)
+	}
+}


### PR DESCRIPTION
Per si-tx-proto §3.6 the party whose turn it is may accept the other side's offer — that can be the buyer, not only the seller. The accepting bank sends GET /negotiations/{r}/{id}/accept to the other bank, which forms and submits the settlement transaction. Our inbound accept handler previously rejected this with 403 ("only the seller's bank may accept") whenever we were the buyer, so a partner-seller accepting our offer could never settle.

- accept(): authorize by turn (§3.3) instead of role; wrong turn now returns 409, not a blanket 403.
- runAcceptDispatch(): coordinate as either role. Dispatch to CounterpartyRoutingNumber (== buyer on seller-rows, so the seller path is behaviour-preserving) and branch the local effect — seller credits premium / reserves stock; buyer reserves+debits premium and materialises the option contract.
- New FinaliseBuyerAcceptCommit (CAS-guarded, exactly-once) plus closeAndReserveBuyerPremium / releaseBuyerPremium helpers.
- reconcileAcceptCommit: made role-aware so the crash-recovery cron can't misfire on buyer-coordinated rows.
- Test: TestReconcileAcceptCommit_BuyerCoordinator.