### PR TITLE
feat(exchange): fund dividends (reinvest/payout) + fund statistics; +…

### DIFF
--- a/account-service/internal/service/notify_internal_test.go
+++ b/account-service/internal/service/notify_internal_test.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/internal/notify"
+)
+
+func TestCardNotifyHelpers(t *testing.T) {
+	n := notify.NewClient("", "")
+
+	// WithNotifier setters chain.
+	cs := (&CardService{}).WithNotifier(n)
+	if cs == nil {
+		t.Fatal("CardService.WithNotifier returned nil")
+	}
+	if (&AccountService{}).WithNotifier(n) == nil {
+		t.Fatal("AccountService.WithNotifier returned nil")
+	}
+
+	card := &models.Card{ClientID: 5, BrojKartice: "1234567890123456"}
+	// All status branches (no-op client, so no network).
+	for _, st := range []string{"blokirana", "aktivna", "deaktivirana", "nepoznato"} {
+		cs.emitCardStatusInApp(card, st)
+	}
+	// Guard branches: nil notifier, and ClientID 0.
+	(&CardService{}).emitCardStatusInApp(card, "blokirana")
+	cs.emitCardStatusInApp(&models.Card{ClientID: 0, BrojKartice: "x"}, "blokirana")
+
+	// maskCardNumber: short (returned as-is) and long (masked).
+	if got := maskCardNumber("12"); got != "12" {
+		t.Errorf("maskCardNumber short: got %q", got)
+	}
+	if got := maskCardNumber("1234567890123456"); got != "•••• 3456" {
+		t.Errorf("maskCardNumber long: got %q", got)
+	}
+}

--- a/account-service/internal/util/token_revocation_test.go
+++ b/account-service/internal/util/token_revocation_test.go
@@ -1,0 +1,76 @@
+package util_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/account-service/internal/util"
+)
+
+// TestTokenRevocation_NoRealRedis exercises every token-revocation code path
+// without a live Redis: an empty address yields a nil store, and a dead address
+// builds a client whose calls fail fast (timeouts) so the error/fail-open
+// branches run too.
+func TestTokenRevocation_NoRealRedis(t *testing.T) {
+	if util.NewRedisTokenRevocationStore("", "", 0) != nil {
+		t.Error("empty addr should yield a nil store")
+	}
+	store := util.NewRedisTokenRevocationStore("127.0.0.1:1", "", 0)
+	if store == nil {
+		t.Fatal("expected a store for a non-empty addr")
+	}
+
+	if util.RevokedTokenKey("jti") == "" {
+		t.Error("RevokedTokenKey should be non-empty")
+	}
+
+	// Close: real store and nil receiver.
+	_ = store.Close()
+	var nilStore *util.TokenRevocationStore
+	_ = nilStore.Close()
+
+	ctx := context.Background()
+	// IsRevoked guards: nil store, empty jti.
+	if ok, _ := nilStore.IsRevoked(ctx, "j"); ok {
+		t.Error("nil store should report not revoked")
+	}
+	if ok, _ := store.IsRevoked(ctx, ""); ok {
+		t.Error("empty jti should report not revoked")
+	}
+	_, _ = store.IsRevoked(ctx, "jti") // dead client -> error path (fails fast)
+
+	// IsTokenRevoked: nil claims, no store configured, store configured (fail-open).
+	if util.IsTokenRevoked(ctx, nil) {
+		t.Error("nil claims -> not revoked")
+	}
+	c := &util.Claims{}
+	c.ID = "jti-x"
+	util.SetTokenRevocationStore(nil)
+	if util.IsTokenRevoked(ctx, c) {
+		t.Error("no store configured -> not revoked")
+	}
+	util.SetTokenRevocationStore(store)
+	_ = util.IsTokenRevoked(ctx, c) // dead client -> fails open (false)
+	util.SetTokenRevocationStore(nil)
+
+	// ConfigureTokenRevocationFromEnv: disabled (no addr) and enabled paths.
+	os.Unsetenv("REDIS_ADDR")
+	ConfigureAndClose(t)
+	os.Setenv("REDIS_ADDR", "127.0.0.1:1")
+	os.Setenv("REDIS_DB", "1")
+	ConfigureAndClose(t)
+	os.Setenv("REDIS_DB", "not-a-number") // invalid -> warn branch
+	ConfigureAndClose(t)
+	os.Unsetenv("REDIS_ADDR")
+	os.Unsetenv("REDIS_DB")
+}
+
+func ConfigureAndClose(t *testing.T) {
+	t.Helper()
+	closeFn := util.ConfigureTokenRevocationFromEnv("test")
+	if closeFn == nil {
+		t.Fatal("ConfigureTokenRevocationFromEnv returned nil close func")
+	}
+	closeFn()
+}

--- a/auth-service/internal/database/error_paths_test.go
+++ b/auth-service/internal/database/error_paths_test.go
@@ -1,0 +1,29 @@
+package database
+
+import "testing"
+
+func TestMigrate_ClosedDB_Errors(t *testing.T) {
+	db := newInMemoryDB(t, "auth_migrate_closed")
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("DB(): %v", err)
+	}
+	_ = sqlDB.Close()
+	if err := Migrate(db); err == nil {
+		t.Fatal("expected migrate error on a closed connection")
+	}
+}
+
+func TestSeedPermissions_Unmigrated_Errors(t *testing.T) {
+	db := newInMemoryDB(t, "auth_seedperm_unmigrated")
+	if err := SeedPermissions(db); err == nil {
+		t.Fatal("expected error seeding permissions without a table")
+	}
+}
+
+func TestSeedDefaultAdmin_Unmigrated_Errors(t *testing.T) {
+	db := newInMemoryDB(t, "auth_admin_unmigrated")
+	if err := SeedDefaultAdmin(db); err == nil {
+		t.Fatal("expected error seeding admin without tables")
+	}
+}

--- a/auth-service/internal/util/token_revocation_test.go
+++ b/auth-service/internal/util/token_revocation_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -51,4 +52,67 @@ func TestIsTokenRevokedWithoutStoreFailsOpen(t *testing.T) {
 	}) {
 		t.Fatal("expected revoked check without store to fail open")
 	}
+}
+
+// TestTokenRevocationStore_NoRealRedis covers the store constructor, Close,
+// RevokeJTI, IsRevoked and the env configuration without a live Redis: a dead
+// address builds a client whose calls fail fast, exercising the error paths.
+func TestTokenRevocationStore_NoRealRedis(t *testing.T) {
+	if NewRedisTokenRevocationStore("", "", 0) != nil {
+		t.Error("empty addr should yield a nil store")
+	}
+	store := NewRedisTokenRevocationStore("127.0.0.1:1", "", 0)
+	if store == nil {
+		t.Fatal("expected a store for a non-empty addr")
+	}
+	ctx := context.Background()
+
+	// Close: real + nil receiver.
+	_ = store.Close()
+	var nilStore *TokenRevocationStore
+	_ = nilStore.Close()
+
+	// RevokeJTI branches.
+	if err := nilStore.RevokeJTI(ctx, "j", time.Minute); !errors.Is(err, ErrTokenRevocationUnavailable) {
+		t.Errorf("nil store -> unavailable, got %v", err)
+	}
+	if err := store.RevokeJTI(ctx, "", time.Minute); !errors.Is(err, ErrTokenNotRevocable) {
+		t.Errorf("empty jti -> not-revocable, got %v", err)
+	}
+	if err := store.RevokeJTI(ctx, "j", 0); err != nil {
+		t.Errorf("ttl<=0 -> no-op, got %v", err)
+	}
+	_ = store.RevokeJTI(ctx, "j", time.Minute) // dead client -> set error
+
+	// IsRevoked branches.
+	if ok, _ := nilStore.IsRevoked(ctx, "j"); ok {
+		t.Error("nil store -> not revoked")
+	}
+	if ok, _ := store.IsRevoked(ctx, ""); ok {
+		t.Error("empty jti -> not revoked")
+	}
+	_, _ = store.IsRevoked(ctx, "j")
+
+	// RevokeTokenClaims/IsTokenRevoked with a (dead) store configured.
+	c := &Claims{RegisteredClaims: jwt.RegisteredClaims{ID: "x", ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour))}}
+	SetTokenRevocationStore(store)
+	_ = RevokeTokenClaims(ctx, c)
+	_ = IsTokenRevoked(ctx, c)
+	// Already-expired token -> ttl<=0 no-op.
+	expired := &Claims{RegisteredClaims: jwt.RegisteredClaims{ID: "y", ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour))}}
+	if err := RevokeTokenClaims(ctx, expired); err != nil {
+		t.Errorf("expired token revoke -> no-op, got %v", err)
+	}
+	SetTokenRevocationStore(nil)
+
+	// ConfigureTokenRevocationFromEnv: disabled, enabled, invalid REDIS_DB.
+	os.Unsetenv("REDIS_ADDR")
+	ConfigureTokenRevocationFromEnv("t")()
+	os.Setenv("REDIS_ADDR", "127.0.0.1:1")
+	os.Setenv("REDIS_DB", "2")
+	ConfigureTokenRevocationFromEnv("t")()
+	os.Setenv("REDIS_DB", "not-a-number")
+	ConfigureTokenRevocationFromEnv("t")()
+	os.Unsetenv("REDIS_ADDR")
+	os.Unsetenv("REDIS_DB")
 }

--- a/client-service/internal/service/client_create_coverage_test.go
+++ b/client-service/internal/service/client_create_coverage_test.go
@@ -1,0 +1,66 @@
+package service_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/client-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/client-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/client-service/internal/service"
+	"gorm.io/gorm"
+)
+
+func TestCreateClient_ValidationAndRepoErrors(t *testing.T) {
+	ok := func() *mockClientRepo {
+		return &mockClientRepo{
+			emailExistsFn: func(string, uint) (bool, error) { return false, nil },
+			createFn:      func(c *models.Client) error { c.ID = 1; return nil },
+		}
+	}
+
+	// Invalid phone.
+	in := validCreateClientInput()
+	in.BrojTelefona = "abc"
+	if _, _, err := newTestClientService(ok(), &mockPermRepo{}).CreateClient(in); err == nil {
+		t.Error("expected error for invalid phone")
+	}
+	// Invalid email.
+	in = validCreateClientInput()
+	in.Email = "not-an-email"
+	if _, _, err := newTestClientService(ok(), &mockPermRepo{}).CreateClient(in); err == nil {
+		t.Error("expected error for invalid email")
+	}
+	// Date of birth in the future.
+	in = validCreateClientInput()
+	in.DatumRodjenja = time.Now().Add(48 * time.Hour).Unix()
+	if _, _, err := newTestClientService(ok(), &mockPermRepo{}).CreateClient(in); err == nil {
+		t.Error("expected error for future date of birth")
+	}
+	// Email already in use.
+	exists := &mockClientRepo{emailExistsFn: func(string, uint) (bool, error) { return true, nil }}
+	if _, _, err := newTestClientService(exists, &mockPermRepo{}).CreateClient(validCreateClientInput()); err == nil {
+		t.Error("expected error for duplicate email")
+	}
+	// EmailExists repo error.
+	existsErr := &mockClientRepo{emailExistsFn: func(string, uint) (bool, error) { return false, errors.New("db down") }}
+	if _, _, err := newTestClientService(existsErr, &mockPermRepo{}).CreateClient(validCreateClientInput()); err == nil {
+		t.Error("expected error when EmailExists fails")
+	}
+	// Create repo error.
+	createErr := &mockClientRepo{
+		emailExistsFn: func(string, uint) (bool, error) { return false, nil },
+		createFn:      func(*models.Client) error { return errors.New("insert failed") },
+	}
+	if _, _, err := newTestClientService(createErr, &mockPermRepo{}).CreateClient(validCreateClientInput()); err == nil {
+		t.Error("expected error when Create fails")
+	}
+}
+
+func TestNewClientService_Constructs(t *testing.T) {
+	// The constructor only wraps the handle in repositories; a zero-value *gorm.DB
+	// is enough to exercise it without a driver dependency.
+	if service.NewClientService(&config.Config{}, &gorm.DB{}) == nil {
+		t.Fatal("NewClientService returned nil")
+	}
+}

--- a/employee-service/internal/database/error_paths_test.go
+++ b/employee-service/internal/database/error_paths_test.go
@@ -1,0 +1,27 @@
+package database
+
+import "testing"
+
+// TestMigrate_ClosedDB_Errors covers the Migrate error-wrap path: a closed
+// connection makes AutoMigrate fail, which propagates through withMigrationLock
+// (sqlite branch) and is wrapped by Migrate.
+func TestMigrate_ClosedDB_Errors(t *testing.T) {
+	db := openSQLite(t, "employee_migrate_closed")
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("DB(): %v", err)
+	}
+	_ = sqlDB.Close()
+	if err := Migrate(db); err == nil {
+		t.Fatal("expected migrate error on a closed connection")
+	}
+}
+
+// TestSeedPermissions_Unmigrated_Errors covers the backfill error branch:
+// seeding before the permissions table exists fails.
+func TestSeedPermissions_Unmigrated_Errors(t *testing.T) {
+	db := openSQLite(t, "employee_seedperm_unmigrated")
+	if err := SeedPermissions(db); err == nil {
+		t.Fatal("expected error seeding permissions without a table")
+	}
+}

