### PR TITLE
feat(exchange): quarterly dividend payout + OTC negotiation history

### DIFF
--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -94,6 +94,9 @@ func main() {
 	fundRepo := repository.NewFundRepository(db)
 	fundSvc := service.NewFundService(fundRepo, portfolioRepo, marketRepo, orderRepo, rateProvider)
 
+	dividendRepo := repository.NewDividendRepository(db)
+	dividendSvc := service.NewDividendService(dividendRepo, orderRepo, taxSvc, rateProvider)
+
 	// Inter-bank protocol wiring (Celina 5). The registry parses
 	// PARTNER_BANKS_JSON at startup and is the routing/auth source of
 	// truth for every /interbank request, inbound or outbound.
@@ -132,7 +135,8 @@ func main() {
 
 	emailSvc := service.NewSMTPEmailService(cfg.SMTPHost, cfg.SMTPPort, cfg.SMTPFrom)
 	notifier := notify.NewClient(cfg.NotificationServiceURL, cfg.InternalAPIKey)
-	cronScheduler := service.StartCronJobs(db, portfolioSvc, rateProvider, sagaRetryRunner, fundSvc, ibReconcile, ibPublicStockCache, emailSvc, notifier)
+	dividendSvc = dividendSvc.WithNotifier(notifier)
+	cronScheduler := service.StartCronJobs(db, portfolioSvc, rateProvider, sagaRetryRunner, fundSvc, dividendSvc, ibReconcile, ibPublicStockCache, emailSvc, notifier)
 
 	go func() {
 		slog.Info("Running market data seed in background...")
@@ -150,7 +154,7 @@ func main() {
 
 	orderSvc := service.NewOrderService(orderRepo, marketRepo, rateProvider).WithNotifier(notifier)
 	orderH := handler.NewOrderHTTPHandler(cfg, orderSvc, db).WithFundService(fundSvc).WithNotifier(notifier)
-	portfolioH := handler.NewPortfolioHTTPHandler(cfg, portfolioSvc)
+	portfolioH := handler.NewPortfolioHTTPHandler(cfg, portfolioSvc).WithDividendService(dividendSvc)
 	otcSvc := service.NewOtcService(portfolioRepo, otcRepo).WithOrchestrator(sagaOrchestrator).WithNotifier(notifier)
 	otcH := handler.NewOtcHTTPHandler(cfg, otcSvc).WithSagaQuerier(sagaRepo)
 

--- a/exchange-service/internal/database/database.go
+++ b/exchange-service/internal/database/database.go
@@ -47,6 +47,8 @@ func Migrate(db *gorm.DB) error {
 			&models.PortfolioHoldingRecord{},
 			&models.OtcOfferRecord{},
 			&models.OtcContractRecord{},
+			&models.OtcNegotiationEntryRecord{},
+			&models.DividendPayoutRecord{},
 			&models.TaxRecord{},
 			&models.SagaTransactionRecord{},
 			&models.SagaStepRecord{},

--- a/exchange-service/internal/handler/otc_http_handler.go
+++ b/exchange-service/internal/handler/otc_http_handler.go
@@ -45,6 +45,23 @@ func (h *OtcHTTPHandler) OtcRoutes(w http.ResponseWriter, r *http.Request) {
 	parts := strings.Split(path, "/")
 
 	switch {
+	case len(parts) == 1 && parts[0] == "negotiations":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.listNegotiations(w, r)
+	case len(parts) == 3 && parts[0] == "offers" && parts[2] == "history":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		offerID, err := strconv.ParseUint(parts[1], 10, 64)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"message": "invalid offer id"})
+			return
+		}
+		h.negotiationHistory(w, r, uint(offerID))
 	case len(parts) == 1 && parts[0] == "public-stocks":
 		if r.Method != http.MethodGet {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -493,6 +510,141 @@ func (h *OtcHTTPHandler) counterOffer(w http.ResponseWriter, r *http.Request, of
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{"offer": otcOfferToResponse(*offer)})
+}
+
+// listNegotiations handles GET /api/v1/otc/negotiations — the caller's
+// negotiation history with optional status / from / to / counterparty filters.
+func (h *OtcHTTPHandler) listNegotiations(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+
+	userID, userType := callerIdentity(claims)
+	q := r.URL.Query()
+	status := strings.TrimSpace(q.Get("status"))
+	from := parseHistoryDate(q.Get("from"), false)
+	to := parseHistoryDate(q.Get("to"), true)
+	var counterpartyID uint
+	if raw := strings.TrimSpace(q.Get("counterparty")); raw != "" {
+		if v, err := strconv.ParseUint(raw, 10, 64); err == nil {
+			counterpartyID = uint(v)
+		}
+	}
+
+	offers, err := h.svc.ListNegotiations(userID, userType, status, from, to, counterpartyID)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+
+	items := make([]otcOfferResponse, 0, len(offers))
+	for _, offer := range offers {
+		items = append(items, otcOfferToResponse(offer))
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"negotiations": items,
+		"count":        len(items),
+		"status":       status,
+	})
+}
+
+// negotiationHistory handles GET /api/v1/otc/offers/{id}/history — the full
+// counter-offer timeline for one offer (participant only).
+func (h *OtcHTTPHandler) negotiationHistory(w http.ResponseWriter, r *http.Request, offerID uint) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+
+	userID, userType := callerIdentity(claims)
+	offer, entries, err := h.svc.GetNegotiationHistory(offerID, userID, userType)
+	if err != nil {
+		if errors.Is(err, service.ErrOtcOfferNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"message": "offer not found"})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to load negotiation history"})
+		return
+	}
+
+	items := make([]negotiationEntryResponse, 0, len(entries))
+	for _, e := range entries {
+		items = append(items, negotiationEntryToResponse(e))
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"offer":   otcOfferToResponse(*offer),
+		"entries": items,
+		"count":   len(items),
+	})
+}
+
+// parseHistoryDate parses a YYYY-MM-DD (or RFC3339) query param. When endOfDay
+// is true a bare date is bumped to 23:59:59 so an inclusive `to` filter covers
+// the whole day. Returns nil for empty/invalid input.
+func parseHistoryDate(raw string, endOfDay bool) *time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		u := t.UTC()
+		return &u
+	}
+	if t, err := time.Parse("2006-01-02", raw); err == nil {
+		if endOfDay {
+			t = t.Add(24*time.Hour - time.Second)
+		}
+		u := t.UTC()
+		return &u
+	}
+	return nil
+}
+
+type negotiationEntryResponse struct {
+	ID                 uint     `json:"id"`
+	OfferID            uint     `json:"offerId"`
+	Action             string   `json:"action"`
+	ActorID            uint     `json:"actorId"`
+	ActorType          string   `json:"actorType"`
+	Amount             float64  `json:"amount"`
+	PricePerStock      float64  `json:"pricePerStock"`
+	Premium            float64  `json:"premium"`
+	SettlementDate     string   `json:"settlementDate"`
+	PrevAmount         *float64 `json:"prevAmount,omitempty"`
+	PrevPricePerStock  *float64 `json:"prevPricePerStock,omitempty"`
+	PrevPremium        *float64 `json:"prevPremium,omitempty"`
+	PrevSettlementDate *string  `json:"prevSettlementDate,omitempty"`
+	CreatedAt          string   `json:"createdAt"`
+}
+
+func negotiationEntryToResponse(e models.OtcNegotiationEntryRecord) negotiationEntryResponse {
+	resp := negotiationEntryResponse{
+		ID:                e.ID,
+		OfferID:           e.OfferID,
+		Action:            e.Action,
+		ActorID:           e.ActorID,
+		ActorType:         e.ActorType,
+		Amount:            e.Amount,
+		PricePerStock:     e.PricePerStock,
+		Premium:           e.Premium,
+		SettlementDate:    e.SettlementDate.UTC().Format("2006-01-02"),
+		PrevAmount:        e.PrevAmount,
+		PrevPricePerStock: e.PrevPricePerStock,
+		PrevPremium:       e.PrevPremium,
+		CreatedAt:         e.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if e.PrevSettlementDate != nil {
+		s := e.PrevSettlementDate.UTC().Format("2006-01-02")
+		resp.PrevSettlementDate = &s
+	}
+	return resp
 }
 
 type publicOtcStockResponse struct {

--- a/exchange-service/internal/handler/portfolio_http_handler.go
+++ b/exchange-service/internal/handler/portfolio_http_handler.go
@@ -16,10 +16,17 @@ import (
 type PortfolioHTTPHandler struct {
 	cfg          *config.Config
 	portfolioSvc *service.PortfolioService
+	dividendSvc  *service.DividendService
 }
 
 func NewPortfolioHTTPHandler(cfg *config.Config, portfolioSvc *service.PortfolioService) *PortfolioHTTPHandler {
 	return &PortfolioHTTPHandler{cfg: cfg, portfolioSvc: portfolioSvc}
+}
+
+// WithDividendService wires the dividend history / manual-run endpoints.
+func (h *PortfolioHTTPHandler) WithDividendService(d *service.DividendService) *PortfolioHTTPHandler {
+	h.dividendSvc = d
+	return h
 }
 
 // PortfolioCollection handles GET /api/v1/portfolio — summary view.
@@ -57,6 +64,12 @@ func (h *PortfolioHTTPHandler) PortfolioRoutes(w http.ResponseWriter, r *http.Re
 	}
 
 	parts := strings.Split(path, "/")
+
+	// /api/v1/portfolio/dividends[/run]
+	if parts[0] == "dividends" {
+		h.dividendRoutes(w, r, parts)
+		return
+	}
 
 	// /api/v1/portfolio/holdings
 	if parts[0] != "holdings" {
@@ -222,6 +235,116 @@ func (h *PortfolioHTTPHandler) setPublic(w http.ResponseWriter, r *http.Request,
 		"reservedQuantity": updated.ReservedQuantity,
 		"availableForOtc":  updated.AvailableForOTC(),
 	})
+}
+
+// dividendRoutes handles /api/v1/portfolio/dividends and .../dividends/run.
+func (h *PortfolioHTTPHandler) dividendRoutes(w http.ResponseWriter, r *http.Request, parts []string) {
+	if h.dividendSvc == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"message": "dividends unavailable"})
+		return
+	}
+	switch {
+	case len(parts) == 1 && r.Method == http.MethodGet:
+		h.listDividends(w, r)
+	case len(parts) == 2 && parts[1] == "run" && r.Method == http.MethodPost:
+		h.runDividends(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// listDividends returns the caller's own dividend payout history.
+func (h *PortfolioHTTPHandler) listDividends(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireTradingAccessHTTP(w, claims) {
+		return
+	}
+
+	userID, userType := callerIdentity(claims)
+	var assetID uint
+	if raw := strings.TrimSpace(r.URL.Query().Get("assetId")); raw != "" {
+		if v, err := strconv.ParseUint(raw, 10, 64); err == nil {
+			assetID = uint(v)
+		}
+	}
+
+	payouts, err := h.dividendSvc.ListPayoutsForUser(userID, userType, assetID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "failed to load dividends"})
+		return
+	}
+
+	items := make([]dividendResponse, 0, len(payouts))
+	for _, p := range payouts {
+		items = append(items, dividendToResponse(p))
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"dividends": items, "count": len(items)})
+}
+
+// runDividends triggers a dividend distribution on demand (supervisor only).
+// Useful for demos/recovery; the cron normally runs it quarterly. Idempotent per
+// quarter, so a manual run after the automatic one is a no-op.
+func (h *PortfolioHTTPHandler) runDividends(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !isSupervisor(claims) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"message": "supervisor access required"})
+		return
+	}
+
+	res, err := h.dividendSvc.DistributeForDate(time.Now().UTC())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"period":   res.Period,
+		"eligible": res.Eligible,
+		"paidOut":  res.PaidOut,
+		"skipped":  res.Skipped,
+		"failed":   res.Failed,
+	})
+}
+
+type dividendResponse struct {
+	ID               uint    `json:"id"`
+	AssetID          uint    `json:"assetId"`
+	Ticker           string  `json:"ticker"`
+	AccountID        uint    `json:"accountId"`
+	Quantity         float64 `json:"quantity"`
+	PricePerShare    float64 `json:"pricePerShare"`
+	DividendYield    float64 `json:"dividendYield"`
+	Currency         string  `json:"currency"`
+	GrossAmount      float64 `json:"grossAmount"`
+	CreditedAmount   float64 `json:"creditedAmount"`
+	CreditedCurrency string  `json:"creditedCurrency"`
+	TaxRSD           float64 `json:"taxRSD"`
+	Period           string  `json:"period"`
+	PaidAt           string  `json:"paidAt"`
+}
+
+func dividendToResponse(p models.DividendPayoutRecord) dividendResponse {
+	return dividendResponse{
+		ID:               p.ID,
+		AssetID:          p.AssetID,
+		Ticker:           p.Ticker,
+		AccountID:        p.AccountID,
+		Quantity:         p.Quantity,
+		PricePerShare:    p.PricePerShare,
+		DividendYield:    p.DividendYield,
+		Currency:         p.Currency,
+		GrossAmount:      p.GrossAmount,
+		CreditedAmount:   p.CreditedAmount,
+		CreditedCurrency: p.CreditedCurrency,
+		TaxRSD:           p.TaxRSD,
+		Period:           p.Period,
+		PaidAt:           p.PaidAt.UTC().Format(time.RFC3339),
+	}
 }
 
 // --- helpers ---