--- a/exchange-service/cmd/server/main.go
+++ b/exchange-service/cmd/server/main.go
@@ -96,6 +96,7 @@ func main() {
 
 	dividendRepo := repository.NewDividendRepository(db)
 	dividendSvc := service.NewDividendService(dividendRepo, orderRepo, taxSvc, rateProvider)
+	fundSvc = fundSvc.WithDividendRepo(dividendRepo)
 
 	// Inter-bank protocol wiring (Celina 5). The registry parses
 	// PARTNER_BANKS_JSON at startup and is the routing/auth source of
@@ -136,6 +137,7 @@ func main() {
 	emailSvc := service.NewSMTPEmailService(cfg.SMTPHost, cfg.SMTPPort, cfg.SMTPFrom)
 	notifier := notify.NewClient(cfg.NotificationServiceURL, cfg.InternalAPIKey)
 	dividendSvc = dividendSvc.WithNotifier(notifier)
+	fundSvc = fundSvc.WithNotifier(notifier)
 	cronScheduler := service.StartCronJobs(db, portfolioSvc, rateProvider, sagaRetryRunner, fundSvc, dividendSvc, ibReconcile, ibPublicStockCache, emailSvc, notifier)
 
 	go func() {

--- a/exchange-service/internal/database/connect_test.go
+++ b/exchange-service/internal/database/connect_test.go
@@ -1,0 +1,21 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
+)
+
+// TestConnect_Error covers the Connect error path: a refused connection
+// (localhost:1) makes gorm.Open fail fast, exercising the DSN build + error
+// wrap without needing a live PostgreSQL.
+func TestConnect_Error(t *testing.T) {
+	cfg := &config.Config{
+		DBHost: "127.0.0.1", DBPort: "1", DBUser: "u", DBPassword: "p",
+		DBName: "x", DBSSLMode: "disable",
+	}
+	db, err := Connect(cfg)
+	if err == nil {
+		t.Fatalf("expected connection error to 127.0.0.1:1, got db=%v", db)
+	}
+}

--- a/exchange-service/internal/database/database.go
+++ b/exchange-service/internal/database/database.go
@@ -57,6 +57,7 @@ func Migrate(db *gorm.DB) error {
 			&models.ClientFundTransactionRecord{},
 			&models.ClientFundPositionRecord{},
 			&models.FundPerformanceHistoryRecord{},
+			&models.FundDividendRecord{},
 			&models.InterbankInboundMessage{},
 			&models.InterbankOtcNegotiation{},
 			&models.InterbankPendingTx{},

--- a/exchange-service/internal/handler/dividend_fund_endpoints_test.go
+++ b/exchange-service/internal/handler/dividend_fund_endpoints_test.go
@@ -1,0 +1,230 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+	"gorm.io/gorm"
+)
+
+func do(t *testing.T, h http.HandlerFunc, method, target, token, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body != "" {
+		r = httptest.NewRequest(method, target, strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+	} else {
+		r = httptest.NewRequest(method, target, nil)
+	}
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	h(rec, r)
+	return rec
+}
+
+// --- Portfolio dividend endpoints ---
+
+func setupPortfolioWithDividends(t *testing.T, db *gorm.DB) *PortfolioHTTPHandler {
+	t.Helper()
+	cfg := &config.Config{JWTSecret: testJWTSecret}
+	rates := fundRatesProv{}
+	psvc := service.NewPortfolioService(
+		repository.NewPortfolioRepository(db),
+		service.NewTaxService(repository.NewTaxRepository(db), repository.NewMarketRepository(db), rates),
+		repository.NewMarketRepository(db),
+		repository.NewOrderRepository(db),
+	)
+	divSvc := service.NewDividendService(
+		repository.NewDividendRepository(db),
+		repository.NewOrderRepository(db),
+		service.NewTaxService(repository.NewTaxRepository(db), repository.NewMarketRepository(db), rates),
+		rates,
+	)
+	return NewPortfolioHTTPHandler(cfg, psvc).WithDividendService(divSvc)
+}
+
+func TestPortfolioDividends_ListEmpty(t *testing.T) {
+	db := newFundTestDB(t, "pf_div_list")
+	h := setupPortfolioWithDividends(t, db)
+	rec := do(t, h.PortfolioRoutes, http.MethodGet, "/api/v1/portfolio/dividends", clientToken(t), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Count int `json:"count"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Count != 0 {
+		t.Errorf("expected 0 dividends, got %d", resp.Count)
+	}
+}
+
+func TestPortfolioDividends_Unauthorized(t *testing.T) {
+	db := newFundTestDB(t, "pf_div_unauth")
+	h := setupPortfolioWithDividends(t, db)
+	rec := do(t, h.PortfolioRoutes, http.MethodGet, "/api/v1/portfolio/dividends", "", "")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func TestPortfolioDividends_RunRequiresSupervisor(t *testing.T) {
+	db := newFundTestDB(t, "pf_div_run")
+	h := setupPortfolioWithDividends(t, db)
+	// Client cannot trigger.
+	if rec := do(t, h.PortfolioRoutes, http.MethodPost, "/api/v1/portfolio/dividends/run", clientToken(t), ""); rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for client, got %d", rec.Code)
+	}
+	// Supervisor can: no holdings -> 0 paid, 200.
+	rec := do(t, h.PortfolioRoutes, http.MethodPost, "/api/v1/portfolio/dividends/run", supervisorToken(t), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for supervisor, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// --- Fund statistics / dividends / policy / benchmark / run ---
+
+func setupFundWithDividends(t *testing.T, db *gorm.DB) *FundHTTPHandler {
+	t.Helper()
+	cfg := &config.Config{JWTSecret: testJWTSecret}
+	rates := fundRatesProv{}
+	svc := service.NewFundService(
+		repository.NewFundRepository(db),
+		repository.NewPortfolioRepository(db),
+		repository.NewMarketRepository(db),
+		repository.NewOrderRepository(db),
+		rates,
+	).WithDividendRepo(repository.NewDividendRepository(db))
+	return NewFundHTTPHandler(cfg, svc)
+}
+
+// createFundViaAPI creates a fund as the supervisor (EmployeeID 6 -> manager 6).
+func createFundViaAPI(t *testing.T, h *FundHTTPHandler) uint {
+	t.Helper()
+	rec := do(t, h.FundRoutes, http.MethodPost, "/api/v1/funds", supervisorToken(t), `{"naziv":"F1","opis":"d","minimalniUlog":1000}`)
+	if rec.Code != http.StatusCreated && rec.Code != http.StatusOK {
+		t.Fatalf("create fund: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Fund struct {
+			ID uint `json:"id"`
+		} `json:"fund"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode fund: %v", err)
+	}
+	return resp.Fund.ID
+}
+
+func TestFundStatistics_InsufficientData(t *testing.T) {
+	db := newFundTestDB(t, "fh_stats")
+	h := setupFundWithDividends(t, db)
+	id := createFundViaAPI(t, h)
+	rec := do(t, h.FundRoutes, http.MethodGet, "/api/v1/funds/"+itoa(id)+"/statistics", clientToken(t), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Statistics struct {
+			Available bool `json:"available"`
+		} `json:"statistics"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Statistics.Available {
+		t.Errorf("expected available=false for a fund with no snapshots")
+	}
+}
+
+func TestFundDividends_ListAndBenchmark(t *testing.T) {
+	db := newFundTestDB(t, "fh_fdiv")
+	h := setupFundWithDividends(t, db)
+	id := createFundViaAPI(t, h)
+
+	if rec := do(t, h.FundRoutes, http.MethodGet, "/api/v1/funds/"+itoa(id)+"/dividends", clientToken(t), ""); rec.Code != http.StatusOK {
+		t.Fatalf("dividends: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if rec := do(t, h.FundRoutes, http.MethodGet, "/api/v1/funds/benchmark", clientToken(t), ""); rec.Code != http.StatusOK {
+		t.Fatalf("benchmark: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestFundDividendPolicy_Guards(t *testing.T) {
+	db := newFundTestDB(t, "fh_policy")
+	h := setupFundWithDividends(t, db)
+	id := createFundViaAPI(t, h)
+	path := "/api/v1/funds/" + itoa(id) + "/dividend-policy"
+
+	// Client cannot set policy.
+	if rec := do(t, h.FundRoutes, http.MethodPut, path, clientToken(t), `{"policy":"payout"}`); rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for client, got %d", rec.Code)
+	}
+	// Invalid policy value.
+	if rec := do(t, h.FundRoutes, http.MethodPut, path, supervisorToken(t), `{"policy":"bogus"}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid policy, got %d", rec.Code)
+	}
+	// Supervisor-manager sets it.
+	rec := do(t, h.FundRoutes, http.MethodPut, path, supervisorToken(t), `{"policy":"payout"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		DividendPolicy string `json:"dividendPolicy"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.DividendPolicy != "payout" {
+		t.Errorf("expected payout, got %q", resp.DividendPolicy)
+	}
+}
+
+func TestFundDividends_RunRequiresSupervisor(t *testing.T) {
+	db := newFundTestDB(t, "fh_run")
+	h := setupFundWithDividends(t, db)
+	if rec := do(t, h.FundRoutes, http.MethodPost, "/api/v1/funds/dividends/run", clientToken(t), ""); rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for client, got %d", rec.Code)
+	}
+	rec := do(t, h.FundRoutes, http.MethodPost, "/api/v1/funds/dividends/run", supervisorToken(t), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for supervisor, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// --- OTC negotiation endpoints ---
+
+func TestOtcNegotiations_ListAndHistory(t *testing.T) {
+	db := newTestDB(t, "otc_neg_http")
+	h := setupOtcHandler(t, db)
+	// Empty negotiations list -> 200.
+	if rec := do(t, h.OtcRoutes, http.MethodGet, "/api/v1/otc/negotiations", clientToken(t), ""); rec.Code != http.StatusOK {
+		t.Fatalf("negotiations list: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	// History for a nonexistent offer -> 404.
+	if rec := do(t, h.OtcRoutes, http.MethodGet, "/api/v1/otc/offers/9999/history", clientToken(t), ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown offer history, got %d", rec.Code)
+	}
+	// Unauthenticated -> 401.
+	if rec := do(t, h.OtcRoutes, http.MethodGet, "/api/v1/otc/negotiations", "", ""); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+}
+
+func itoa(v uint) string {
+	if v == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return string(buf[i:])
+}

--- a/exchange-service/internal/handler/fund_http_handler.go
+++ b/exchange-service/internal/handler/fund_http_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
@@ -59,6 +60,18 @@ func (h *FundHTTPHandler) FundRoutes(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.listMyPositions(w, r)
+	case len(parts) == 1 && parts[0] == "benchmark":
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.getBenchmark(w, r)
+	case len(parts) == 2 && parts[0] == "dividends" && parts[1] == "run":
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.runFundDividends(w, r)
 	case len(parts) == 1:
 		id, err := strconv.ParseUint(parts[0], 10, 64)
 		if err != nil {
@@ -107,6 +120,24 @@ func (h *FundHTTPHandler) FundRoutes(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			h.validateFundOrder(w, r, uint(id))
+		case "statistics":
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			h.getStatistics(w, r, uint(id))
+		case "dividends":
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			h.listFundDividends(w, r, uint(id))
+		case "dividend-policy":
+			if r.Method != http.MethodPut {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			h.setDividendPolicy(w, r, uint(id))
 		default:
 			http.NotFound(w, r)
 		}
@@ -135,7 +166,13 @@ func (h *FundHTTPHandler) listFunds(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "neuspesan izracun fonda"})
 			return
 		}
-		items = append(items, summariseToJSON(summary))
+		item := summariseToJSON(summary)
+		// Statistics columns for the discovery page (Celina 4). Best-effort: a
+		// failure leaves the fund without stats rather than failing the list.
+		if stats, err := h.svc.ComputeStatistics(funds[i].ID); err == nil {
+			item["statistics"] = statisticsToJSON(stats)
+		}
+		items = append(items, item)
 	}
 	writeJSON(w, http.StatusOK, map[string]interface{}{"funds": items, "count": len(items)})
 }
@@ -435,6 +472,113 @@ func (h *FundHTTPHandler) validateFundOrder(w http.ResponseWriter, r *http.Reque
 // fundParticipantIdentity maps a JWT into (clientID, clientType) for the
 // fund domain. Clients always invest as themselves; supervisors can pass
 // `asBank=true` to invest on behalf of the bank (clientID=0, type="bank").
+func (h *FundHTTPHandler) getStatistics(w http.ResponseWriter, r *http.Request, fundID uint) {
+	if _, ok := requireAuthenticatedHTTP(w, r, h.cfg); !ok {
+		return
+	}
+	if _, err := h.svc.GetFund(fundID); err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"message": "fond nije pronadjen"})
+		return
+	}
+	stats, err := h.svc.ComputeStatistics(fundID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"statistics": statisticsToJSON(stats)})
+}
+
+func (h *FundHTTPHandler) getBenchmark(w http.ResponseWriter, r *http.Request) {
+	if _, ok := requireAuthenticatedHTTP(w, r, h.cfg); !ok {
+		return
+	}
+	points, err := h.svc.AverageFundBenchmark()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"benchmark": points, "count": len(points)})
+}
+
+func (h *FundHTTPHandler) listFundDividends(w http.ResponseWriter, r *http.Request, fundID uint) {
+	if _, ok := requireAuthenticatedHTTP(w, r, h.cfg); !ok {
+		return
+	}
+	dividends, err := h.svc.ListFundDividends(fundID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+		return
+	}
+	items := make([]map[string]interface{}, 0, len(dividends))
+	for _, d := range dividends {
+		items = append(items, map[string]interface{}{
+			"id":               d.ID,
+			"assetId":          d.AssetID,
+			"ticker":           d.Ticker,
+			"period":           d.Period,
+			"quantity":         d.Quantity,
+			"grossRSD":         d.GrossRSD,
+			"policy":           d.Policy,
+			"reinvestedShares": d.ReinvestedShares,
+			"reinvestedRSD":    d.ReinvestedRSD,
+			"distributedRSD":   d.DistributedRSD,
+			"paidAt":           d.PaidAt.UTC().Format(time.RFC3339),
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"dividends": items, "count": len(items)})
+}
+
+func (h *FundHTTPHandler) setDividendPolicy(w http.ResponseWriter, r *http.Request, fundID uint) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireSupervisorHTTP(w, claims) {
+		return
+	}
+	var body struct {
+		Policy string `json:"policy"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "neispravan zahtev"})
+		return
+	}
+	fund, err := h.svc.SetDividendPolicy(fundID, claims.EmployeeID, body.Policy)
+	if err != nil {
+		if errors.Is(err, service.ErrFundNotFound) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"message": "fond nije pronadjen"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"fundId": fund.ID, "dividendPolicy": fund.DividendPolicy})
+}
+
+// runFundDividends triggers a fund-dividend distribution on demand (supervisor
+// only). Mirrors the client/bank manual trigger; idempotent per quarter.
+func (h *FundHTTPHandler) runFundDividends(w http.ResponseWriter, r *http.Request) {
+	claims, ok := requireAuthenticatedHTTP(w, r, h.cfg)
+	if !ok {
+		return
+	}
+	if !requireSupervisorHTTP(w, claims) {
+		return
+	}
+	res, err := h.svc.DistributeFundDividends(time.Now().UTC())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"message": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"period":    res.Period,
+		"eligible":  res.Eligible,
+		"processed": res.Processed,
+		"skipped":   res.Skipped,
+		"failed":    res.Failed,
+	})
+}
+
 func fundParticipantIdentity(claims *util.Claims, asBank bool) (uint, string, error) {
 	if asBank {
 		if claims.TokenSource != "employee" {
@@ -466,6 +610,7 @@ func summariseToJSON(s *service.FundSummary) map[string]interface{} {
 		"managerId":          s.Fund.ManagerID,
 		"accountId":          s.Fund.AccountID,
 		"datumKreiranja":     s.Fund.DatumKreiranja.Format("2006-01-02"),
+		"dividendPolicy":     s.Fund.DividendPolicy,
 		"fundValueRSD":       s.FundValueRSD,
 		"liquidCashRSD":      s.LiquidCashRSD,
 		"holdingsValueRSD":   s.HoldingsValueRSD,
@@ -473,5 +618,16 @@ func summariseToJSON(s *service.FundSummary) map[string]interface{} {
 		"profitRSD":          s.ProfitRSD,
 		"participantsCount":  s.ParticipantsCount,
 		"withdrawalCommRate": s.WithdrawalCommRate,
+	}
+}
+
+func statisticsToJSON(st service.FundStatistics) map[string]interface{} {
+	return map[string]interface{}{
+		"available":           st.Available,
+		"monthsOfData":        st.MonthsOfData,
+		"annualizedReturn":    st.AnnualizedReturn,
+		"volatility":          st.Volatility,
+		"rewardToVariability": st.RewardToVariability,
+		"maxDrawdown":         st.MaxDrawdown,
 	}
 }

--- a/exchange-service/internal/models/fund.go
+++ b/exchange-service/internal/models/fund.go
@@ -14,12 +14,45 @@ type InvestmentFundRecord struct {
 	MinimalniUlog  float64   `gorm:"column:minimalni_ulog;not null"`
 	ManagerID      uint      `gorm:"column:manager_id;not null;index"`
 	AccountID      uint      `gorm:"column:account_id;not null;uniqueIndex"`
+	// DividendPolicy decides what happens to dividends the fund's stocks pay
+	// (Celina 4): "reinvest" (default) auto-buys more of the paying stock;
+	// "payout" distributes the cash to participants pro-rata to their share.
+	// Either way the dividend first flows into the fund's RSD cash (the inflow).
+	DividendPolicy string    `gorm:"column:dividend_policy;not null;default:'reinvest'"`
 	DatumKreiranja time.Time `gorm:"column:datum_kreiranja;not null"`
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 }
 
 func (InvestmentFundRecord) TableName() string { return "investment_funds" }
+
+const (
+	FundDividendPolicyReinvest = "reinvest"
+	FundDividendPolicyPayout   = "payout"
+)
+
+// FundDividendRecord is the audit trail of one quarterly dividend a fund's
+// stock paid. The (fund_id, asset_id, period) unique index makes distribution
+// idempotent. GrossRSD is the dividend received into the fund (RSD); then
+// either ReinvestedRSD/ReinvestedShares (policy=reinvest) or DistributedRSD
+// (policy=payout, paid out to participants) accounts for where it went.
+type FundDividendRecord struct {
+	ID               uint      `gorm:"primaryKey"`
+	FundID           uint      `gorm:"column:fund_id;not null;index;uniqueIndex:idx_fund_dividend_fund_asset_period"`
+	AssetID          uint      `gorm:"column:asset_id;not null;uniqueIndex:idx_fund_dividend_fund_asset_period"`
+	Ticker           string    `gorm:"not null"`
+	Period           string    `gorm:"not null;uniqueIndex:idx_fund_dividend_fund_asset_period"` // "2026-Q2"
+	Quantity         float64   `gorm:"not null"`
+	GrossRSD         float64   `gorm:"column:gross_rsd;not null"`
+	Policy           string    `gorm:"not null"`
+	ReinvestedShares float64   `gorm:"column:reinvested_shares;not null;default:0"`
+	ReinvestedRSD    float64   `gorm:"column:reinvested_rsd;not null;default:0"`
+	DistributedRSD   float64   `gorm:"column:distributed_rsd;not null;default:0"`
+	PaidAt           time.Time `gorm:"column:paid_at;not null"`
+	CreatedAt        time.Time
+}
+
+func (FundDividendRecord) TableName() string { return "fund_dividends" }
 
 const (
 	FundTransactionStatusPending   = "pending"

--- a/exchange-service/internal/repository/dividend_repository.go
+++ b/exchange-service/internal/repository/dividend_repository.go
@@ -52,6 +52,24 @@ func (r *DividendRepository) ListDividendEligibleHoldings() ([]DividendEligibleH
 	return rows, err
 }
 
+// ListFundDividendEligibleHoldings returns every positive fund-owned stock
+// holding whose listing pays a dividend. The fund-dividend mechanism (Celina 4)
+// processes these; the client/bank payout above deliberately skips them.
+func (r *DividendRepository) ListFundDividendEligibleHoldings() ([]DividendEligibleHolding, error) {
+	var rows []DividendEligibleHolding
+	err := r.db.Table("portfolio_holdings AS ph").
+		Select(`ph.id AS holding_id, ph.user_id, ph.user_type, ph.asset_id,
+			ph.account_id, ph.quantity, ml.ticker, ml.price,
+			me.currency, s.dividend_yield`).
+		Joins("JOIN market_listings ml ON ml.id = ph.asset_id AND ml.type = 'stock'").
+		Joins("JOIN market_exchanges me ON me.id = ml.exchange_id").
+		Joins("JOIN stocks s ON s.listing_id = ml.id AND s.dividend_yield > 0").
+		Where("ph.quantity > 0 AND ph.user_type = 'fund'").
+		Order("ph.id ASC").
+		Scan(&rows).Error
+	return rows, err
+}
+
 // PayoutExists reports whether a payout has already been recorded for this
 // (asset, holder, period) — the idempotency guard for re-runs of one quarter.
 func (r *DividendRepository) PayoutExists(assetID, userID uint, userType, period string) (bool, error) {

--- a/exchange-service/internal/repository/fund_dividend_test.go
+++ b/exchange-service/internal/repository/fund_dividend_test.go
@@ -1,0 +1,94 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+)
+
+func TestDividendRepository_FundEligibleHoldings_OnlyFunds(t *testing.T) {
+	db := openRepoTestDB(t, "fund_div_eligible")
+	r := NewDividendRepository(db)
+
+	// fund-owned dividend stock (eligible), client-owned (excluded here), zero-yield fund (excluded)
+	seedDividendStock(t, db, "FAAPL", "USD", 200, 0.04, 9, "fund", 5)
+	seedDividendStock(t, db, "CAAPL", "USD", 200, 0.04, 1, "client", 5)
+	seedDividendStock(t, db, "FZERO", "USD", 50, 0, 9, "fund", 5)
+
+	rows, err := r.ListFundDividendEligibleHoldings()
+	if err != nil {
+		t.Fatalf("ListFundDividendEligibleHoldings: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 fund holding (client + zero-yield excluded), got %d", len(rows))
+	}
+	if rows[0].UserType != "fund" || rows[0].Ticker != "FAAPL" {
+		t.Errorf("unexpected row: %+v", rows[0])
+	}
+}
+
+func TestFundRepository_DividendHistoryAndPolicy(t *testing.T) {
+	db := openRepoTestDB(t, "fund_div_hist")
+	r := NewFundRepository(db)
+
+	// A fund whose dividend policy we can flip.
+	db.Exec(`INSERT INTO currencies (id, kod, aktivan) VALUES (1,'RSD',1)`)
+	fund, err := r.CreateFundWithAccount("Div Fund", "x", 1000, 7)
+	if err != nil {
+		t.Fatalf("create fund: %v", err)
+	}
+	if fund.DividendPolicy != models.FundDividendPolicyReinvest {
+		t.Errorf("expected default policy 'reinvest', got %q", fund.DividendPolicy)
+	}
+
+	if err := r.UpdateDividendPolicy(fund.ID, models.FundDividendPolicyPayout); err != nil {
+		t.Fatalf("UpdateDividendPolicy: %v", err)
+	}
+	got, _ := r.GetFundByID(fund.ID)
+	if got.DividendPolicy != models.FundDividendPolicyPayout {
+		t.Errorf("expected policy 'payout', got %q", got.DividendPolicy)
+	}
+
+	// Idempotency + history.
+	exists, _ := r.FundDividendExists(fund.ID, 1, "2026-Q2")
+	if exists {
+		t.Error("expected no dividend yet")
+	}
+	rec := &models.FundDividendRecord{
+		FundID: fund.ID, AssetID: 1, Ticker: "AAPL", Period: "2026-Q2", Quantity: 10,
+		GrossRSD: 500, Policy: models.FundDividendPolicyPayout, DistributedRSD: 480, PaidAt: time.Now().UTC(),
+	}
+	if err := r.CreateFundDividend(rec); err != nil {
+		t.Fatalf("CreateFundDividend: %v", err)
+	}
+	exists, _ = r.FundDividendExists(fund.ID, 1, "2026-Q2")
+	if !exists {
+		t.Error("expected dividend to exist after create")
+	}
+	hist, _ := r.ListFundDividends(fund.ID)
+	if len(hist) != 1 || hist[0].DistributedRSD != 480 {
+		t.Errorf("unexpected history: %+v", hist)
+	}
+}
+
+func TestFundRepository_FindParticipantRSDAccount(t *testing.T) {
+	db := openRepoTestDB(t, "fund_div_acct")
+	r := NewFundRepository(db)
+
+	db.Exec(`INSERT INTO currencies (id, kod, aktivan) VALUES (1,'RSD',1),(2,'USD',1)`)
+	db.Exec(`INSERT INTO firmas (id, naziv, is_state) VALUES (1,'EXBanka',0)`)
+	// client RSD account, a fund (fondacija) RSD account that must be ignored for bank lookup,
+	// and a bank firm RSD account.
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id, podvrsta) VALUES (10,1,'aktivan',7,'tekuci')`)
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, firma_id, podvrsta) VALUES (20,1,'aktivan',1,'fondacija')`)
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, firma_id, podvrsta) VALUES (21,1,'aktivan',1,'tekuci')`)
+
+	if id, err := r.FindParticipantRSDAccount(7, "client"); err != nil || id != 10 {
+		t.Errorf("expected client RSD account 10, got %d err=%v", id, err)
+	}
+	// Bank lookup must skip the fund (fondacija) account and pick the plain firm account.
+	if id, err := r.FindParticipantRSDAccount(0, "bank"); err != nil || id != 21 {
+		t.Errorf("expected bank firm RSD account 21 (not fondacija), got %d err=%v", id, err)
+	}
+}

--- a/exchange-service/internal/repository/fund_repository.go
+++ b/exchange-service/internal/repository/fund_repository.go
@@ -68,6 +68,17 @@ func (r *FundRepository) GetAccountByID(accountID uint) (*FundAccountRef, error)
 	return getFundAccountRef(r.db, accountID, false)
 }
 
+// CreditAccountTx / DebitAccountTx expose the internal balance moves so callers
+// (e.g. fund-dividend distribution) can compose them inside their own
+// transaction. DebitAccountTx fails if the available balance is insufficient.
+func CreditAccountTx(tx *gorm.DB, accountID uint, amount float64) error {
+	return creditFundAccount(tx, accountID, amount)
+}
+
+func DebitAccountTx(tx *gorm.DB, accountID uint, amount float64) error {
+	return debitFundAccount(tx, accountID, amount)
+}
+
 func (r *FundRepository) findOrCreateRSDCurrencyID(tx *gorm.DB) (uint, error) {
 	var id uint
 	err := tx.Table("currencies").Select("id").Where("kod = ?", "RSD").Limit(1).Scan(&id).Error
@@ -349,6 +360,51 @@ func (r *FundRepository) ListTransactionsForClient(clientID uint, clientType str
 		return nil, err
 	}
 	return txs, nil
+}
+
+// --- dividends (Celina 4) ---
+
+func (r *FundRepository) UpdateDividendPolicy(fundID uint, policy string) error {
+	return r.db.Model(&models.InvestmentFundRecord{}).Where("id = ?", fundID).
+		Updates(map[string]interface{}{"dividend_policy": policy, "updated_at": time.Now().UTC()}).Error
+}
+
+func (r *FundRepository) FundDividendExists(fundID, assetID uint, period string) (bool, error) {
+	var count int64
+	err := r.db.Model(&models.FundDividendRecord{}).
+		Where("fund_id = ? AND asset_id = ? AND period = ?", fundID, assetID, period).
+		Count(&count).Error
+	return count > 0, err
+}
+
+func (r *FundRepository) CreateFundDividend(rec *models.FundDividendRecord) error {
+	return r.db.Create(rec).Error
+}
+
+func (r *FundRepository) ListFundDividends(fundID uint) ([]models.FundDividendRecord, error) {
+	var recs []models.FundDividendRecord
+	if err := r.db.Where("fund_id = ?", fundID).Order("paid_at DESC, id DESC").Find(&recs).Error; err != nil {
+		return nil, err
+	}
+	return recs, nil
+}
+
+// FindParticipantRSDAccount returns an active RSD account for a fund participant
+// (client_id for clients; a non-state firm account for the bank), or 0 if none.
+func (r *FundRepository) FindParticipantRSDAccount(clientID uint, clientType string) (uint, error) {
+	q := r.db.Table("accounts").
+		Select("accounts.id").
+		Joins("JOIN currencies ON currencies.id = accounts.currency_id").
+		Where("currencies.kod = 'RSD' AND accounts.status = 'aktivan'")
+	if clientType == "client" {
+		q = q.Where("accounts.client_id = ?", clientID)
+	} else {
+		q = q.Joins("JOIN firmas ON firmas.id = accounts.firma_id").
+			Where("firmas.is_state = false AND accounts.podvrsta <> 'fondacija'")
+	}
+	var id uint
+	err := q.Limit(1).Scan(&id).Error
+	return id, err
 }
 
 // --- performance ---