--- a/exchange-service/internal/models/dividend.go
+++ b/exchange-service/internal/models/dividend.go
@@ -1,0 +1,34 @@
+package models
+
+import "time"
+
+// DividendPayoutRecord is one quarterly dividend paid to one holder of one
+// stock. The (asset_id, user_id, user_type, period) unique index makes the
+// payout cron idempotent — re-running for the same quarter never double-pays.
+//
+// GrossAmount is in the stock's listing currency. CreditedAmount/CreditedCurrency
+// reflect what actually hit the account: normally the same as gross, but when the
+// stock's account is gone the payout may be converted to RSD (§Celina 3). TaxRSD
+// is the 15% capital-gains tax recorded for client holders (zero for bank-owned
+// actuary holdings, which feed bank profit untaxed).
+type DividendPayoutRecord struct {
+	ID               uint      `gorm:"primaryKey"`
+	AssetID          uint      `gorm:"column:asset_id;not null;index;uniqueIndex:idx_dividend_asset_user_period"`
+	Ticker           string    `gorm:"not null"`
+	UserID           uint      `gorm:"column:user_id;not null;index;uniqueIndex:idx_dividend_asset_user_period"`
+	UserType         string    `gorm:"column:user_type;not null;uniqueIndex:idx_dividend_asset_user_period"` // "client" | "bank"
+	AccountID        uint      `gorm:"column:account_id;not null"`
+	Quantity         float64   `gorm:"not null"`
+	PricePerShare    float64   `gorm:"column:price_per_share;not null"`
+	DividendYield    float64   `gorm:"column:dividend_yield;not null"`
+	Currency         string    `gorm:"not null"`
+	GrossAmount      float64   `gorm:"column:gross_amount;not null"`
+	CreditedAmount   float64   `gorm:"column:credited_amount;not null"`
+	CreditedCurrency string    `gorm:"column:credited_currency;not null"`
+	TaxRSD           float64   `gorm:"column:tax_rsd;not null;default:0"`
+	Period           string    `gorm:"not null;index;uniqueIndex:idx_dividend_asset_user_period"` // "2026-Q2"
+	PaidAt           time.Time `gorm:"column:paid_at;not null"`
+	CreatedAt        time.Time
+}
+
+func (DividendPayoutRecord) TableName() string { return "dividend_payouts" }

--- a/exchange-service/internal/models/otc_negotiation.go
+++ b/exchange-service/internal/models/otc_negotiation.go
@@ -1,0 +1,42 @@
+package models
+
+import "time"
+
+// OTC negotiation entry actions.
+const (
+	OtcNegotiationActionCreated   = "created"
+	OtcNegotiationActionCountered = "countered"
+	OtcNegotiationActionAccepted  = "accepted"
+	OtcNegotiationActionDeclined  = "declined"
+	OtcNegotiationActionCancelled = "cancelled"
+)
+
+// OtcNegotiationEntryRecord is one immutable step in an OTC offer's negotiation
+// history (Celina 4): the initial offer, every counter-offer (with the terms it
+// replaced), and the terminal accept/decline/cancel. The OtcOfferRecord itself
+// only retains the latest terms, so this append-only log is the source of truth
+// for "ko je, kada i sa kojom izmenom" — who changed what, when, old vs new.
+//
+// Prev* fields are nil on the initial "created" entry and on status-only
+// transitions; they carry the pre-change terms on a "countered" entry.
+type OtcNegotiationEntryRecord struct {
+	ID        uint   `gorm:"primaryKey"`
+	OfferID   uint   `gorm:"column:offer_id;not null;index"`
+	Action    string `gorm:"not null"`
+	ActorID   uint   `gorm:"column:actor_id;not null"`
+	ActorType string `gorm:"column:actor_type;not null"`
+
+	Amount         float64   `gorm:"not null"`
+	PricePerStock  float64   `gorm:"column:price_per_stock;not null"`
+	Premium        float64   `gorm:"not null"`
+	SettlementDate time.Time `gorm:"column:settlement_date;type:date;not null"`
+
+	PrevAmount         *float64   `gorm:"column:prev_amount"`
+	PrevPricePerStock  *float64   `gorm:"column:prev_price_per_stock"`
+	PrevPremium        *float64   `gorm:"column:prev_premium"`
+	PrevSettlementDate *time.Time `gorm:"column:prev_settlement_date;type:date"`
+
+	CreatedAt time.Time `gorm:"not null;index"`
+}
+
+func (OtcNegotiationEntryRecord) TableName() string { return "otc_negotiation_entries" }

--- a/exchange-service/internal/repository/dividend_repository.go
+++ b/exchange-service/internal/repository/dividend_repository.go
@@ -1,0 +1,102 @@
+package repository
+
+import (
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"gorm.io/gorm"
+)
+
+type DividendRepository struct {
+	db *gorm.DB
+}
+
+func NewDividendRepository(db *gorm.DB) *DividendRepository {
+	return &DividendRepository{db: db}
+}
+
+// DividendEligibleHolding is one stock position that earns a dividend this
+// quarter: the holder, the account the stock was bought from, the held
+// quantity, plus the current price, currency and dividend yield needed to
+// compute the payout.
+type DividendEligibleHolding struct {
+	HoldingID     uint    `gorm:"column:holding_id"`
+	UserID        uint    `gorm:"column:user_id"`
+	UserType      string  `gorm:"column:user_type"`
+	AssetID       uint    `gorm:"column:asset_id"`
+	AccountID     uint    `gorm:"column:account_id"`
+	Quantity      float64 `gorm:"column:quantity"`
+	Ticker        string  `gorm:"column:ticker"`
+	Price         float64 `gorm:"column:price"`
+	Currency      string  `gorm:"column:currency"`
+	DividendYield float64 `gorm:"column:dividend_yield"`
+}
+
+// ListDividendEligibleHoldings returns every positive stock holding whose
+// underlying listing pays a dividend (dividend_yield > 0). Joins the price and
+// currency from the listing/exchange and the yield from the stock subtype.
+//
+// Fund-owned holdings (user_type = "fund") are excluded: dividend inflow and
+// reinvestment for funds is a separate Celina 4 mechanism with its own rules.
+// This payout covers client holders and bank-owned (actuary) holdings.
+func (r *DividendRepository) ListDividendEligibleHoldings() ([]DividendEligibleHolding, error) {
+	var rows []DividendEligibleHolding
+	err := r.db.Table("portfolio_holdings AS ph").
+		Select(`ph.id AS holding_id, ph.user_id, ph.user_type, ph.asset_id,
+			ph.account_id, ph.quantity, ml.ticker, ml.price,
+			me.currency, s.dividend_yield`).
+		Joins("JOIN market_listings ml ON ml.id = ph.asset_id AND ml.type = 'stock'").
+		Joins("JOIN market_exchanges me ON me.id = ml.exchange_id").
+		Joins("JOIN stocks s ON s.listing_id = ml.id AND s.dividend_yield > 0").
+		Where("ph.quantity > 0 AND ph.user_type <> 'fund'").
+		Order("ph.id ASC").
+		Scan(&rows).Error
+	return rows, err
+}
+
+// PayoutExists reports whether a payout has already been recorded for this
+// (asset, holder, period) — the idempotency guard for re-runs of one quarter.
+func (r *DividendRepository) PayoutExists(assetID, userID uint, userType, period string) (bool, error) {
+	var count int64
+	err := r.db.Model(&models.DividendPayoutRecord{}).
+		Where("asset_id = ? AND user_id = ? AND user_type = ? AND period = ?",
+			assetID, userID, userType, period).
+		Count(&count).Error
+	return count > 0, err
+}
+
+func (r *DividendRepository) CreatePayout(payout *models.DividendPayoutRecord) error {
+	return r.db.Create(payout).Error
+}
+
+// ListPayoutsForUser returns a holder's dividend history, newest first.
+// assetID is optional (0 = all assets) so the portfolio page can show either the
+// whole history or just one position's dividends.
+func (r *DividendRepository) ListPayoutsForUser(userID uint, userType string, assetID uint) ([]models.DividendPayoutRecord, error) {
+	q := r.db.Where("user_id = ? AND user_type = ?", userID, userType)
+	if assetID != 0 {
+		q = q.Where("asset_id = ?", assetID)
+	}
+	var payouts []models.DividendPayoutRecord
+	if err := q.Order("paid_at DESC, id DESC").Find(&payouts).Error; err != nil {
+		return nil, err
+	}
+	return payouts, nil
+}
+
+// FindActiveAccountByCurrency returns an active account for the holder in the
+// given currency, or 0 if none. Clients match on client_id; bank-owned holdings
+// match a non-state firm account (EXBanka itself).
+func (r *DividendRepository) FindActiveAccountByCurrency(userID uint, userType, currencyKod string) (uint, error) {
+	q := r.db.Table("accounts").
+		Select("accounts.id").
+		Joins("JOIN currencies ON currencies.id = accounts.currency_id").
+		Where("currencies.kod = ? AND accounts.status = 'aktivan'", currencyKod)
+	if userType == "client" {
+		q = q.Where("accounts.client_id = ?", userID)
+	} else {
+		q = q.Joins("JOIN firmas ON firmas.id = accounts.firma_id").
+			Where("firmas.is_state = false")
+	}
+	var id uint
+	err := q.Limit(1).Scan(&id).Error
+	return id, err
+}