--- a/exchange-service/internal/repository/interbank_saga_coverage_test.go
+++ b/exchange-service/internal/repository/interbank_saga_coverage_test.go
@@ -1,0 +1,57 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+)
+
+func TestInterbankAndSagaListHelpers(t *testing.T) {
+	db := openRepoTestDB(t, "ib_saga_lists")
+	now := time.Now().UTC()
+
+	ex := NewInterbankExerciseRepository(db)
+	if _, err := ex.ListStuckPendingOutbound(now, 10); err != nil {
+		t.Fatalf("ListStuckPendingOutbound: %v", err)
+	}
+	if _, err := ex.ListUndispatchedTerminalOutbound(now, 10); err != nil {
+		t.Fatalf("ListUndispatchedTerminalOutbound: %v", err)
+	}
+	if _, err := NewInterbankOtcRepository(db).ListUndispatchedAcceptCommits(now, 10); err != nil {
+		t.Fatalf("ListUndispatchedAcceptCommits: %v", err)
+	}
+
+	// saga AppendAttempt against a real saga row.
+	saga := &models.SagaTransactionRecord{Type: "otc_exercise", Status: "in_progress", CreatedAt: now, UpdatedAt: now}
+	if err := db.Create(saga).Error; err != nil {
+		t.Fatalf("seed saga: %v", err)
+	}
+	if err := NewSagaRepository(db).AppendAttempt(saga.ID, "F1", "ok", ""); err != nil {
+		t.Fatalf("AppendAttempt: %v", err)
+	}
+}
+
+func TestOtcRepository_ExpiryReminderHelpers(t *testing.T) {
+	db := openRepoTestDB(t, "otc_reminder")
+	now := time.Now().UTC()
+
+	c := &models.OtcContractRecord{
+		StockListingID: 1, SellerHoldingID: 1, Amount: 1, StrikePrice: 1,
+		SettlementDate: now.Add(48 * time.Hour),
+		BuyerID:        1, BuyerType: "client", BuyerAccountID: 1,
+		SellerID:       2, SellerType: "client", SellerAccountID: 2,
+		Status:         models.OtcContractStatusValid, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(c).Error; err != nil {
+		t.Fatalf("seed contract: %v", err)
+	}
+
+	r := NewOtcRepository(db)
+	if _, err := r.ListContractsNeedingExpiryReminder(now, 3); err != nil {
+		t.Fatalf("ListContractsNeedingExpiryReminder: %v", err)
+	}
+	if err := r.MarkExpiryReminderSent(c.ID); err != nil {
+		t.Fatalf("MarkExpiryReminderSent: %v", err)
+	}
+}

--- a/exchange-service/internal/repository/order_portfolio_coverage_test.go
+++ b/exchange-service/internal/repository/order_portfolio_coverage_test.go
@@ -1,0 +1,101 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"gorm.io/gorm"
+)
+
+func TestOrderRepository_MarginStopAndRefund(t *testing.T) {
+	db := openRepoTestDB(t, "ord_margin")
+	r := NewOrderRepository(db)
+
+	o := &models.OrderRecord{
+		UserID: 1, UserType: "client", AssetID: 5, Direction: "buy",
+		IsMargin: true, MarginLoan: 1000, Quantity: 1, ContractSize: 1, PricePerUnit: 1,
+		Status: "done", AccountID: 50, RemainingPortions: 0,
+		LastModification: time.Now().UTC(), CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(o).Error; err != nil {
+		t.Fatalf("seed order: %v", err)
+	}
+
+	if id, err := r.FindLatestBuyAccountID(1, "client", 5); err != nil || id != 50 {
+		t.Fatalf("FindLatestBuyAccountID: %d err=%v", id, err)
+	}
+	if err := r.SetStopTriggered(o.ID); err != nil {
+		t.Fatalf("SetStopTriggered: %v", err)
+	}
+	if err := r.SetMarginLoan(o.ID, 800); err != nil {
+		t.Fatalf("SetMarginLoan: %v", err)
+	}
+	if loans, err := r.ListOutstandingMarginLoansForUserAsset(1, "client", 5); err != nil || len(loans) != 1 {
+		t.Fatalf("ListOutstandingMarginLoans: %d err=%v", len(loans), err)
+	}
+	if applied, err := r.ReduceMarginLoan(o.ID, 500); err != nil || applied != 500 {
+		t.Fatalf("ReduceMarginLoan partial: applied=%v err=%v", applied, err)
+	}
+	if applied, _ := r.ReduceMarginLoan(o.ID, 9999); applied != 300 {
+		t.Errorf("ReduceMarginLoan clamp: applied=%v want 300", applied)
+	}
+	if applied, _ := r.ReduceMarginLoan(o.ID, 0); applied != 0 {
+		t.Errorf("ReduceMarginLoan zero: applied=%v want 0", applied)
+	}
+
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, raspolozivo_stanje, stanje) VALUES (50, 1, 'aktivan', 100, 100)`)
+	if err := r.RefundBuyOverReservation(o.ID, 50, 10); err != nil {
+		t.Fatalf("RefundBuyOverReservation: %v", err)
+	}
+	if err := r.RefundBuyOverReservation(o.ID, 50, 0); err != nil {
+		t.Fatalf("RefundBuyOverReservation no-op: %v", err)
+	}
+}
+
+func TestPortfolioRepository_SetAccountAndBuyFillTx(t *testing.T) {
+	db := openRepoTestDB(t, "port_extra")
+	pr := NewPortfolioRepository(db)
+
+	if err := pr.RecordBuyFill(1, "client", 7, 50, 10, 100); err != nil {
+		t.Fatalf("RecordBuyFill: %v", err)
+	}
+	var h models.PortfolioHoldingRecord
+	if err := db.Where("user_id = 1 AND asset_id = 7").First(&h).Error; err != nil {
+		t.Fatalf("load holding: %v", err)
+	}
+	if err := pr.SetHoldingAccountID(h.ID, 99); err != nil {
+		t.Fatalf("SetHoldingAccountID: %v", err)
+	}
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return RecordBuyFillTx(tx, 1, "client", 7, 50, 5, 110)
+	}); err != nil {
+		t.Fatalf("RecordBuyFillTx existing: %v", err)
+	}
+	// New holding via the tx variant.
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return RecordBuyFillTx(tx, 2, "client", 8, 51, 3, 50)
+	}); err != nil {
+		t.Fatalf("RecordBuyFillTx new: %v", err)
+	}
+}
+
+func TestFundRepository_CreditDebitTx(t *testing.T) {
+	db := openRepoTestDB(t, "fund_txhelpers")
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, raspolozivo_stanje, stanje) VALUES (60, 1, 'aktivan', 100, 100)`)
+
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		if err := CreditAccountTx(tx, 60, 50); err != nil {
+			return err
+		}
+		return DebitAccountTx(tx, 60, 30)
+	}); err != nil {
+		t.Fatalf("credit/debit tx: %v", err)
+	}
+	// Insufficient funds -> error.
+	if err := db.Transaction(func(tx *gorm.DB) error {
+		return DebitAccountTx(tx, 60, 999999)
+	}); err == nil {
+		t.Error("expected insufficient-funds error")
+	}
+}

--- a/exchange-service/internal/repository/portfolio_repository.go
+++ b/exchange-service/internal/repository/portfolio_repository.go
@@ -133,6 +133,35 @@ func (r *PortfolioRepository) RecordBuyFill(userID uint, userType string, assetI
 	})
 }
 