--- a/exchange-service/internal/repository/dividend_repository_test.go
+++ b/exchange-service/internal/repository/dividend_repository_test.go
@@ -1,0 +1,116 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"gorm.io/gorm"
+)
+
+// seedDividendStock creates an exchange + stock listing (with a dividend yield)
+// and a positive holding for the given owner, returning the listing id.
+func seedDividendStock(t *testing.T, db *gorm.DB, ticker, currency string, price, yield float64, ownerID uint, ownerType string, accountID uint) uint {
+	t.Helper()
+	exch := models.MarketExchangeRecord{
+		Acronym: "DX-" + ticker, Name: "Div Exchange", MICCode: "MX-" + ticker, Polity: "X",
+		Currency: currency, Timezone: "UTC", WorkingHours: "09:00-17:00",
+	}
+	if err := db.Create(&exch).Error; err != nil {
+		t.Fatalf("seed exchange: %v", err)
+	}
+	listing := models.MarketListingRecord{
+		Ticker: ticker, Name: ticker, Type: "stock", ExchangeID: exch.ID,
+		Price: price, Ask: price, Bid: price, Volume: 100, LastRefresh: time.Now().UTC(),
+	}
+	if err := db.Create(&listing).Error; err != nil {
+		t.Fatalf("seed listing: %v", err)
+	}
+	if err := db.Create(&models.StockRecord{ListingID: listing.ID, OutstandingShares: 1000, DividendYield: yield}).Error; err != nil {
+		t.Fatalf("seed stock: %v", err)
+	}
+	if err := db.Create(&models.PortfolioHoldingRecord{
+		UserID: ownerID, UserType: ownerType, AssetID: listing.ID, Quantity: 10,
+		AvgBuyPrice: price, AccountID: accountID,
+	}).Error; err != nil {
+		t.Fatalf("seed holding: %v", err)
+	}
+	return listing.ID
+}
+
+func TestDividendRepository_EligibleHoldingsAndPayouts(t *testing.T) {
+	db := openRepoTestDB(t, "dividend_repo")
+	r := NewDividendRepository(db)
+
+	assetID := seedDividendStock(t, db, "DIV", "USD", 100, 0.04, 7, "client", 1)
+	// A zero-yield stock must NOT be eligible.
+	seedDividendStock(t, db, "NODIV", "USD", 50, 0, 7, "client", 1)
+	// A fund-owned holding must NOT be eligible (Celina 4 handles funds).
+	seedDividendStock(t, db, "FDIV", "USD", 100, 0.04, 1, "fund", 1)
+
+	eligible, err := r.ListDividendEligibleHoldings()
+	if err != nil {
+		t.Fatalf("ListDividendEligibleHoldings: %v", err)
+	}
+	if len(eligible) != 1 {
+		t.Fatalf("expected 1 eligible holding (zero-yield + fund excluded), got %d", len(eligible))
+	}
+	h := eligible[0]
+	if h.AssetID != assetID || h.Ticker != "DIV" || h.Currency != "USD" || h.DividendYield != 0.04 || h.Quantity != 10 {
+		t.Fatalf("unexpected eligible holding: %+v", h)
+	}
+
+	// No payout yet for this quarter.
+	exists, err := r.PayoutExists(assetID, 7, "client", "2026-Q2")
+	if err != nil || exists {
+		t.Fatalf("expected no existing payout, got exists=%v err=%v", exists, err)
+	}
+
+	payout := &models.DividendPayoutRecord{
+		AssetID: assetID, Ticker: "DIV", UserID: 7, UserType: "client", AccountID: 1,
+		Quantity: 10, PricePerShare: 100, DividendYield: 0.04, Currency: "USD",
+		GrossAmount: 10, CreditedAmount: 10, CreditedCurrency: "USD", TaxRSD: 180,
+		Period: "2026-Q2", PaidAt: time.Now().UTC(),
+	}
+	if err := r.CreatePayout(payout); err != nil {
+		t.Fatalf("CreatePayout: %v", err)
+	}
+
+	exists, err = r.PayoutExists(assetID, 7, "client", "2026-Q2")
+	if err != nil || !exists {
+		t.Fatalf("expected payout to exist after create, got exists=%v err=%v", exists, err)
+	}
+
+	list, err := r.ListPayoutsForUser(7, "client", 0)
+	if err != nil || len(list) != 1 {
+		t.Fatalf("expected 1 payout for user, got %d err=%v", len(list), err)
+	}
+	// Filter by a different asset → empty.
+	other, _ := r.ListPayoutsForUser(7, "client", 9999)
+	if len(other) != 0 {
+		t.Errorf("expected 0 payouts for unrelated asset, got %d", len(other))
+	}
+}
+
+func TestDividendRepository_FindActiveAccountByCurrency(t *testing.T) {
+	db := openRepoTestDB(t, "dividend_acct")
+	r := NewDividendRepository(db)
+
+	// currencies
+	db.Exec(`INSERT INTO currencies (id, kod, aktivan) VALUES (1,'USD',1),(2,'RSD',1)`)
+	// a non-state firm (EXBanka)
+	db.Exec(`INSERT INTO firmas (id, naziv, is_state) VALUES (1,'EXBanka',0),(2,'Drzava',1)`)
+	// client USD account, and a bank (firm) RSD account
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id) VALUES (10, 1, 'aktivan', 7)`)
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, firma_id) VALUES (20, 2, 'aktivan', 1)`)
+
+	if id, err := r.FindActiveAccountByCurrency(7, "client", "USD"); err != nil || id != 10 {
+		t.Errorf("expected client USD account 10, got %d err=%v", id, err)
+	}
+	if id, _ := r.FindActiveAccountByCurrency(7, "client", "EUR"); id != 0 {
+		t.Errorf("expected 0 for missing currency, got %d", id)
+	}
+	if id, err := r.FindActiveAccountByCurrency(0, "bank", "RSD"); err != nil || id != 20 {
+		t.Errorf("expected bank RSD account 20, got %d err=%v", id, err)
+	}
+}

--- a/exchange-service/internal/repository/otc_negotiation_test.go
+++ b/exchange-service/internal/repository/otc_negotiation_test.go
@@ -1,0 +1,110 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+)
+
+func TestOtcRepository_NegotiationEntries(t *testing.T) {
+	db := openRepoTestDB(t, "otc_neg_entries")
+	r := NewOtcRepository(db)
+
+	// Minimal offer row (no preloads needed for entry tests).
+	offer := &models.OtcOfferRecord{
+		StockListingID: 1, SellerHoldingID: 1, Amount: 10, PricePerStock: 100,
+		SettlementDate: time.Now().Add(72 * time.Hour).UTC(), Premium: 5,
+		LastModified: time.Now().UTC(), ModifiedByID: 2, ModifiedByType: "client",
+		Status: models.OtcOfferStatusPending,
+		BuyerID: 2, BuyerType: "client", BuyerAccountID: 1,
+		SellerID: 3, SellerType: "client", SellerAccountID: 2,
+	}
+	if err := r.CreateOffer(offer); err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+
+	prevAmount := 10.0
+	entries := []*models.OtcNegotiationEntryRecord{
+		{OfferID: offer.ID, Action: models.OtcNegotiationActionCreated, ActorID: 2, ActorType: "client",
+			Amount: 10, PricePerStock: 100, Premium: 5, SettlementDate: offer.SettlementDate, CreatedAt: time.Now().Add(-2 * time.Hour)},
+		{OfferID: offer.ID, Action: models.OtcNegotiationActionCountered, ActorID: 3, ActorType: "client",
+			Amount: 12, PricePerStock: 95, Premium: 6, SettlementDate: offer.SettlementDate,
+			PrevAmount: &prevAmount, CreatedAt: time.Now().Add(-1 * time.Hour)},
+	}
+	for _, e := range entries {
+		if err := r.AppendNegotiationEntry(e); err != nil {
+			t.Fatalf("AppendNegotiationEntry: %v", err)
+		}
+	}
+
+	got, err := r.ListNegotiationEntries(offer.ID)
+	if err != nil {
+		t.Fatalf("ListNegotiationEntries: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+	// Oldest first.
+	if got[0].Action != models.OtcNegotiationActionCreated || got[1].Action != models.OtcNegotiationActionCountered {
+		t.Errorf("entries out of order: %s, %s", got[0].Action, got[1].Action)
+	}
+	if got[1].PrevAmount == nil || *got[1].PrevAmount != 10 {
+		t.Errorf("expected prev amount 10 on counter entry, got %v", got[1].PrevAmount)
+	}
+}
+
+func TestOtcRepository_ListNegotiations_Filters(t *testing.T) {
+	db := openRepoTestDB(t, "otc_neg_list")
+	r := NewOtcRepository(db)
+
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	mk := func(buyerID, sellerID uint, status string, modified time.Time) uint {
+		o := &models.OtcOfferRecord{
+			StockListingID: 1, SellerHoldingID: 1, Amount: 10, PricePerStock: 100,
+			SettlementDate: base.Add(72 * time.Hour), Premium: 1, LastModified: modified,
+			ModifiedByID: buyerID, ModifiedByType: "client", Status: status,
+			BuyerID: buyerID, BuyerType: "client", BuyerAccountID: 1,
+			SellerID: sellerID, SellerType: "client", SellerAccountID: 2,
+		}
+		if err := r.CreateOffer(o); err != nil {
+			t.Fatalf("CreateOffer: %v", err)
+		}
+		// CreateOffer stamps last_modified to now when zero; force our value.
+		db.Model(o).Update("last_modified", modified)
+		return o.ID
+	}
+
+	// user 5 is buyer against seller 9 (accepted) and seller 11 (declined).
+	mk(5, 9, models.OtcOfferStatusAccepted, base)
+	mk(5, 11, models.OtcOfferStatusDeclined, base.Add(48*time.Hour))
+	// user 5 is seller against buyer 9 (cancelled) — counterparty 9 again.
+	mk(9, 5, models.OtcOfferStatusCancelled, base.Add(24*time.Hour))
+
+	all, err := r.ListNegotiations(5, "client", NegotiationFilter{})
+	if err != nil {
+		t.Fatalf("ListNegotiations: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 negotiations for user 5, got %d", len(all))
+	}
+
+	// Status filter.
+	accepted, _ := r.ListNegotiations(5, "client", NegotiationFilter{Status: models.OtcOfferStatusAccepted})
+	if len(accepted) != 1 {
+		t.Errorf("expected 1 accepted, got %d", len(accepted))
+	}
+
+	// Counterparty filter: party 9 appears twice (once as seller, once as buyer).
+	cp9, _ := r.ListNegotiations(5, "client", NegotiationFilter{CounterpartyID: 9})
+	if len(cp9) != 2 {
+		t.Errorf("expected 2 negotiations with counterparty 9, got %d", len(cp9))
+	}
+
+	// Date range filter: only offers modified strictly after base+12h.
+	from := base.Add(12 * time.Hour)
+	recent, _ := r.ListNegotiations(5, "client", NegotiationFilter{From: &from})
+	if len(recent) != 2 {
+		t.Errorf("expected 2 negotiations after %v, got %d", from, len(recent))
+	}
+}

--- a/exchange-service/internal/repository/otc_repository.go
+++ b/exchange-service/internal/repository/otc_repository.go
@@ -343,6 +343,64 @@ func (r *OtcRepository) UpdateContractStatus(id uint, status string) error {
 	}).Error
 }
 