+// RecordBuyFillTx is the transaction-aware variant of RecordBuyFill. Used by
+// fund-service so dividend reinvestment can run inside the same transaction as
+// the cash debit.
+func RecordBuyFillTx(tx *gorm.DB, userID uint, userType string, assetID, accountID uint, filledQty float64, fillPrice float64) error {
+	var h models.PortfolioHoldingRecord
+	err := tx.Where("user_id = ? AND user_type = ? AND asset_id = ?", userID, userType, assetID).
+		First(&h).Error
+
+	now := time.Now().UTC()
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		h = models.PortfolioHoldingRecord{
+			UserID: userID, UserType: userType, AssetID: assetID, AccountID: accountID,
+			Quantity: filledQty, AvgBuyPrice: fillPrice, CreatedAt: now, UpdatedAt: now,
+		}
+		return tx.Create(&h).Error
+	}
+	if err != nil {
+		return err
+	}
+	newQty := h.Quantity + filledQty
+	newAvg := (h.Quantity*h.AvgBuyPrice + filledQty*fillPrice) / newQty
+	return tx.Model(&h).Updates(map[string]interface{}{
+		"quantity":      newQty,
+		"avg_buy_price": newAvg,
+		"account_id":    accountID,
+		"updated_at":    now,
+	}).Error
+}
+
 // RecordSellFill atomically decreases the holding quantity and accumulates
 // realized profit. Returns the realized profit for this fill.
 func (r *PortfolioRepository) RecordSellFill(userID uint, userType string, assetID uint, filledQty float64, sellPrice float64) (realizedProfit float64, err error) {

--- a/exchange-service/internal/repository/watchlist_pricealert_test.go
+++ b/exchange-service/internal/repository/watchlist_pricealert_test.go
@@ -1,0 +1,95 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+)
+
+func TestWatchlistRepository_CRUD(t *testing.T) {
+	db := openRepoTestDB(t, "wl_crud")
+	exch := models.MarketExchangeRecord{Acronym: "WX", Name: "X", MICCode: "WX1", Polity: "X", Currency: "USD", Timezone: "UTC", WorkingHours: "09-17"}
+	if err := db.Create(&exch).Error; err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if err := db.Create(&models.MarketListingRecord{
+		Ticker: "WLT", Name: "WLT", Type: "stock", ExchangeID: exch.ID,
+		Price: 10, Ask: 10, Bid: 10, Volume: 1, LastRefresh: time.Now().UTC(),
+	}).Error; err != nil {
+		t.Fatalf("listing: %v", err)
+	}
+
+	r := NewWatchlistRepository(db)
+	w := &models.Watchlist{UserID: 1, UserType: "client", Name: "tech"}
+	if err := r.Create(w); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if list, err := r.ListByUser(1, "client"); err != nil || len(list) != 1 {
+		t.Fatalf("ListByUser: %d err=%v", len(list), err)
+	}
+	if got, _ := r.GetByID(w.ID); got == nil {
+		t.Fatal("GetByID hit returned nil")
+	}
+	if miss, _ := r.GetByID(99999); miss != nil {
+		t.Error("GetByID miss should be nil")
+	}
+
+	if item, err := r.AddItem(w.ID, "WLT"); err != nil || item == nil {
+		t.Fatalf("AddItem valid: %v", err)
+	}
+	if _, err := r.AddItem(w.ID, "WLT"); err != ErrDuplicateItem {
+		t.Errorf("AddItem duplicate: want ErrDuplicateItem, got %v", err)
+	}
+	if _, err := r.AddItem(w.ID, "NOPE"); err != ErrTickerNotFound {
+		t.Errorf("AddItem unknown: want ErrTickerNotFound, got %v", err)
+	}
+
+	if items, err := r.GetItems(w.ID); err != nil || len(items) != 1 {
+		t.Fatalf("GetItems: %d err=%v", len(items), err)
+	}
+	if err := r.RemoveItem(w.ID, "WLT"); err != nil {
+		t.Fatalf("RemoveItem: %v", err)
+	}
+	if items, _ := r.GetItems(w.ID); len(items) != 0 {
+		t.Errorf("GetItems after remove: %d", len(items))
+	}
+	if err := r.Delete(w.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if got, _ := r.GetByID(w.ID); got != nil {
+		t.Error("GetByID after delete should be nil")
+	}
+}
+
+func TestPriceAlertRepository_CRUD(t *testing.T) {
+	db := openRepoTestDB(t, "pa_crud")
+	r := NewPriceAlertRepository(db)
+
+	a := &models.PriceAlert{
+		UserID: 1, UserType: "client", Ticker: "AAA", Condition: "ABOVE",
+		Threshold: 100, NotificationEmail: "e@x.com", IsActive: true,
+	}
+	if err := r.Create(a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if list, err := r.ListByUser(1, "client"); err != nil || len(list) != 1 {
+		t.Fatalf("ListByUser: %d err=%v", len(list), err)
+	}
+	if got, _ := r.GetByID(a.ID); got == nil {
+		t.Fatal("GetByID hit returned nil")
+	}
+	_, _ = r.GetByID(99999) // miss path
+
+	if active, err := r.GetActiveByTicker("AAA"); err != nil || len(active) != 1 {
+		t.Fatalf("GetActiveByTicker: %d err=%v", len(active), err)
+	}
+	if err := r.Deactivate(a.ID); err != nil {
+		t.Fatalf("Deactivate: %v", err)
+	}
+	if active, _ := r.GetActiveByTicker("AAA"); len(active) != 0 {
+		t.Errorf("GetActiveByTicker after deactivate: %d", len(active))
+	}
+}

--- a/exchange-service/internal/service/cron_service.go
+++ b/exchange-service/internal/service/cron_service.go
@@ -137,11 +137,23 @@ func StartCronJobs(
 			res, derr := dividendSvc.DistributeForDate(now)
 			if derr != nil {
 				slog.Error("Quarterly dividend distribution failed", "error", derr)
-				return
+			} else {
+				slog.Info("Quarterly dividend distribution finished",
+					"period", res.Period, "eligible", res.Eligible,
+					"paid", res.PaidOut, "skipped", res.Skipped, "failed", res.Failed)
 			}
-			slog.Info("Quarterly dividend distribution finished",
-				"period", res.Period, "eligible", res.Eligible,
-				"paid", res.PaidOut, "skipped", res.Skipped, "failed", res.Failed)
+			// Fund-held stocks pay dividends too (Celina 4) — distributed into the
+			// fund per its policy. Runs after the client/bank payout above.
+			if fundSvc != nil {
+				fres, ferr := fundSvc.DistributeFundDividends(now)
+				if ferr != nil {
+					slog.Error("Quarterly fund dividend distribution failed", "error", ferr)
+				} else {
+					slog.Info("Quarterly fund dividend distribution finished",
+						"period", fres.Period, "eligible", fres.Eligible,
+						"processed", fres.Processed, "skipped", fres.Skipped, "failed", fres.Failed)
+				}
+			}
 		})
 		if err != nil {
 			slog.Error("Failed to add dividend payout cron job", "error", err)

--- a/exchange-service/internal/service/dividend_distribution_test.go
+++ b/exchange-service/internal/service/dividend_distribution_test.go
@@ -1,0 +1,192 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/notify"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+	"gorm.io/gorm"
+)
+
+// openDivTestDB returns a migrated DB plus the reference currencies/accounts/
+// firmas tables the dividend + fund-dividend money moves read from.
+func openDivTestDB(t *testing.T, name string) *gorm.DB {
+	t.Helper()
+	db := openTestDB(t, name)
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS currencies (
+			id INTEGER PRIMARY KEY AUTOINCREMENT, kod TEXT, naziv TEXT, simbol TEXT, drzava TEXT,
+			aktivan BOOLEAN, created_at DATETIME, updated_at DATETIME
+		)`,
+		`CREATE TABLE IF NOT EXISTS accounts (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			broj_racuna TEXT, currency_id INTEGER, tip TEXT, vrsta TEXT, podvrsta TEXT,
+			stanje REAL DEFAULT 0, raspolozivo_stanje REAL DEFAULT 0,
+			dnevni_limit REAL, mesecni_limit REAL,
+			dnevna_potrosnja REAL DEFAULT 0, mesecna_potrosnja REAL DEFAULT 0,
+			datum_isteka DATETIME, odrzavanje_racuna REAL DEFAULT 0,
+			naziv TEXT, status TEXT, created_at DATETIME, updated_at DATETIME,
+			client_id INTEGER, firma_id INTEGER, zaposleni_id INTEGER
+		)`,
+		`CREATE TABLE IF NOT EXISTS firmas (id INTEGER PRIMARY KEY AUTOINCREMENT, naziv TEXT, is_state BOOLEAN DEFAULT 0)`,
+		`INSERT INTO currencies (id, kod, aktivan) VALUES (1,'RSD',1),(2,'USD',1)`,
+		`INSERT INTO firmas (id, naziv, is_state) VALUES (1,'EXBanka',0)`,
+	}
+	for _, s := range stmts {
+		if err := db.Exec(s).Error; err != nil {
+			t.Fatalf("seed ref tables: %v", err)
+		}
+	}
+	return db
+}
+
+// seedDivStock creates an exchange + stock listing (with a dividend yield) and
+// returns the listing id.
+func seedDivStock(t *testing.T, db *gorm.DB, ticker, currency string, price, yield float64) uint {
+	t.Helper()
+	exch := models.MarketExchangeRecord{
+		Acronym: "DX-" + ticker, Name: "X", MICCode: "MX-" + ticker, Polity: "X",
+		Currency: currency, Timezone: "UTC", WorkingHours: "09:00-17:00",
+	}
+	if err := db.Create(&exch).Error; err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	listing := models.MarketListingRecord{
+		Ticker: ticker, Name: ticker, Type: "stock", ExchangeID: exch.ID,
+		Price: price, Ask: price, Bid: price, Volume: 100, LastRefresh: time.Now().UTC(),
+	}
+	if err := db.Create(&listing).Error; err != nil {
+		t.Fatalf("listing: %v", err)
+	}
+	if err := db.Create(&models.StockRecord{ListingID: listing.ID, OutstandingShares: 1000, DividendYield: yield}).Error; err != nil {
+		t.Fatalf("stock: %v", err)
+	}
+	return listing.ID
+}
+
+func seedHolding(t *testing.T, db *gorm.DB, userID uint, userType string, assetID uint, qty float64, accountID uint) {
+	t.Helper()
+	if err := db.Create(&models.PortfolioHoldingRecord{
+		UserID: userID, UserType: userType, AssetID: assetID, Quantity: qty,
+		AvgBuyPrice: 1, AccountID: accountID, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	}).Error; err != nil {
+		t.Fatalf("holding: %v", err)
+	}
+}
+
+func acctBalance(t *testing.T, db *gorm.DB, id uint) float64 {
+	t.Helper()
+	var bal float64
+	if err := db.Table("accounts").Select("raspolozivo_stanje").Where("id = ?", id).Scan(&bal).Error; err != nil {
+		t.Fatalf("acct balance: %v", err)
+	}
+	return bal
+}
+
+func newDividendSvc(db *gorm.DB) *service.DividendService {
+	rates := &mockRateProv{rates: map[string]float64{"USD:RSD": 100}}
+	taxSvc := service.NewTaxService(repository.NewTaxRepository(db), repository.NewMarketRepository(db), rates)
+	return service.NewDividendService(repository.NewDividendRepository(db), repository.NewOrderRepository(db), taxSvc, rates)
+}
+
+func TestDividendService_DistributeForDate_ClientPayoutTaxAndIdempotent(t *testing.T) {
+	db := openDivTestDB(t, "div_dist_client")
+	assetID := seedDivStock(t, db, "DVA", "USD", 200, 0.04) // 4% yield
+	// Client 7 holds 100 shares bought from USD account 10.
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id) VALUES (10, 2, 'aktivan', 7)`)
+	seedHolding(t, db, 7, "client", assetID, 100, 10)
+
+	before := acctBalance(t, db, 10)
+	svc := newDividendSvc(db)
+	res, err := svc.DistributeForDate(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("DistributeForDate: %v", err)
+	}
+	if res.PaidOut != 1 || res.Failed != 0 {
+		t.Fatalf("expected 1 paid 0 failed, got %+v", res)
+	}
+
+	// gross = 100 * 200 * 0.04/4 = 200 USD, credited to the buy account (USD match).
+	if got := acctBalance(t, db, 10) - before; got != 200 {
+		t.Errorf("expected account credited by 200, got %v", got)
+	}
+	// Tax recorded for the client: 200 USD -> 20000 RSD * 15% = 3000.
+	taxSvc := service.NewTaxService(repository.NewTaxRepository(db), repository.NewMarketRepository(db), &mockRateProv{rates: map[string]float64{"USD:RSD": 100}})
+	taxes, _ := taxSvc.ListTaxRecords(7, "client", "")
+	if len(taxes) != 1 || taxes[0].TaxRSD != 3000 {
+		t.Errorf("expected 1 tax record of 3000, got %+v", taxes)
+	}
+	// History endpoint returns the payout.
+	payouts, _ := svc.ListPayoutsForUser(7, "client", 0)
+	if len(payouts) != 1 || payouts[0].GrossAmount != 200 {
+		t.Errorf("expected 1 payout of 200, got %+v", payouts)
+	}
+
+	// Idempotent: a second run pays nothing more.
+	res2, _ := svc.DistributeForDate(time.Now().UTC())
+	if res2.PaidOut != 0 || res2.Skipped != 1 {
+		t.Errorf("expected idempotent re-run (0 paid, 1 skipped), got %+v", res2)
+	}
+}
+
+func TestDividendService_DistributeForDate_BankUntaxedAndFundExcluded(t *testing.T) {
+	db := openDivTestDB(t, "div_dist_bank")
+	assetID := seedDivStock(t, db, "DVB", "USD", 100, 0.04)
+	// Bank holding (user 0) bought from a bank USD account.
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, firma_id) VALUES (20, 2, 'aktivan', 1)`)
+	seedHolding(t, db, 0, "bank", assetID, 100, 20)
+	// A fund holding on the same stock must be ignored by the client/bank path.
+	seedHolding(t, db, 1, "fund", assetID, 100, 20)
+
+	svc := newDividendSvc(db)
+	res, err := svc.DistributeForDate(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("DistributeForDate: %v", err)
+	}
+	if res.PaidOut != 1 {
+		t.Fatalf("expected only the bank holding paid (fund excluded), got %+v", res)
+	}
+	// Bank holders are not taxed.
+	taxSvc := service.NewTaxService(repository.NewTaxRepository(db), repository.NewMarketRepository(db), &mockRateProv{})
+	if taxes, _ := taxSvc.ListTaxRecords(0, "bank", ""); len(taxes) != 0 {
+		t.Errorf("bank holdings must be untaxed, got %d tax records", len(taxes))
+	}
+}
+
+// TestDividendService_WithNotifier exercises the WithNotifier wiring and the
+// emit branch of notifyHolder. The notifier points at a dead endpoint; emits are
+// fire-and-forget best-effort, so the distribution must still succeed.
+func TestDividendService_WithNotifier(t *testing.T) {
+	db := openDivTestDB(t, "div_notify")
+	assetID := seedDivStock(t, db, "DVN", "USD", 100, 0.04)
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id) VALUES (40, 2, 'aktivan', 7)`)
+	seedHolding(t, db, 7, "client", assetID, 100, 40)
+
+	svc := newDividendSvc(db).WithNotifier(notify.NewClient("http://127.0.0.1:0", "k"))
+	res, err := svc.DistributeForDate(time.Now().UTC())
+	if err != nil || res.PaidOut != 1 {
+		t.Fatalf("expected 1 paid with notifier wired, got %+v err=%v", res, err)
+	}
+}
+
+func TestDividendService_DistributeForDate_RSDFallbackAccount(t *testing.T) {
+	db := openDivTestDB(t, "div_dist_fallback")
+	assetID := seedDivStock(t, db, "DVC", "USD", 100, 0.04)
+	// Buy account is RSD (currency mismatch) -> primary path skipped. The holder
+	// has no USD account, so the payout converts to RSD and credits the RSD one.
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id) VALUES (30, 1, 'aktivan', 8)`)
+	seedHolding(t, db, 8, "client", assetID, 100, 30)
+
+	before := acctBalance(t, db, 30)
+	svc := newDividendSvc(db)
+	if _, err := svc.DistributeForDate(time.Now().UTC()); err != nil {
+		t.Fatalf("DistributeForDate: %v", err)
+	}
+	// gross 100 USD -> 10000 RSD credited to the RSD account.
+	if got := acctBalance(t, db, 30) - before; got != 10000 {
+		t.Errorf("expected RSD account credited by 10000, got %v", got)
+	}
+}

--- a/exchange-service/internal/service/fund_dividend_distribution_test.go
+++ b/exchange-service/internal/service/fund_dividend_distribution_test.go
@@ -1,0 +1,189 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/notify"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+	"gorm.io/gorm"
+)
+
+func newFundSvc(db *gorm.DB) *service.FundService {
+	rates := &mockRateProv{rates: map[string]float64{"USD:RSD": 100}}
+	return service.NewFundService(
+		repository.NewFundRepository(db),
+		repository.NewPortfolioRepository(db),
+		repository.NewMarketRepository(db),
+		repository.NewOrderRepository(db),
+		rates,
+	).WithDividendRepo(repository.NewDividendRepository(db))
+}
+
+func holdingQty(t *testing.T, db *gorm.DB, fundID, assetID uint) float64 {
+	t.Helper()
+	var qty float64
+	db.Table("portfolio_holdings").Select("quantity").
+		Where("user_id = ? AND user_type = 'fund' AND asset_id = ?", fundID, assetID).Scan(&qty)
+	return qty
+}
+
+func TestFundService_DistributeFundDividends_Reinvest(t *testing.T) {
+	db := openDivTestDB(t, "fund_div_reinvest")
+	svc := newFundSvc(db)
+
+	fund, err := svc.CreateFund(service.CreateFundInput{Naziv: "Reinvest Fund", Opis: "x", MinimalniUlog: 1000, ManagerID: 6})
+	if err != nil {
+		t.Fatalf("CreateFund: %v", err)
+	}
+	// 400 shares @ 50 USD, 4% yield. gross = 400*50*0.01 = 200 USD -> 20000 RSD.
+	// priceRSD = 5000 -> 4 whole shares reinvested.
+	assetID := seedDivStock(t, db, "FRE", "USD", 50, 0.04)
+	seedHolding(t, db, fund.ID, "fund", assetID, 400, fund.AccountID)
+
+	res, err := svc.DistributeFundDividends(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("DistributeFundDividends: %v", err)
+	}
+	if res.Processed != 1 || res.Failed != 0 {
+		t.Fatalf("expected 1 processed, got %+v", res)
+	}
+	if got := holdingQty(t, db, fund.ID, assetID); got != 404 {
+		t.Errorf("expected holding 400 -> 404 after reinvest, got %v", got)
+	}
+	hist, _ := svc.ListFundDividends(fund.ID)
+	if len(hist) != 1 || hist[0].ReinvestedShares != 4 || hist[0].Policy != models.FundDividendPolicyReinvest {
+		t.Errorf("unexpected dividend record: %+v", hist)
+	}
+
+	// Idempotent.
+	res2, _ := svc.DistributeFundDividends(time.Now().UTC())
+	if res2.Processed != 0 || res2.Skipped != 1 {
+		t.Errorf("expected idempotent re-run, got %+v", res2)
+	}
+}
+
+func TestFundService_DistributeFundDividends_Payout(t *testing.T) {
+	db := openDivTestDB(t, "fund_div_payout")
+	svc := newFundSvc(db)
+
+	fund, err := svc.CreateFund(service.CreateFundInput{Naziv: "Payout Fund", Opis: "x", MinimalniUlog: 1000, ManagerID: 6})
+	if err != nil {
+		t.Fatalf("CreateFund: %v", err)
+	}
+	if _, err := svc.SetDividendPolicy(fund.ID, 6, models.FundDividendPolicyPayout); err != nil {
+		t.Fatalf("SetDividendPolicy: %v", err)
+	}
+
+	assetID := seedDivStock(t, db, "FPA", "USD", 100, 0.04)
+	seedHolding(t, db, fund.ID, "fund", assetID, 100, fund.AccountID) // gross 100 USD -> 10000 RSD
+
+	// Sole participant: client 9 with a RSD payout account.
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id) VALUES (90, 1, 'aktivan', 9)`)
+	db.Create(&models.ClientFundPositionRecord{
+		ClientID: 9, ClientType: "client", FundID: fund.ID, UkupanUlozeniIznos: 1000,
+		DatumPoslednjePromene: time.Now().UTC(), CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	})
+
+	before := acctBalance(t, db, 90)
+	res, err := svc.DistributeFundDividends(time.Now().UTC())
+	if err != nil {
+		t.Fatalf("DistributeFundDividends: %v", err)
+	}
+	if res.Processed != 1 {
+		t.Fatalf("expected 1 processed, got %+v", res)
+	}
+	// 100% share -> the full 10000 RSD is paid to the client.
+	if got := acctBalance(t, db, 90) - before; got != 10000 {
+		t.Errorf("expected client paid 10000 RSD, got %v", got)
+	}
+	hist, _ := svc.ListFundDividends(fund.ID)
+	if len(hist) != 1 || hist[0].DistributedRSD != 10000 || hist[0].Policy != models.FundDividendPolicyPayout {
+		t.Errorf("unexpected dividend record: %+v", hist)
+	}
+}
+
+// TestFundService_DistributeFundDividends_PayoutNotifies covers the
+// notifyFundDividendPayout emit branch (best-effort, dead endpoint).
+func TestFundService_DistributeFundDividends_PayoutNotifies(t *testing.T) {
+	db := openDivTestDB(t, "fund_div_notify")
+	svc := newFundSvc(db).WithNotifier(notify.NewClient("http://127.0.0.1:0", "k"))
+
+	fund, _ := svc.CreateFund(service.CreateFundInput{Naziv: "Notify Fund", Opis: "x", MinimalniUlog: 1000, ManagerID: 6})
+	_, _ = svc.SetDividendPolicy(fund.ID, 6, models.FundDividendPolicyPayout)
+	assetID := seedDivStock(t, db, "FPN", "USD", 100, 0.04)
+	seedHolding(t, db, fund.ID, "fund", assetID, 100, fund.AccountID)
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id) VALUES (95, 1, 'aktivan', 9)`)
+	db.Create(&models.ClientFundPositionRecord{
+		ClientID: 9, ClientType: "client", FundID: fund.ID, UkupanUlozeniIznos: 1000,
+		DatumPoslednjePromene: time.Now().UTC(), CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	})
+
+	res, err := svc.DistributeFundDividends(time.Now().UTC())
+	if err != nil || res.Processed != 1 {
+		t.Fatalf("expected 1 processed with notifier wired, got %+v err=%v", res, err)
+	}
+}
+
+func TestFundService_SetDividendPolicy_Guards(t *testing.T) {
+	db := openDivTestDB(t, "fund_policy_guards")
+	svc := newFundSvc(db)
+	fund, _ := svc.CreateFund(service.CreateFundInput{Naziv: "Guard Fund", Opis: "x", MinimalniUlog: 1000, ManagerID: 6})
+
+	// Wrong manager.
+	if _, err := svc.SetDividendPolicy(fund.ID, 999, models.FundDividendPolicyPayout); err == nil {
+		t.Error("expected error for non-manager")
+	}
+	// Invalid policy.
+	if _, err := svc.SetDividendPolicy(fund.ID, 6, "bogus"); err == nil {
+		t.Error("expected error for invalid policy")
+	}
+	// Valid.
+	updated, err := svc.SetDividendPolicy(fund.ID, 6, models.FundDividendPolicyPayout)
+	if err != nil || updated.DividendPolicy != models.FundDividendPolicyPayout {
+		t.Errorf("expected policy update to payout, got %v err=%v", updated, err)
+	}
+}
+
+func TestFundService_StatisticsAndBenchmark(t *testing.T) {
+	db := openDivTestDB(t, "fund_stats_db")
+	svc := newFundSvc(db)
+	fund, _ := svc.CreateFund(service.CreateFundInput{Naziv: "Stats Fund", Opis: "x", MinimalniUlog: 1000, ManagerID: 6})
+
+	// Five monthly snapshots: 100 -> 110 -> 99 -> 120 -> 130.
+	vals := []struct {
+		d string
+		v float64
+	}{
+		{"2026-02-28", 100000}, {"2026-03-31", 110000}, {"2026-04-30", 99000},
+		{"2026-05-31", 120000}, {"2026-06-15", 130000},
+	}
+	for _, s := range vals {
+		d, _ := time.Parse("2006-01-02", s.d)
+		if err := db.Create(&models.FundPerformanceHistoryRecord{FundID: fund.ID, Date: d, FundValue: s.v, CreatedAt: time.Now().UTC()}).Error; err != nil {
+			t.Fatalf("snapshot: %v", err)
+		}
+	}
+
+	stats, err := svc.ComputeStatistics(fund.ID)
+	if err != nil {
+		t.Fatalf("ComputeStatistics: %v", err)
+	}
+	if !stats.Available || stats.MonthsOfData != 4 {
+		t.Fatalf("expected available with 4 monthly returns, got %+v", stats)
+	}
+	// Max drawdown 110 -> 99 = 0.10.
+	if stats.MaxDrawdown < 0.099 || stats.MaxDrawdown > 0.101 {
+		t.Errorf("expected drawdown ~0.10, got %v", stats.MaxDrawdown)
+	}
+
+	bench, err := svc.AverageFundBenchmark()
+	if err != nil {
+		t.Fatalf("AverageFundBenchmark: %v", err)
+	}
+	if len(bench) != 5 || bench[0].IndexValue != 100 {
+		t.Errorf("expected 5 benchmark points starting at 100, got %+v", bench)
+	}
+}

--- a/exchange-service/internal/service/fund_dividend_service.go
+++ b/exchange-service/internal/service/fund_dividend_service.go
@@ -1,0 +1,285 @@
+package service
+
+import (
+	"fmt"
+	"log/slog"
+	"math"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/notify"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"gorm.io/gorm"
+)
+
+// FundDividendRunResult summarises a fund-dividend distribution run.
+type FundDividendRunResult struct {
+	Period    string
+	Eligible  int
+	Processed int
+	Skipped   int
+	Failed    int
+}
+
+// DistributeFundDividends pays the quarter's dividends on fund-held stocks
+// (Celina 4). For each eligible holding the gross dividend (converted to RSD)
+// flows into the fund's cash account, then the fund's DividendPolicy decides the
+// rest: "reinvest" buys whole shares of the paying stock back, "payout"
+// distributes the cash to participants pro-rata to their share. Idempotent per
+// (fund, asset, quarter). Builds on — and stays consistent with — the Celina 3
+// client/bank payout (DividendService), which deliberately skips fund holdings.
+func (s *FundService) DistributeFundDividends(now time.Time) (FundDividendRunResult, error) {
+	period := QuarterPeriod(now)
+	result := FundDividendRunResult{Period: period}
+	if s.dividendRepo == nil {
+		return result, fmt.Errorf("fund dividends: dividend repo not wired")
+	}
+
+	holdings, err := s.dividendRepo.ListFundDividendEligibleHoldings()
+	if err != nil {
+		return result, fmt.Errorf("list fund dividend holdings: %w", err)
+	}
+	result.Eligible = len(holdings)
+
+	for _, h := range holdings {
+		grossNative := h.Quantity * h.Price * (h.DividendYield / dividendQuartersPerYear)
+		grossRSD := round2RSD(s.dividendToRSD(grossNative, h.Currency))
+		if grossRSD <= 0.005 {
+			result.Skipped++
+			continue
+		}
+		fundID := h.UserID
+
+		exists, err := s.fundRepo.FundDividendExists(fundID, h.AssetID, period)
+		if err != nil {
+			slog.Error("fund dividend: exists check failed", "fundID", fundID, "assetID", h.AssetID, "error", err)
+			result.Failed++
+			continue
+		}
+		if exists {
+			result.Skipped++
+			continue
+		}
+
+		fund, err := s.fundRepo.GetFundByID(fundID)
+		if err != nil || fund == nil {
+			result.Skipped++
+			continue
+		}
+
+		rec, err := s.processFundDividend(fund, h, grossRSD, period, now)
+		if err != nil {
+			slog.Error("fund dividend: processing failed", "fundID", fundID, "assetID", h.AssetID, "error", err)
+			result.Failed++
+			continue
+		}
+		if err := s.fundRepo.CreateFundDividend(rec); err != nil {
+			slog.Error("fund dividend: money moved but record failed", "fundID", fundID, "assetID", h.AssetID, "error", err)
+			result.Failed++
+			continue
+		}
+		result.Processed++
+	}
+
+	slog.Info("fund dividend: distribution complete",
+		"period", result.Period, "eligible", result.Eligible,
+		"processed", result.Processed, "skipped", result.Skipped, "failed", result.Failed)
+	return result, nil
+}
+
+// processFundDividend runs the inflow + policy for one holding atomically and
+// returns the audit record (unsaved).
+func (s *FundService) processFundDividend(fund *models.InvestmentFundRecord, h repository.DividendEligibleHolding, grossRSD float64, period string, now time.Time) (*models.FundDividendRecord, error) {
+	rec := &models.FundDividendRecord{
+		FundID: fund.ID, AssetID: h.AssetID, Ticker: h.Ticker, Period: period,
+		Quantity: h.Quantity, GrossRSD: grossRSD, Policy: fund.DividendPolicy, PaidAt: now.UTC(),
+	}
+
+	// For payout, resolve the per-participant plan BEFORE opening the write
+	// transaction. Reading inside the tx would deadlock the single-writer SQLite
+	// test DB, and keeps the transaction to pure money moves on Postgres too.
+	var payoutPlan []fundPayoutTarget
+	if fund.DividendPolicy == models.FundDividendPolicyPayout {
+		plan, err := s.computePayoutPlan(fund, grossRSD)
+		if err != nil {
+			return nil, err
+		}
+		payoutPlan = plan
+	}
+
+	var notifyPayouts []fundPayoutTarget
+	txErr := s.fundRepo.DB().Transaction(func(tx *gorm.DB) error {
+		// Inflow: the dividend always lands in the fund's cash first.
+		if err := repository.CreditAccountTx(tx, fund.AccountID, grossRSD); err != nil {
+			return err
+		}
+
+		switch fund.DividendPolicy {
+		case models.FundDividendPolicyPayout:
+			distributed := 0.0
+			for _, t := range payoutPlan {
+				if err := repository.DebitAccountTx(tx, fund.AccountID, t.AmountRSD); err != nil {
+					return err
+				}
+				if err := repository.CreditAccountTx(tx, t.AccountID, t.AmountRSD); err != nil {
+					return err
+				}
+				distributed = round2RSD(distributed + t.AmountRSD)
+			}
+			rec.DistributedRSD = distributed
+			notifyPayouts = payoutPlan
+		default: // reinvest
+			shares, costRSD, err := s.reinvestFundDividendTx(tx, fund, h, grossRSD, now)
+			if err != nil {
+				return err
+			}
+			rec.ReinvestedShares = shares
+			rec.ReinvestedRSD = costRSD
+		}
+		return nil
+	})
+	if txErr != nil {
+		return nil, txErr
+	}
+
+	for _, t := range notifyPayouts {
+		s.notifyFundDividendPayout(fund, h.Ticker, t)
+	}
+	return rec, nil
+}
+
+// reinvestFundDividendTx buys whole shares of the paying stock with the freshly
+// received dividend cash, leaving any remainder as fund cash. Returns the shares
+// bought and the RSD spent. Mirrors the liquidation path's order-ledger writes.
+func (s *FundService) reinvestFundDividendTx(tx *gorm.DB, fund *models.InvestmentFundRecord, h repository.DividendEligibleHolding, grossRSD float64, now time.Time) (float64, float64, error) {
+	priceRSD := s.dividendToRSD(h.Price, h.Currency)
+	if priceRSD <= 0 {
+		return 0, 0, nil // can't price — leave the inflow as cash
+	}
+	shares := math.Floor(grossRSD / priceRSD)
+	if shares <= 0 {
+		return 0, 0, nil // dividend too small for a whole share — stays as cash
+	}
+	costRSD := round2RSD(shares * priceRSD)
+
+	if err := repository.DebitAccountTx(tx, fund.AccountID, costRSD); err != nil {
+		return 0, 0, err
+	}
+	order := &models.OrderRecord{
+		UserID: fund.ID, UserType: models.PortfolioOwnerFund, AssetID: h.AssetID,
+		OrderType: "market", Direction: "buy", Quantity: int64(shares), ContractSize: 1,
+		PricePerUnit: h.Price, Status: "done", IsDone: true, RemainingPortions: 0,
+		AccountID: fund.AccountID, LastModification: now, CreatedAt: now,
+	}
+	if err := tx.Create(order).Error; err != nil {
+		return 0, 0, err
+	}
+	if err := tx.Create(&models.OrderTransactionRecord{
+		OrderID: order.ID, Quantity: order.Quantity, PricePerUnit: h.Price, ExecutedAt: now,
+	}).Error; err != nil {
+		return 0, 0, err
+	}
+	if err := repository.RecordBuyFillTx(tx, fund.ID, models.PortfolioOwnerFund, h.AssetID, fund.AccountID, shares, h.Price); err != nil {
+		return 0, 0, err
+	}
+	return shares, costRSD, nil
+}
+
+type fundPayoutTarget struct {
+	ClientID   uint
+	ClientType string
+	AccountID  uint
+	AmountRSD  float64
+}
+
+// computePayoutPlan resolves how the dividend cash splits across participants
+// pro-rata to their share of the fund: each gets floor(gross × share) into their
+// RSD account (rounded down so the total never exceeds the gross; any remainder
+// stays in fund cash). Participants without a payable account are skipped, their
+// slice staying in the fund. Read-only — the actual debits/credits run later in
+// the distribution transaction.
+func (s *FundService) computePayoutPlan(fund *models.InvestmentFundRecord, grossRSD float64) ([]fundPayoutTarget, error) {
+	positions, err := s.fundRepo.ListPositionsForFund(fund.ID)
+	if err != nil {
+		return nil, err
+	}
+	total := 0.0
+	for _, p := range positions {
+		total += p.UkupanUlozeniIznos
+	}
+	if total <= 0 || len(positions) == 0 {
+		return nil, nil // no participants — leave as cash
+	}
+
+	targets := make([]fundPayoutTarget, 0, len(positions))
+	for _, p := range positions {
+		share := p.UkupanUlozeniIznos / total
+		amount := math.Floor(grossRSD*share*100) / 100
+		if amount <= 0 {
+			continue
+		}
+		acctID, err := s.fundRepo.FindParticipantRSDAccount(p.ClientID, p.ClientType)
+		if err != nil {
+			return nil, err
+		}
+		if acctID == 0 {
+			continue // no payable account — their slice stays in fund cash
+		}
+		targets = append(targets, fundPayoutTarget{
+			ClientID: p.ClientID, ClientType: p.ClientType, AccountID: acctID, AmountRSD: amount,
+		})
+	}
+	return targets, nil
+}
+
+func (s *FundService) notifyFundDividendPayout(fund *models.InvestmentFundRecord, ticker string, t fundPayoutTarget) {
+	if s.notifier == nil || t.ClientType != "client" {
+		return
+	}
+	s.notifier.Emit(notify.Event{
+		UserID:   t.ClientID,
+		UserType: "client",
+		Type:     "FUND_DIVIDEND_PAID",
+		Title:    "Dividenda iz fonda",
+		Body: fmt.Sprintf("Fond \"%s\" vam je isplatio dividendu (%s): %.2f RSD.",
+			fund.Naziv, ticker, t.AmountRSD),
+		Link: "/funds",
+	})
+}
+
+// ListFundDividends returns a fund's dividend history.
+func (s *FundService) ListFundDividends(fundID uint) ([]models.FundDividendRecord, error) {
+	return s.fundRepo.ListFundDividends(fundID)
+}
+
+// SetDividendPolicy updates a fund's dividend policy (manager only).
+func (s *FundService) SetDividendPolicy(fundID, actorID uint, policy string) (*models.InvestmentFundRecord, error) {
+	if policy != models.FundDividendPolicyReinvest && policy != models.FundDividendPolicyPayout {
+		return nil, fmt.Errorf("nepoznata politika dividendi: %s", policy)
+	}
+	fund, err := s.GetFund(fundID)
+	if err != nil {
+		return nil, err
+	}
+	if fund.ManagerID != actorID {
+		return nil, fmt.Errorf("supervisor ne upravlja ovim fondom")
+	}
+	if err := s.fundRepo.UpdateDividendPolicy(fundID, policy); err != nil {
+		return nil, err
+	}
+	fund.DividendPolicy = policy
+	return fund, nil
+}
+
+// dividendToRSD converts amount from currency to RSD via the rate provider,
+// falling back to 1:1 when no rate exists.
+func (s *FundService) dividendToRSD(amount float64, currency string) float64 {
+	if currency == "" || currency == "RSD" {
+		return amount
+	}
+	rate, err := s.rateProvider.GetRate(currency, "RSD")
+	if err != nil || rate == 0 {
+		return amount
+	}
+	return amount * rate
+}

--- a/exchange-service/internal/service/fund_service.go
+++ b/exchange-service/internal/service/fund_service.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/notify"
 	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
 	"gorm.io/gorm"
 )
@@ -32,6 +33,21 @@ type FundService struct {
 	marketRepo    *repository.MarketRepository
 	orderRepo     *repository.OrderRepository
 	rateProvider  RateProviderInterface
+	dividendRepo  *repository.DividendRepository // optional; wired for fund dividends
+	notifier      *notify.Client                 // optional; best-effort in-app notifications
+}
+
+// WithDividendRepo wires the repository used to discover fund-held
+// dividend-paying holdings (Celina 4 fund dividends).
+func (s *FundService) WithDividendRepo(d *repository.DividendRepository) *FundService {
+	s.dividendRepo = d
+	return s
+}
+
+// WithNotifier wires the optional best-effort notification client.
+func (s *FundService) WithNotifier(n *notify.Client) *FundService {
+	s.notifier = n
+	return s
 }
 
 func NewFundService(

--- a/exchange-service/internal/service/fund_statistics.go
+++ b/exchange-service/internal/service/fund_statistics.go
@@ -1,0 +1,224 @@
+package service
+
+import (
+	"math"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+)
+
+// minMonthlyReturnsForStats is the smallest number of month-over-month returns
+// (i.e. monthly snapshots minus one) needed before risk/return metrics are
+// shown. Below this the series is too short for a meaningful std-dev (§Celina 4
+// "metrike imaju smisla tek kada postoji dovoljno istorijskih podataka").
+const minMonthlyReturnsForStats = 2
+
+// stdDevEpsilon is the floor below which a monthly-return std-dev is treated as
+// zero, so floating-point noise on near-constant returns can't explode the
+// reward-to-variability ratio.
+const stdDevEpsilon = 1e-9
+
+// FundStatistics holds the §Celina 4 risk/return metrics for a fund. All ratios
+// are annualized from monthly returns. When Available is false the fund has too
+// little history and the numeric fields should be ignored.
+type FundStatistics struct {
+	Available           bool    `json:"available"`
+	MonthsOfData        int     `json:"monthsOfData"` // number of monthly returns used
+	AnnualizedReturn    float64 `json:"annualizedReturn"`
+	Volatility          float64 `json:"volatility"`
+	RewardToVariability float64 `json:"rewardToVariability"`
+	MaxDrawdown         float64 `json:"maxDrawdown"`
+}
+
+// ComputeStatistics derives the fund's metrics from its full daily snapshot
+// history. Max drawdown uses the daily series; the annualized return,
+// volatility and reward-to-variability use month-end values resampled from it.
+func (s *FundService) ComputeStatistics(fundID uint) (FundStatistics, error) {
+	snapshots, err := s.fundRepo.ListPerformance(fundID, time.Unix(0, 0).UTC(), time.Now().UTC())
+	if err != nil {
+		return FundStatistics{}, err
+	}
+	return computeFundStatistics(snapshots), nil
+}
+
+func computeFundStatistics(snapshots []models.FundPerformanceHistoryRecord) FundStatistics {
+	stats := FundStatistics{}
+	if len(snapshots) == 0 {
+		return stats
+	}
+
+	// Max drawdown over the full daily series.
+	stats.MaxDrawdown = round4(maxDrawdown(snapshots))
+
+	monthly := monthEndValues(snapshots)
+	returns := simpleReturns(monthly)
+	stats.MonthsOfData = len(returns)
+	if len(returns) < minMonthlyReturnsForStats {
+		return stats // Available stays false
+	}
+
+	mean := meanOf(returns)
+	std := stdDevSample(returns, mean)
+
+	// Annualized return from the geometric mean of monthly returns.
+	growth := 1.0
+	for _, r := range returns {
+		growth *= (1 + r)
+	}
+	annualized := math.Pow(growth, 12.0/float64(len(returns))) - 1
+
+	stats.Available = true
+	stats.AnnualizedReturn = round4(annualized)
+	stats.Volatility = round4(std * math.Sqrt(12)) // annualized volatility
+	// Guard against floating-point noise: near-constant returns yield a tiny
+	// non-zero std that would otherwise blow the ratio up to ~1e15.
+	if std > stdDevEpsilon {
+		// Reward-to-variability (Sharpe, risk-free = 0), annualized.
+		stats.RewardToVariability = round4((mean / std) * math.Sqrt(12))
+	}
+	return stats
+}
+
+// monthEndValues returns the last snapshot value of each calendar month, in
+// chronological order. Snapshots are assumed already sorted ascending by date.
+func monthEndValues(snapshots []models.FundPerformanceHistoryRecord) []float64 {
+	type ym struct {
+		y int
+		m time.Month
+	}
+	order := make([]ym, 0)
+	last := map[ym]float64{}
+	for _, snap := range snapshots {
+		key := ym{snap.Date.Year(), snap.Date.Month()}
+		if _, seen := last[key]; !seen {
+			order = append(order, key)
+		}
+		last[key] = snap.FundValue
+	}
+	out := make([]float64, 0, len(order))
+	for _, k := range order {
+		out = append(out, last[k])
+	}
+	return out
+}
+
+func simpleReturns(values []float64) []float64 {
+	if len(values) < 2 {
+		return nil
+	}
+	out := make([]float64, 0, len(values)-1)
+	for i := 1; i < len(values); i++ {
+		if values[i-1] == 0 {
+			continue
+		}
+		out = append(out, values[i]/values[i-1]-1)
+	}
+	return out
+}
+
+// maxDrawdown returns the largest peak-to-trough decline as a positive fraction
+// (e.g. 0.25 = a 25% drop from a prior peak).
+func maxDrawdown(snapshots []models.FundPerformanceHistoryRecord) float64 {
+	peak := math.Inf(-1)
+	worst := 0.0
+	for _, snap := range snapshots {
+		v := snap.FundValue
+		if v > peak {
+			peak = v
+		}
+		if peak > 0 {
+			dd := (peak - v) / peak
+			if dd > worst {
+				worst = dd
+			}
+		}
+	}
+	return worst
+}
+
+func meanOf(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, x := range xs {
+		sum += x
+	}
+	return sum / float64(len(xs))
+}
+
+func stdDevSample(xs []float64, mean float64) float64 {
+	if len(xs) < 2 {
+		return 0
+	}
+	ss := 0.0
+	for _, x := range xs {
+		d := x - mean
+		ss += d * d
+	}
+	return math.Sqrt(ss / float64(len(xs)-1))
+}
+
+func round4(v float64) float64 {
+	return math.Round(v*10000) / 10000
+}
+
+// BenchmarkPoint is one point of the cross-fund average performance index.
+type BenchmarkPoint struct {
+	Date       string  `json:"date"`
+	IndexValue float64 `json:"indexValue"` // average of all funds, each rebased to 100 at its own start
+}
+
+// AverageFundBenchmark builds the §Celina 4 comparison curve: every fund's
+// snapshot series is rebased to 100 at its own first snapshot, then averaged per
+// date across all funds that have data on that date. Lets the detail page
+// overlay one fund against the system-wide average.
+func (s *FundService) AverageFundBenchmark() ([]BenchmarkPoint, error) {
+	funds, err := s.fundRepo.ListFunds()
+	if err != nil {
+		return nil, err
+	}
+	sums := map[string]float64{}
+	counts := map[string]int{}
+	dateOrder := make([]string, 0)
+	seen := map[string]bool{}
+
+	for i := range funds {
+		snaps, err := s.fundRepo.ListPerformance(funds[i].ID, time.Unix(0, 0).UTC(), time.Now().UTC())
+		if err != nil {
+			return nil, err
+		}
+		if len(snaps) == 0 || snaps[0].FundValue <= 0 {
+			continue
+		}
+		base := snaps[0].FundValue
+		for _, snap := range snaps {
+			d := snap.Date.Format("2006-01-02")
+			if !seen[d] {
+				seen[d] = true
+				dateOrder = append(dateOrder, d)
+			}
+			sums[d] += (snap.FundValue / base) * 100
+			counts[d]++
+		}
+	}
+
+	sortStrings(dateOrder)
+	out := make([]BenchmarkPoint, 0, len(dateOrder))
+	for _, d := range dateOrder {
+		if counts[d] == 0 {
+			continue
+		}
+		out = append(out, BenchmarkPoint{Date: d, IndexValue: round2RSD(sums[d] / float64(counts[d]))})
+	}
+	return out, nil
+}
+
+// sortStrings sorts date strings ascending (YYYY-MM-DD sorts lexicographically).
+func sortStrings(xs []string) {
+	for i := 1; i < len(xs); i++ {
+		for j := i; j > 0 && xs[j-1] > xs[j]; j-- {
+			xs[j-1], xs[j] = xs[j], xs[j-1]
+		}
+	}
+}

--- a/exchange-service/internal/service/fund_statistics_internal_test.go
+++ b/exchange-service/internal/service/fund_statistics_internal_test.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+)
+
+func snap(y int, m time.Month, d int, v float64) models.FundPerformanceHistoryRecord {
+	return models.FundPerformanceHistoryRecord{Date: time.Date(y, m, d, 0, 0, 0, 0, time.UTC), FundValue: v}
+}
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 0.001 }
+
+func TestComputeFundStatistics_InsufficientData(t *testing.T) {
+	// One monthly point → zero returns → not available.
+	st := computeFundStatistics([]models.FundPerformanceHistoryRecord{snap(2026, 1, 31, 100)})
+	if st.Available {
+		t.Errorf("expected not available with a single snapshot, got %+v", st)
+	}
+	if st.MonthsOfData != 0 {
+		t.Errorf("expected 0 monthly returns, got %d", st.MonthsOfData)
+	}
+}
+
+func TestComputeFundStatistics_SteadyGrowth(t *testing.T) {
+	// +10% each month for 3 months → 3 monthly returns of 0.10.
+	snaps := []models.FundPerformanceHistoryRecord{
+		snap(2026, 1, 31, 100),
+		snap(2026, 2, 28, 110),
+		snap(2026, 3, 31, 121),
+		snap(2026, 4, 30, 133.1),
+	}
+	st := computeFundStatistics(snaps)
+	if !st.Available || st.MonthsOfData != 3 {
+		t.Fatalf("expected available with 3 returns, got %+v", st)
+	}
+	// Geometric annualized: (1.1^3)^(12/3) - 1.
+	want := math.Pow(math.Pow(1.1, 3), 4) - 1
+	if !approx(st.AnnualizedReturn, round4(want)) {
+		t.Errorf("annualizedReturn=%v, want ~%v", st.AnnualizedReturn, round4(want))
+	}
+	// Constant returns → zero volatility and zero reward-to-variability.
+	if st.Volatility != 0 {
+		t.Errorf("expected 0 volatility for constant returns, got %v", st.Volatility)
+	}
+	if st.RewardToVariability != 0 {
+		t.Errorf("expected 0 reward-to-variability when std=0, got %v", st.RewardToVariability)
+	}
+	if st.MaxDrawdown != 0 {
+		t.Errorf("expected 0 drawdown on monotonic growth, got %v", st.MaxDrawdown)
+	}
+}
+
+func TestComputeFundStatistics_MaxDrawdownAndVolatility(t *testing.T) {
+	// 100 -> 110 -> 90 -> 120. Peak 110, trough 90 => drawdown 20/110.
+	snaps := []models.FundPerformanceHistoryRecord{
+		snap(2026, 1, 31, 100),
+		snap(2026, 2, 28, 110),
+		snap(2026, 3, 31, 90),
+		snap(2026, 4, 30, 120),
+	}
+	st := computeFundStatistics(snaps)
+	if !st.Available {
+		t.Fatalf("expected available, got %+v", st)
+	}
+	wantDD := round4(20.0 / 110.0)
+	if !approx(st.MaxDrawdown, wantDD) {
+		t.Errorf("maxDrawdown=%v, want ~%v", st.MaxDrawdown, wantDD)
+	}
+	if st.Volatility <= 0 {
+		t.Errorf("expected positive volatility for varying returns, got %v", st.Volatility)
+	}
+}
+
+func TestMonthEndValues_TakesLastPerMonth(t *testing.T) {
+	snaps := []models.FundPerformanceHistoryRecord{
+		snap(2026, 1, 10, 100),
+		snap(2026, 1, 20, 105), // later January wins
+		snap(2026, 2, 5, 110),
+	}
+	got := monthEndValues(snaps)
+	if len(got) != 2 || got[0] != 105 || got[1] != 110 {
+		t.Errorf("expected [105 110], got %v", got)
+	}
+}

--- a/loan-service/internal/service/loan_coverage_extra_test.go
+++ b/loan-service/internal/service/loan_coverage_extra_test.go
@@ -1,0 +1,33 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/loan-service/internal/notify"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/loan-service/internal/service"
+)
+
+func TestBaseInterestRate_Varijabilna_AllBands(t *testing.T) {
+	cases := []struct {
+		amount float64
+		want   float64
+	}{
+		{50_000, 4.5},
+		{250_000, 3.8},
+		{750_000, 3.2},
+		{3_000_000, 2.5},
+		{6_000_000, 2.0},
+	}
+	for _, c := range cases {
+		if got := service.BaseInterestRate(c.amount, "varijabilna"); got != c.want {
+			t.Errorf("BaseInterestRate(%.0f, varijabilna)=%v, want %v", c.amount, got, c.want)
+		}
+	}
+}
+
+func TestWithAppNotifier_Chains(t *testing.T) {
+	svc := service.NewLoanService(nil, nil, nil, nil)
+	if svc.WithAppNotifier(notify.NewClient("", "")) != svc {
+		t.Error("WithAppNotifier should return the same service for chaining")
+	}
+}

--- a/payment-service/internal/service/notify_internal_test.go
+++ b/payment-service/internal/service/notify_internal_test.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/payment-service/internal/models"
+)
+
+func TestNotifyHelpers(t *testing.T) {
+	n := NewAppNotifier(&config.Config{NotificationServiceURL: "", InternalAPIKey: ""})
+	if n == nil {
+		t.Fatal("NewAppNotifier returned nil")
+	}
+	if (&PaymentService{}).WithAppNotifier(n) == nil {
+		t.Error("PaymentService.WithAppNotifier returned nil")
+	}
+	if (&PrenosService{}).WithAppNotifier(n) == nil {
+		t.Error("PrenosService.WithAppNotifier returned nil")
+	}
+
+	p := &models.Payment{Iznos: 100, RacunPrimaocaBroj: "111"}
+	sender := uint(1)
+	receiver := uint(2)
+
+	// nil client -> early return.
+	emitPaymentSettled(nil, p, &sender, &receiver, "payment")
+	// payment kind, both sender + receiver.
+	emitPaymentSettled(n, p, &sender, &receiver, "payment")
+	// prenos kind, sender only (receiver not our client).
+	emitPaymentSettled(n, p, &sender, nil, "prenos")
+	// receiver only (e.g. incoming to our client from elsewhere).
+	emitPaymentSettled(n, p, nil, &receiver, "payment")
+}

--- a/transfer-service/internal/service/notify_internal_test.go
+++ b/transfer-service/internal/service/notify_internal_test.go
@@ -1,0 +1,26 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/transfer-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/transfer-service/internal/models"
+)
+
+func TestNotifyHelpers(t *testing.T) {
+	// NewAppNotifier builds a (no-op) client from config.
+	n := NewAppNotifier(&config.Config{NotificationServiceURL: "", InternalAPIKey: ""})
+	if n == nil {
+		t.Fatal("NewAppNotifier returned nil")
+	}
+	// WithAppNotifier chains on the service.
+	svc := (&TransferService{}).WithAppNotifier(n)
+	if svc == nil {
+		t.Fatal("WithAppNotifier returned nil")
+	}
+
+	// emitTransferSettled: nil guard branch + the emit branch (no-op client).
+	emitTransferSettled(nil, &models.Transfer{}, nil)
+	cid := uint(5)
+	emitTransferSettled(n, &models.Transfer{Iznos: 100, ValutaIznosa: "RSD"}, &cid)
+}


### PR DESCRIPTION
…test coverage

Celina 4 fund features (exchange-service):
- Per-fund DividendPolicy ("reinvest" default | "payout") + FundDividendRecord (table fund_dividends, unique fund+asset+period -> idempotent). On the same quarterly tick as the Celina 3 payout, fund-held dividend stocks pay into the fund's RSD cash (inflow), then reinvest auto-buys whole shares of the paying stock, or payout distributes pro-rata to participants' RSD accounts + FUND_DIVIDEND_PAID. Fund holdings excluded from the client/bank path. Endpoints: GET /funds/{id}/dividends, PUT /funds/{id}/dividend-policy (manager+supervisor), POST /funds/dividends/run.
- Fund statistics from the daily snapshot series (monthly-resampled): annualized return, volatility, reward-to-variability (Sharpe rf=0), max drawdown; min-data guard + stdDevEpsilon floor. AverageFundBenchmark = each fund rebased to 100, averaged per date. GET /funds/{id}/statistics, GET /funds/benchmark; stats embedded per-fund in GET /funds.
- Fix: fund payout resolved participants/accounts inside the write tx, which deadlocked SQLite (and was poor practice on Postgres) — now precomputed before the tx (computePayoutPlan).

Test coverage to >=80% on 11 packages (quick-win batch + util + repository): loan/transfer/payment/account/client service, employee/auth/exchange database, account/auth util (Redis token-revocation via dead-address client), exchange repository (watchlist/price-alert CRUD, order/portfolio/fund tx helpers, interbank/saga/otc list helpers). Plus service+handler tests for the new dividend/fund/OTC-negotiation code. Still pending: exchange service/handler.