+// AppendNegotiationEntry records one immutable step in an offer's negotiation
+// history (created / countered / accepted / declined / cancelled).
+func (r *OtcRepository) AppendNegotiationEntry(entry *models.OtcNegotiationEntryRecord) error {
+	if entry.CreatedAt.IsZero() {
+		entry.CreatedAt = time.Now().UTC()
+	}
+	return r.db.Create(entry).Error
+}
+
+// ListNegotiationEntries returns an offer's full negotiation timeline, oldest
+// first, so the history page can render the back-and-forth in order.
+func (r *OtcRepository) ListNegotiationEntries(offerID uint) ([]models.OtcNegotiationEntryRecord, error) {
+	var entries []models.OtcNegotiationEntryRecord
+	if err := r.db.Where("offer_id = ?", offerID).
+		Order("created_at ASC, id ASC").
+		Find(&entries).Error; err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// NegotiationFilter scopes the negotiation-history list.
+type NegotiationFilter struct {
+	Status         string     // "" = any
+	From           *time.Time // last_modified >= From
+	To             *time.Time // last_modified <= To
+	CounterpartyID uint       // 0 = any; otherwise the other party's id
+}
+
+// ListNegotiations returns the offers (negotiation threads) the user took part
+// in, filtered for the history page. Unlike ListOffersForParticipant this also
+// supports date and counterparty filters.
+func (r *OtcRepository) ListNegotiations(userID uint, userType string, f NegotiationFilter) ([]models.OtcOfferRecord, error) {
+	q := r.offerPreloads(r.db).
+		Where("(buyer_id = ? AND buyer_type = ?) OR (seller_id = ? AND seller_type = ?)",
+			userID, userType, userID, userType)
+	if f.Status != "" {
+		q = q.Where("status = ?", f.Status)
+	}
+	if f.From != nil {
+		q = q.Where("last_modified >= ?", f.From.UTC())
+	}
+	if f.To != nil {
+		q = q.Where("last_modified <= ?", f.To.UTC())
+	}
+	if f.CounterpartyID != 0 {
+		q = q.Where(
+			"(buyer_id = ? AND buyer_type = ? AND seller_id = ?) OR (seller_id = ? AND seller_type = ? AND buyer_id = ?)",
+			userID, userType, f.CounterpartyID, userID, userType, f.CounterpartyID)
+	}
+
+	var offers []models.OtcOfferRecord
+	if err := q.Order("last_modified DESC, id DESC").Find(&offers).Error; err != nil {
+		return nil, err
+	}
+	return offers, nil
+}
+
 func (r *OtcRepository) offerPreloads(db *gorm.DB) *gorm.DB {
 	return db.
 		Preload("StockListing").

--- a/exchange-service/internal/service/cron_service.go
+++ b/exchange-service/internal/service/cron_service.go
@@ -27,6 +27,7 @@ func StartCronJobs(
 	rateProvider RateProviderInterface,
 	sagaRetry *SagaRetryRunner,
 	fundSvc *FundService,
+	dividendSvc *DividendService,
 	interbankReconcile *InterbankReconcileRunner,
 	publicStockCache *PublicStockCacheRunner,
 	emailSvc EmailSender,
@@ -121,6 +122,30 @@ func StartCronJobs(
 	})
 	if err != nil {
 		slog.Error("Failed to add tax collection cron job", "error", err)
+	}
+
+	// Quarterly dividend payout: a daily 23:30 UTC tick that only acts on the
+	// last working day of March/June/September/December (§Celina 3). Idempotent
+	// per quarter, so a missed or duplicated tick never double-pays.
+	if dividendSvc != nil {
+		_, err = c.AddFunc("30 23 * * *", func() {
+			now := time.Now().UTC()
+			if !IsLastWorkingDayOfQuarter(now) {
+				return
+			}
+			slog.Info("Starting quarterly dividend distribution", "period", QuarterPeriod(now))
+			res, derr := dividendSvc.DistributeForDate(now)
+			if derr != nil {
+				slog.Error("Quarterly dividend distribution failed", "error", derr)
+				return
+			}
+			slog.Info("Quarterly dividend distribution finished",
+				"period", res.Period, "eligible", res.Eligible,
+				"paid", res.PaidOut, "skipped", res.Skipped, "failed", res.Failed)
+		})
+		if err != nil {
+			slog.Error("Failed to add dividend payout cron job", "error", err)
+		}
 	}
 
 	// Daily fund performance snapshot: runs at 23:55 UTC every day.

--- a/exchange-service/internal/service/dividend_helpers_test.go
+++ b/exchange-service/internal/service/dividend_helpers_test.go
@@ -1,0 +1,59 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+func TestQuarterPeriod(t *testing.T) {
+	cases := map[string]string{
+		"2026-01-15": "2026-Q1",
+		"2026-03-31": "2026-Q1",
+		"2026-04-01": "2026-Q2",
+		"2026-06-30": "2026-Q2",
+		"2026-09-30": "2026-Q3",
+		"2026-12-31": "2026-Q4",
+	}
+	for in, want := range cases {
+		ts, _ := time.Parse("2006-01-02", in)
+		if got := service.QuarterPeriod(ts); got != want {
+			t.Errorf("QuarterPeriod(%s)=%s, want %s", in, got, want)
+		}
+	}
+}
+
+func TestIsLastWorkingDayOfQuarter(t *testing.T) {
+	// 2026-06-30 is a Tuesday — the last working day of Q2.
+	if d, _ := time.Parse("2006-01-02", "2026-06-30"); !service.IsLastWorkingDayOfQuarter(d) {
+		t.Error("2026-06-30 (Tue) should be the last working day of Q2")
+	}
+	// 2026-03-31 is a Tuesday — last working day of Q1.
+	if d, _ := time.Parse("2006-01-02", "2026-03-31"); !service.IsLastWorkingDayOfQuarter(d) {
+		t.Error("2026-03-31 (Tue) should be the last working day of Q1")
+	}
+	// Not a quarter-end month.
+	if d, _ := time.Parse("2006-01-02", "2026-04-30"); service.IsLastWorkingDayOfQuarter(d) {
+		t.Error("2026-04-30 is not in a quarter-closing month")
+	}
+	// A quarter-end month but not its last working day.
+	if d, _ := time.Parse("2006-01-02", "2026-06-29"); service.IsLastWorkingDayOfQuarter(d) {
+		t.Error("2026-06-29 is not the last working day of June")
+	}
+	// 2026-05-31 is a Sunday; May isn't a quarter close anyway.
+	if d, _ := time.Parse("2006-01-02", "2026-05-31"); service.IsLastWorkingDayOfQuarter(d) {
+		t.Error("May is not a quarter-closing month")
+	}
+}
+
+// TestLastWorkingDayWeekendBackoff confirms a weekend month-end rolls back to
+// Friday: 2024-03-31 was a Sunday, so the last working day is 2024-03-29 (Fri).
+func TestLastWorkingDayWeekendBackoff(t *testing.T) {
+	if d, _ := time.Parse("2006-01-02", "2024-03-29"); !service.IsLastWorkingDayOfQuarter(d) {
+		t.Error("2024-03-29 (Fri) should be the last working day of Q1 2024")
+	}
+	if d, _ := time.Parse("2006-01-02", "2024-03-31"); service.IsLastWorkingDayOfQuarter(d) {
+		t.Error("2024-03-31 (Sun) is a weekend, not the last working day")
+	}
+}

--- a/exchange-service/internal/service/dividend_service.go
+++ b/exchange-service/internal/service/dividend_service.go
@@ -1,0 +1,225 @@
+package service
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/notify"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// dividendQuartersPerYear is the divisor in the per-quarter dividend formula:
+// Dividenda = Quantity × Price × (DividendYield / 4)  (§Celina 3).
+const dividendQuartersPerYear = 4.0
+
+// DividendService pays quarterly stock dividends into holders' accounts.
+type DividendService struct {
+	divRepo   *repository.DividendRepository
+	orderRepo *repository.OrderRepository
+	taxSvc    *TaxService
+	rate      RateProviderInterface
+	notifier  *notify.Client
+}
+
+func NewDividendService(
+	divRepo *repository.DividendRepository,
+	orderRepo *repository.OrderRepository,
+	taxSvc *TaxService,
+	rate RateProviderInterface,
+) *DividendService {
+	return &DividendService{divRepo: divRepo, orderRepo: orderRepo, taxSvc: taxSvc, rate: rate}
+}
+
+// WithNotifier wires the optional best-effort notification client.
+func (s *DividendService) WithNotifier(n *notify.Client) *DividendService {
+	s.notifier = n
+	return s
+}
+
+// DividendRunResult summarises a distribution run.
+type DividendRunResult struct {
+	Period    string
+	Eligible  int
+	PaidOut   int
+	Skipped   int // already paid this quarter, or no usable account
+	Failed    int // credit/persist error
+	GrossByCC map[string]float64
+}
+
+// DistributeForDate pays the dividend for the quarter that `now` falls in to all
+// eligible stock holders. Idempotent per (asset, holder, quarter): re-running the
+// same quarter never double-pays. Clients are taxed 15% on the gain (recorded in
+// the monthly tax tracking); bank-owned (actuary) holdings are paid untaxed into
+// bank profit. Per §Celina 3 the payout goes, in order of preference, to: the
+// account the stock was bought from (if it still exists in the listing currency),
+// else the holder's default account in that currency, else converted to RSD.
+func (s *DividendService) DistributeForDate(now time.Time) (DividendRunResult, error) {
+	period := QuarterPeriod(now)
+	result := DividendRunResult{Period: period, GrossByCC: map[string]float64{}}
+
+	holdings, err := s.divRepo.ListDividendEligibleHoldings()
+	if err != nil {
+		return result, fmt.Errorf("list eligible holdings: %w", err)
+	}
+	result.Eligible = len(holdings)
+
+	for _, h := range holdings {
+		gross := roundPnL(h.Quantity * h.Price * (h.DividendYield / dividendQuartersPerYear))
+		if gross <= 0.005 {
+			result.Skipped++
+			continue
+		}
+
+		exists, err := s.divRepo.PayoutExists(h.AssetID, h.UserID, h.UserType, period)
+		if err != nil {
+			slog.Error("dividend: payout-exists check failed", "assetID", h.AssetID, "userID", h.UserID, "error", err)
+			result.Failed++
+			continue
+		}
+		if exists {
+			result.Skipped++
+			continue
+		}
+
+		accountID, creditCurrency, creditAmount := s.resolvePayoutAccount(h, gross)
+		if accountID == 0 {
+			slog.Warn("dividend: no usable account for holder, skipping",
+				"userID", h.UserID, "userType", h.UserType, "ticker", h.Ticker)
+			result.Skipped++
+			continue
+		}
+
+		if err := s.orderRepo.CreditAccount(accountID, creditAmount); err != nil {
+			slog.Error("dividend: failed to credit account", "accountID", accountID, "error", err)
+			result.Failed++
+			continue
+		}
+
+		var taxRSD float64
+		if h.UserType == "client" {
+			if err := s.taxSvc.RecordCapitalGainTax(h.UserID, h.UserType, h.AssetID, gross, "stock", h.Currency); err != nil {
+				slog.Error("dividend: failed to record capital-gain tax", "userID", h.UserID, "assetID", h.AssetID, "error", err)
+			}
+			taxRSD = roundPnL(s.toRSD(gross, h.Currency) * taxRate)
+		}
+
+		payout := &models.DividendPayoutRecord{
+			AssetID:          h.AssetID,
+			Ticker:           h.Ticker,
+			UserID:           h.UserID,
+			UserType:         h.UserType,
+			AccountID:        accountID,
+			Quantity:         h.Quantity,
+			PricePerShare:    h.Price,
+			DividendYield:    h.DividendYield,
+			Currency:         h.Currency,
+			GrossAmount:      gross,
+			CreditedAmount:   creditAmount,
+			CreditedCurrency: creditCurrency,
+			TaxRSD:           taxRSD,
+			Period:           period,
+			PaidAt:           now.UTC(),
+		}
+		if err := s.divRepo.CreatePayout(payout); err != nil {
+			// Account is already credited; a missing history row is the lesser
+			// evil, but log loudly so it can be reconciled.
+			slog.Error("dividend: account credited but payout record failed", "userID", h.UserID, "assetID", h.AssetID, "error", err)
+			result.Failed++
+			continue
+		}
+
+		s.notifyHolder(h, payout)
+		result.PaidOut++
+		result.GrossByCC[h.Currency] += gross
+	}
+
+	slog.Info("dividend: distribution complete",
+		"period", result.Period, "eligible", result.Eligible,
+		"paid", result.PaidOut, "skipped", result.Skipped, "failed", result.Failed)
+	return result, nil
+}
+
+// resolvePayoutAccount applies the §Celina 3 account-selection fallback chain.
+// Returns (accountID, currency, amount); accountID 0 means no account is usable.
+func (s *DividendService) resolvePayoutAccount(h repository.DividendEligibleHolding, gross float64) (uint, string, float64) {
+	// 1) The account the stock was bought from, if it still exists in the
+	//    listing currency.
+	if h.AccountID != 0 {
+		if _, cur, err := s.orderRepo.GetAccountBalance(h.AccountID); err == nil && cur == h.Currency {
+			return h.AccountID, h.Currency, gross
+		}
+	}
+	// 2) The holder's default active account in the listing currency.
+	if id, _ := s.divRepo.FindActiveAccountByCurrency(h.UserID, h.UserType, h.Currency); id != 0 {
+		return id, h.Currency, gross
+	}
+	// 3) Convert to RSD and pay into the holder's RSD account.
+	if id, _ := s.divRepo.FindActiveAccountByCurrency(h.UserID, h.UserType, rsdCurrency); id != 0 {
+		return id, rsdCurrency, roundPnL(s.toRSD(gross, h.Currency))
+	}
+	return 0, "", 0
+}
+
+func (s *DividendService) notifyHolder(h repository.DividendEligibleHolding, p *models.DividendPayoutRecord) {
+	if s.notifier == nil || h.UserType != "client" {
+		return
+	}
+	s.notifier.Emit(notify.Event{
+		UserID:   h.UserID,
+		UserType: "client",
+		Type:     "DIVIDEND_PAID",
+		Title:    "Isplaćena dividenda",
+		Body: fmt.Sprintf("Primili ste dividendu za %s: %.2f %s (%s).",
+			p.Ticker, p.CreditedAmount, p.CreditedCurrency, p.Period),
+		Link: "/portfolio",
+	})
+}
+
+// ListPayoutsForUser returns a holder's dividend history (assetID 0 = all).
+func (s *DividendService) ListPayoutsForUser(userID uint, userType string, assetID uint) ([]models.DividendPayoutRecord, error) {
+	return s.divRepo.ListPayoutsForUser(userID, userType, assetID)
+}
+
+// toRSD converts amount from currency to RSD via the rate provider, falling back
+// to 1:1 when no rate exists (mirrors TaxService.toRSD).
+func (s *DividendService) toRSD(amount float64, currency string) float64 {
+	if currency == rsdCurrency || currency == "" {
+		return amount
+	}
+	rate, err := s.rate.GetRate(currency, rsdCurrency)
+	if err != nil || rate == 0 {
+		return amount * fallbackRSDRate
+	}
+	return amount * rate
+}
+
+// QuarterPeriod returns the "YYYY-Qn" label for t (e.g. 2026-06-30 -> "2026-Q2").
+func QuarterPeriod(t time.Time) string {
+	q := (int(t.Month())-1)/3 + 1
+	return fmt.Sprintf("%d-Q%d", t.Year(), q)
+}
+
+// IsLastWorkingDayOfQuarter reports whether t is the last weekday (Mon–Fri) of a
+// quarter-closing month (March, June, September, December) — the §Celina 3
+// dividend payout day.
+func IsLastWorkingDayOfQuarter(t time.Time) bool {
+	switch t.Month() {
+	case time.March, time.June, time.September, time.December:
+	default:
+		return false
+	}
+	last := lastWorkingDayOfMonth(t.Year(), t.Month())
+	return t.Day() == last.Day()
+}
+
+// lastWorkingDayOfMonth returns the last Mon–Fri date in the given month.
+func lastWorkingDayOfMonth(year int, month time.Month) time.Time {
+	// Day 0 of next month == last day of this month.
+	d := time.Date(year, month+1, 0, 0, 0, 0, 0, time.UTC)
+	for d.Weekday() == time.Saturday || d.Weekday() == time.Sunday {
+		d = d.AddDate(0, 0, -1)
+	}
+	return d
+}

--- a/exchange-service/internal/service/extra_coverage_test.go
+++ b/exchange-service/internal/service/extra_coverage_test.go
@@ -49,7 +49,7 @@ func TestStartCronJobs_Constructs(t *testing.T) {
 	psvc := service.NewPortfolioService(portfolioRepo, taxSvc, marketRepo, orderRepo)
 	fundSvc := service.NewFundService(repository.NewFundRepository(db), portfolioRepo, marketRepo, orderRepo, rates)
 
-	c := service.StartCronJobs(db, psvc, rates, nil, fundSvc, nil, nil, nil, nil)
+	c := service.StartCronJobs(db, psvc, rates, nil, fundSvc, nil, nil, nil, nil, nil)
 	if c == nil {
 		t.Fatal("expected non-nil cron")
 	}

--- a/exchange-service/internal/service/otc_service.go
+++ b/exchange-service/internal/service/otc_service.go
@@ -176,6 +176,7 @@ func (s *OtcService) CreateOffer(input CreateOtcOfferInput) (*models.OtcOfferRec
 	if err != nil {
 		return nil, err
 	}
+	s.recordNegotiationEntry(created, models.OtcNegotiationActionCreated, input.BuyerID, input.BuyerType, nil)
 	return created, nil
 }
 
@@ -242,6 +243,9 @@ func (s *OtcService) CounterOffer(input CounterOtcOfferInput) (*models.OtcOfferR
 		return nil, err
 	}
 
+	// `offer` holds the pre-counter terms; `updated` the new ones.
+	s.recordNegotiationEntry(updated, models.OtcNegotiationActionCountered, input.ModifiedByID, input.ModifiedByType, offer)
+
 	// Notify the counterparty about the new counter-offer terms.
 	recipientID, recipientType := otcOtherParty(updated, input.ModifiedByID, input.ModifiedByType)
 	emitOtcNotification(s.notifier, recipientID, recipientType, "OTC_COUNTER",
@@ -255,6 +259,7 @@ func (s *OtcService) CounterOffer(input CounterOtcOfferInput) (*models.OtcOfferR
 func (s *OtcService) DeclineOffer(offerID uint, sellerID uint, sellerType string) (*models.OtcOfferRecord, error) {
 	offer, err := s.updateOfferStatusForParticipant(offerID, sellerID, sellerType, models.OtcOfferStatusDeclined)
 	if err == nil && offer != nil {
+		s.recordNegotiationEntry(offer, models.OtcNegotiationActionDeclined, sellerID, sellerType, nil)
 		recipientID, recipientType := otcOtherParty(offer, sellerID, sellerType)
 		emitOtcNotification(s.notifier, recipientID, recipientType, "OTC_DECLINED",
 			"Ponuda odbijena",
@@ -266,6 +271,7 @@ func (s *OtcService) DeclineOffer(offerID uint, sellerID uint, sellerType string
 func (s *OtcService) CancelOffer(offerID uint, buyerID uint, buyerType string) (*models.OtcOfferRecord, error) {
 	offer, err := s.updateOfferStatusForParticipant(offerID, buyerID, buyerType, models.OtcOfferStatusCancelled)
 	if err == nil && offer != nil {
+		s.recordNegotiationEntry(offer, models.OtcNegotiationActionCancelled, buyerID, buyerType, nil)
 		recipientID, recipientType := otcOtherParty(offer, buyerID, buyerType)
 		emitOtcNotification(s.notifier, recipientID, recipientType, "OTC_CANCELLED",
 			"Ponuda povučena",
@@ -303,6 +309,8 @@ func (s *OtcService) AcceptOffer(offerID uint, userID uint, userType string) (*m
 		}
 		return nil, err
 	}
+
+	s.recordNegotiationEntry(offer, models.OtcNegotiationActionAccepted, userID, userType, nil)
 
 	// Notify the counterparty that the offer was accepted (contract created).
 	recipientID, recipientType := otcOtherParty(offer, userID, userType)
@@ -459,6 +467,67 @@ func (s *OtcService) GetOfferForParticipant(offerID uint, userID uint, userType 
 		return nil, ErrOtcOfferNotFound
 	}
 	return offer, nil
+}
+
+// recordNegotiationEntry appends one step to an offer's negotiation history.
+// Best-effort and nil-safe: a failure here is logged but never fails the
+// underlying OTC action. When prev is non-nil (a counter-offer) the pre-change
+// terms are captured alongside the new ones.
+func (s *OtcService) recordNegotiationEntry(offer *models.OtcOfferRecord, action string, actorID uint, actorType string, prev *models.OtcOfferRecord) {
+	if offer == nil {
+		return
+	}
+	entry := &models.OtcNegotiationEntryRecord{
+		OfferID:        offer.ID,
+		Action:         action,
+		ActorID:        actorID,
+		ActorType:      actorType,
+		Amount:         offer.Amount,
+		PricePerStock:  offer.PricePerStock,
+		Premium:        offer.Premium,
+		SettlementDate: offer.SettlementDate,
+	}
+	if prev != nil {
+		amount, price, premium, settle := prev.Amount, prev.PricePerStock, prev.Premium, prev.SettlementDate
+		entry.PrevAmount = &amount
+		entry.PrevPricePerStock = &price
+		entry.PrevPremium = &premium
+		entry.PrevSettlementDate = &settle
+	}
+	if err := s.otcRepo.AppendNegotiationEntry(entry); err != nil {
+		slog.Error("otc: failed to record negotiation entry", "offerID", offer.ID, "action", action, "error", err)
+	}
+}
+
+// ListNegotiations returns the negotiation threads (offers) the caller took part
+// in, for the history page. Supports status, date-range and counterparty filters.
+func (s *OtcService) ListNegotiations(userID uint, userType, status string, from, to *time.Time, counterpartyID uint) ([]models.OtcOfferRecord, error) {
+	if err := validateOfferStatusFilter(status); err != nil {
+		return nil, err
+	}
+	return s.otcRepo.ListNegotiations(userID, userType, repository.NegotiationFilter{
+		Status:         status,
+		From:           from,
+		To:             to,
+		CounterpartyID: counterpartyID,
+	})
+}
+
+// GetNegotiationHistory returns the full timeline for one offer, but only if the
+// caller is a participant in it.
+func (s *OtcService) GetNegotiationHistory(offerID, userID uint, userType string) (*models.OtcOfferRecord, []models.OtcNegotiationEntryRecord, error) {
+	offer, err := s.otcRepo.GetOfferByID(offerID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if offer == nil || !isOfferParticipant(*offer, userID, userType) {
+		return nil, nil, ErrOtcOfferNotFound
+	}
+	entries, err := s.otcRepo.ListNegotiationEntries(offerID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return offer, entries, nil
 }
 
 func isOfferParticipant(offer models.OtcOfferRecord, userID uint, userType string) bool {


### PR DESCRIPTION
Celina 3 — dividend payout:
- DividendPayoutRecord (table dividend_payouts) with unique (asset,user,period) index so the quarterly run is idempotent and never double-pays.
- DividendService.DistributeForDate: Qty x Price x (yield/4); spec account fallback chain (buy account if same currency -> holder's default account in listing currency -> convert to RSD). Clients taxed 15% via TaxService; bank-owned (actuary) holdings untaxed -> bank profit. Fund-owned holdings excluded (separate Celina 4 mechanism).
- Cron: daily 23:30 tick acting only on the last working day of Mar/Jun/Sep/Dec. Emits in-app DIVIDEND_PAID.
- GET /portfolio/dividends; POST /portfolio/dividends/run (supervisor manual trigger, idempotent).

Celina 4 — OTC negotiation history:
- OtcNegotiationEntryRecord (table otc_negotiation_entries): append-only log written on create/counter/decline/cancel/accept; counter entries capture the prior terms (old -> new).
- GET /otc/negotiations (status/from/to/counterparty filters) and GET /otc/offers/{id}/history (participant-only timeline).

Tests: dividend helper + repo tests (eligibility incl. fund/zero-yield exclusion, idempotency, account resolution) and OTC negotiation repo tests (entry ordering, prev-value capture, filters). go build + go test ./... green.