### PR TITLE
test(exchange): raise service 54.7→77.5% & handler 58.9→64.6%; +2 bug…

### DIFF
--- a/exchange-service/internal/handler/create_order_http_test.go
+++ b/exchange-service/internal/handler/create_order_http_test.go
@@ -1,0 +1,55 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+func setupOrderHandlerWithAccounts(t *testing.T, name string) (*OrderHTTPHandler, *gorm.DB) {
+	t.Helper()
+	db := newTestDB(t, name)
+	seedOtcHandlerAccounts(t, db)                  // accounts 1 (client 200), 2 (client 100), USD
+	seedExchangeAndListing(t, db, "HORD")          // USD stock "HORD" @ 100
+	return setupOrderHandler(t, db), db
+}
+
+func TestOrderHTTP_CreateOrder_ClientMarketBuy(t *testing.T) {
+	h, _ := setupOrderHandlerWithAccounts(t, "h_create_market")
+	body := `{"assetTicker":"HORD","orderType":"market","direction":"buy","quantity":2,"contractSize":1,"accountId":2}`
+	rec := do(t, h.OrdersCollection, http.MethodPost, "/api/v1/orders", clientToken(t), body)
+	if rec.Code != http.StatusCreated && rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOrderHTTP_CreateOrder_LimitAutoDetect(t *testing.T) {
+	h, _ := setupOrderHandlerWithAccounts(t, "h_create_limit")
+	// orderType "market" + a limit value -> auto-detected as a limit order.
+	body := `{"assetTicker":"HORD","orderType":"market","direction":"buy","quantity":1,"contractSize":1,"accountId":2,"limitValue":120}`
+	rec := do(t, h.OrdersCollection, http.MethodPost, "/api/v1/orders", clientToken(t), body)
+	if rec.Code != http.StatusCreated && rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOrderHTTP_CreateOrder_StopAutoDetectAndSell(t *testing.T) {
+	h, _ := setupOrderHandlerWithAccounts(t, "h_create_stop")
+	// Stop value only -> "stop"; sell direction doesn't debit.
+	body := `{"assetTicker":"HORD","orderType":"market","direction":"sell","quantity":1,"contractSize":1,"accountId":2,"stopValue":90}`
+	rec := do(t, h.OrdersCollection, http.MethodPost, "/api/v1/orders", clientToken(t), body)
+	if rec.Code != http.StatusCreated && rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestOrderHTTP_CreateOrder_ValidationError(t *testing.T) {
+	h, _ := setupOrderHandlerWithAccounts(t, "h_create_invalid")
+	// Unknown asset -> service rejects with 400.
+	body := `{"assetTicker":"NOPE","orderType":"market","direction":"buy","quantity":1,"contractSize":1,"accountId":2}`
+	rec := do(t, h.OrdersCollection, http.MethodPost, "/api/v1/orders", clientToken(t), body)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unknown asset, got %d", rec.Code)
+	}
+}

--- a/exchange-service/internal/handler/interbank_otc_validation_test.go
+++ b/exchange-service/internal/handler/interbank_otc_validation_test.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+func setupInterbankOtcWithRegistry(t *testing.T, name string) *InterbankOtcHTTPHandler {
+	t.Helper()
+	db := newFundTestDB(t, name)
+	cfg := &config.Config{JWTSecret: testJWTSecret}
+	reg, err := interbank.NewRegistryFromJSON(333,
+		`[{"code":444,"baseUrl":"http://127.0.0.1:1","outboundKey":"o","inboundKey":"i","displayName":"P"}]`)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	return NewInterbankOtcHTTPHandler(
+		cfg, reg, interbank.NewClient(reg),
+		repository.NewInterbankOtcRepository(db), nil, repository.NewRemotePublicStockRepository(db),
+		repository.NewInterbankOptionContractRepository(db),
+		repository.NewInterbankExerciseRepository(db),
+		repository.NewInterbankWalletRepository(db),
+		repository.NewPortfolioRepository(db),
+		repository.NewMarketRepository(db),
+		db,
+	)
+}
+
+func TestInterbankOtcHTTP_CreateNegotiation_Validation(t *testing.T) {
+	h := setupInterbankOtcWithRegistry(t, "ib_otc_create_val")
+	tok := clientToken(t)
+	path := "/api/v1/interbank-otc/negotiations"
+
+	cases := map[string]string{
+		"bad json":         `{`,
+		"missing seller":   `{"stock":{"ticker":"X"},"amount":1}`,
+		"own bank seller":  `{"sellerId":{"routingNumber":333,"id":"c1"},"stock":{"ticker":"X"},"amount":1}`,
+		"unknown partner":  `{"sellerId":{"routingNumber":999,"id":"c1"},"stock":{"ticker":"X"},"amount":1}`,
+		"empty ticker":     `{"sellerId":{"routingNumber":444,"id":"c1"},"stock":{"ticker":""},"amount":1}`,
+		"non-positive amt": `{"sellerId":{"routingNumber":444,"id":"c1"},"stock":{"ticker":"X"},"amount":0}`,
+	}
+	for name, body := range cases {
+		rec := do(t, h.Routes, http.MethodPost, path, tok, body)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d (%s)", name, rec.Code, rec.Body.String())
+		}
+	}
+
+	// Employee token cannot start interbank negotiations -> 403.
+	if rec := do(t, h.Routes, http.MethodPost, path, supervisorToken(t),
+		`{"sellerId":{"routingNumber":444,"id":"c1"},"stock":{"ticker":"X"},"amount":1}`); rec.Code != http.StatusForbidden {
+		t.Errorf("employee start: expected 403, got %d", rec.Code)
+	}
+}
+
+func TestInterbankOtcHTTP_ExerciseContract_Validation(t *testing.T) {
+	h := setupInterbankOtcWithRegistry(t, "ib_otc_exercise_val")
+
+	// Unauthenticated -> 401.
+	if rec := do(t, h.Routes, http.MethodPost, "/api/v1/interbank-otc/option-contracts/1/exercise", "", ""); rec.Code != http.StatusUnauthorized {
+		t.Errorf("unauth: expected 401, got %d", rec.Code)
+	}
+	// Bad contract id -> 400.
+	if rec := do(t, h.Routes, http.MethodPost, "/api/v1/interbank-otc/option-contracts/abc/exercise", clientToken(t), ""); rec.Code != http.StatusBadRequest {
+		t.Errorf("bad id: expected 400, got %d", rec.Code)
+	}
+	// Unknown contract -> 404.
+	if rec := do(t, h.Routes, http.MethodPost, "/api/v1/interbank-otc/option-contracts/99999/exercise", clientToken(t), ""); rec.Code != http.StatusNotFound {
+		t.Errorf("unknown: expected 404, got %d (%s)", rec.Code, "")
+	}
+}
+
+func TestInterbankOtcHTTP_PublicStocks_ReadsCached(t *testing.T) {
+	db := newFundTestDB(t, "ib_otc_pubstock")
+	cfg := &config.Config{JWTSecret: testJWTSecret}
+	reg, _ := interbank.NewRegistryFromJSON(333,
+		`[{"code":444,"baseUrl":"http://127.0.0.1:1","outboundKey":"o","inboundKey":"i","displayName":"P"}]`)
+	snapRepo := repository.NewRemotePublicStockRepository(db)
+	// Seed a cached snapshot so readCached returns data instead of fanning out.
+	if err := snapRepo.UpsertPayload(444, `[]`); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+	h := NewInterbankOtcHTTPHandler(
+		cfg, reg, interbank.NewClient(reg),
+		repository.NewInterbankOtcRepository(db), nil, snapRepo,
+		repository.NewInterbankOptionContractRepository(db),
+		repository.NewInterbankExerciseRepository(db),
+		repository.NewInterbankWalletRepository(db),
+		repository.NewPortfolioRepository(db),
+		repository.NewMarketRepository(db),
+		db,
+	)
+
+	rec := do(t, h.Routes, http.MethodGet, "/api/v1/interbank-otc/public-stocks", clientToken(t), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("public-stocks status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/exchange-service/internal/handler/interbank_payment_validation_test.go
+++ b/exchange-service/internal/handler/interbank_payment_validation_test.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/config"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+func setupIBPaymentWithRegistry(t *testing.T, name string) *InterbankPaymentHTTPHandler {
+	t.Helper()
+	db := newFundTestDB(t, name)
+	cfg := &config.Config{JWTSecret: testJWTSecret}
+	reg, err := interbank.NewRegistryFromJSON(333,
+		`[{"code":444,"baseUrl":"http://127.0.0.1:1","outboundKey":"o","inboundKey":"i","displayName":"P"}]`)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	return NewInterbankPaymentHTTPHandler(cfg, reg, interbank.NewClient(reg),
+		repository.NewInterbankPaymentRepository(db), repository.NewInterbankPaymentWalletRepository(db), db)
+}
+
+func TestInterbankPaymentHTTP_CreatePayment_Validation(t *testing.T) {
+	h := setupIBPaymentWithRegistry(t, "ib_pay_create_val")
+	path := "/api/v1/payments/cross-bank"
+	tok := clientToken(t)
+
+	// Employee token cannot initiate cross-bank payments.
+	if rec := do(t, h.Routes, http.MethodPost, path, supervisorToken(t),
+		`{"senderAccountNumber":"1","recipientAccountNumber":"2","currency":"RSD","amount":10}`); rec.Code != http.StatusForbidden {
+		t.Errorf("employee: expected 403, got %d", rec.Code)
+	}
+
+	cases := map[string]string{
+		"bad json":         `{`,
+		"missing accounts": `{"currency":"RSD","amount":10}`,
+		"missing currency": `{"senderAccountNumber":"1","recipientAccountNumber":"2","amount":10}`,
+		"unknown currency": `{"senderAccountNumber":"1","recipientAccountNumber":"2","currency":"XYZ","amount":10}`,
+		"non-positive amt": `{"senderAccountNumber":"1","recipientAccountNumber":"2","currency":"RSD","amount":0}`,
+		"same accounts":    `{"senderAccountNumber":"1","recipientAccountNumber":"1","currency":"RSD","amount":10}`,
+	}
+	for name, body := range cases {
+		if rec := do(t, h.Routes, http.MethodPost, path, tok, body); rec.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d (%s)", name, rec.Code, rec.Body.String())
+		}
+	}
+}

--- a/exchange-service/internal/handler/negotiation_dividend_response_test.go
+++ b/exchange-service/internal/handler/negotiation_dividend_response_test.go
@@ -1,0 +1,94 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+)
+
+// TestOtcNegotiationHistory_WithEntries seeds a real negotiation thread so the
+// history endpoint exercises negotiationEntryToResponse + parseHistoryDate.
+func TestOtcNegotiationHistory_WithEntries(t *testing.T) {
+	db := newTestDB(t, "h_neg_hist")
+	seedOtcHandlerAccounts(t, db)
+	_, listingID := seedExchangeAndListing(t, db, "HNH")
+
+	now := time.Now().UTC()
+	settle := now.AddDate(0, 1, 0)
+	offer := &models.OtcOfferRecord{
+		StockListingID: listingID, SellerHoldingID: 1, Amount: 3, PricePerStock: 100,
+		SettlementDate: settle, Premium: 5, LastModified: now, ModifiedByID: 200, ModifiedByType: "client",
+		Status: models.OtcOfferStatusDeclined,
+		BuyerID: 100, BuyerType: "client", BuyerAccountID: 2,
+		SellerID: 200, SellerType: "client", SellerAccountID: 1,
+	}
+	if err := db.Create(offer).Error; err != nil {
+		t.Fatalf("seed offer: %v", err)
+	}
+	prevAmt := 3.0
+	prevSettle := settle
+	for _, e := range []*models.OtcNegotiationEntryRecord{
+		{OfferID: offer.ID, Action: "created", ActorID: 100, ActorType: "client", Amount: 3, PricePerStock: 100, Premium: 5, SettlementDate: settle, CreatedAt: now.Add(-2 * time.Hour)},
+		{OfferID: offer.ID, Action: "countered", ActorID: 200, ActorType: "client", Amount: 4, PricePerStock: 110, Premium: 6, SettlementDate: settle, PrevAmount: &prevAmt, PrevSettlementDate: &prevSettle, CreatedAt: now.Add(-1 * time.Hour)},
+	} {
+		if err := db.Create(e).Error; err != nil {
+			t.Fatalf("seed entry: %v", err)
+		}
+	}
+
+	h := setupOtcHandler(t, db)
+
+	// History endpoint -> populated entries (covers negotiationEntryToResponse).
+	rec := do(t, h.OtcRoutes, http.MethodGet, "/api/v1/otc/offers/"+strconv.FormatUint(uint64(offer.ID), 10)+"/history", clientToken(t), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("history status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Count int `json:"count"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Count != 2 {
+		t.Errorf("expected 2 history entries, got %d", resp.Count)
+	}
+
+	// Negotiations list with date + status filters (covers parseHistoryDate).
+	rec2 := do(t, h.OtcRoutes, http.MethodGet,
+		"/api/v1/otc/negotiations?status=declined&from=2026-01-01&to=2027-12-31&counterparty=200",
+		clientToken(t), "")
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("negotiations status=%d body=%s", rec2.Code, rec2.Body.String())
+	}
+}
+
+// TestPortfolioDividends_WithData seeds a payout so the list endpoint exercises
+// dividendToResponse.
+func TestPortfolioDividends_WithData(t *testing.T) {
+	db := newFundTestDB(t, "h_div_data")
+	h := setupPortfolioWithDividends(t, db)
+
+	now := time.Now().UTC()
+	if err := db.Create(&models.DividendPayoutRecord{
+		AssetID: 1, Ticker: "AAPL", UserID: 100, UserType: "client", AccountID: 2,
+		Quantity: 10, PricePerShare: 200, DividendYield: 0.01, Currency: "USD",
+		GrossAmount: 20, CreditedAmount: 20, CreditedCurrency: "USD", TaxRSD: 300,
+		Period: "2026-Q2", PaidAt: now,
+	}).Error; err != nil {
+		t.Fatalf("seed payout: %v", err)
+	}
+
+	rec := do(t, h.PortfolioRoutes, http.MethodGet, "/api/v1/portfolio/dividends", clientToken(t), "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Count int `json:"count"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Count != 1 {
+		t.Errorf("expected 1 dividend, got %d", resp.Count)
+	}
+}

--- a/exchange-service/internal/models/fund.go
+++ b/exchange-service/internal/models/fund.go
@@ -97,9 +97,11 @@ func (ClientFundPositionRecord) TableName() string { return "client_fund_positio
 // FundPerformanceHistoryRecord stores a daily snapshot of the fund's total
 // value (cash + market value of securities, in RSD).
 type FundPerformanceHistoryRecord struct {
-	ID        uint      `gorm:"primaryKey"`
-	FundID    uint      `gorm:"column:fund_id;not null;index:idx_fund_perf_fund_date"`
-	Date      time.Time `gorm:"type:date;not null;index:idx_fund_perf_fund_date"`
+	ID uint `gorm:"primaryKey"`
+	// (fund_id, date) is unique: one snapshot per fund per day. The unique index
+	// is also what SavePerformanceSnapshot's ON CONFLICT upsert targets.
+	FundID    uint      `gorm:"column:fund_id;not null;uniqueIndex:idx_fund_perf_fund_date"`
+	Date      time.Time `gorm:"type:date;not null;uniqueIndex:idx_fund_perf_fund_date"`
 	FundValue float64   `gorm:"column:fund_value;not null"`
 	CreatedAt time.Time
 }

--- a/exchange-service/internal/repository/order_repository.go
+++ b/exchange-service/internal/repository/order_repository.go
@@ -153,7 +153,7 @@ type ActuaryProfile struct {
 func (r *OrderRepository) GetActuaryProfile(employeeID uint) (*ActuaryProfile, error) {
 	var profile ActuaryProfile
 	err := r.db.Table("actuary_profiles").
-		Select("employee_id, trading_limit as limit, used_limit, need_approval").
+		Select(`employee_id, trading_limit as "limit", used_limit, need_approval`).
 		Where("employee_id = ?", employeeID).
 		First(&profile).Error
 	if err != nil {

--- a/exchange-service/internal/service/cron_bump_internal_test.go
+++ b/exchange-service/internal/service/cron_bump_internal_test.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/notify"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+type cronRateProv struct{}
+
+func (cronRateProv) GetRate(from, to string) (float64, error) { return 100, nil }
+func (cronRateProv) GetAllRates() []ExchangeRate             { return nil }
+
+func TestStartCronJobs_AllDepsWired(t *testing.T) {
+	db := openSagaTestDB(t, "cron_all_deps")
+	rates := cronRateProv{}
+
+	portfolioRepo := repository.NewPortfolioRepository(db)
+	orderRepo := repository.NewOrderRepository(db)
+	marketRepo := repository.NewMarketRepository(db)
+	taxRepo := repository.NewTaxRepository(db)
+	otcRepo := repository.NewOtcRepository(db)
+	sagaRepo := repository.NewSagaRepository(db)
+	dividendRepo := repository.NewDividendRepository(db)
+
+	taxSvc := NewTaxService(taxRepo, marketRepo, rates)
+	portfolioSvc := NewPortfolioService(portfolioRepo, taxSvc, marketRepo, orderRepo)
+	fundSvc := NewFundService(repository.NewFundRepository(db), portfolioRepo, marketRepo, orderRepo, rates)
+	dividendSvc := NewDividendService(dividendRepo, orderRepo, taxSvc, rates)
+	sagaRetry := NewSagaRetryRunner(sagaRepo, otcRepo, NewSagaOrchestrator(sagaRepo, db))
+
+	reg, _ := interbank.NewRegistryFromJSON(333, "[]")
+	client := interbank.NewClient(reg)
+	ibReconcile := NewInterbankReconcileRunner(
+		db, reg, client,
+		repository.NewInterbankPaymentRepository(db),
+		repository.NewInterbankPaymentWalletRepository(db),
+		repository.NewInterbankExerciseRepository(db),
+		repository.NewInterbankWalletRepository(db),
+		repository.NewInterbankOtcRepository(db),
+	)
+	ibCache := NewPublicStockCacheRunner(reg, client, repository.NewRemotePublicStockRepository(db))
+	emailSvc := NewSMTPEmailService("127.0.0.1", 1, "f@x.com")
+	notifier := notify.NewClient("", "")
+
+	c := StartCronJobs(db, portfolioSvc, rates, sagaRetry, fundSvc, dividendSvc, ibReconcile, ibCache, emailSvc, notifier)
+	if c == nil {
+		t.Fatal("StartCronJobs returned nil")
+	}
+	c.Stop()
+}
+
+func TestInterbankReconcile_BumpHelpers(t *testing.T) {
+	db := openSagaTestDB(t, "ib_bumps")
+	r := NewInterbankReconcileRunner(
+		db, nil, nil,
+		repository.NewInterbankPaymentRepository(db),
+		repository.NewInterbankPaymentWalletRepository(db),
+		repository.NewInterbankExerciseRepository(db),
+		repository.NewInterbankWalletRepository(db),
+		repository.NewInterbankOtcRepository(db),
+	)
+	past := time.Now().UTC().Add(-time.Hour)
+
+	neg := &models.InterbankOtcNegotiation{
+		NegotiationRoutingNumber: 333, NegotiationID: "n-bump", LocalRole: models.InterbankNegotiationRoleSeller,
+		CounterpartyRoutingNumber: 444, BuyerRoutingNumber: 444, BuyerID: "b", SellerRoutingNumber: 333, SellerID: "s",
+		StockTicker: "ACME", Amount: 1, PricePerUnitCurrency: "RSD", PricePerUnitAmount: 1,
+		PremiumCurrency: "RSD", PremiumAmount: 1, SettlementDate: past.Format(time.RFC3339),
+		LastModifiedByRoutingNumber: 444, LastModifiedByID: "b", UpdatedAt: past,
+	}
+	if err := db.Create(neg).Error; err != nil {
+		t.Fatalf("seed negotiation: %v", err)
+	}
+	r.bumpNegotiationUpdatedAt(neg)
+
+	ex := &models.InterbankPendingExercise{
+		TxRoutingNumber: 333, TxID: "ex-bump", Direction: models.InterbankExerciseDirectionOutbound,
+		PartnerRoutingNumber: 444, NegotiationRoutingNumber: 444, NegotiationID: "n",
+		StockTicker: "ACME", StockAmount: 1, PricePerUnitCurrency: "RSD", PricePerUnitAmount: 1,
+		CashAmount: 1, BuyerRoutingNumber: 333, BuyerID: "b", SellerRoutingNumber: 444, SellerID: "s",
+		Status: models.InterbankExerciseStatusPending, CreatedAt: past, UpdatedAt: past,
+	}
+	if err := db.Create(ex).Error; err != nil {
+		t.Fatalf("seed exercise: %v", err)
+	}
+	r.bumpExerciseUpdatedAt(ex)
+}

--- a/exchange-service/internal/service/cron_portfolio_extra_test.go
+++ b/exchange-service/internal/service/cron_portfolio_extra_test.go
@@ -1,0 +1,51 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+func TestCheckPriceAlerts(t *testing.T) {
+	db := openTestDB(t, "check_alerts")
+	if err := repository.NewPriceAlertRepository(db).Create(&models.PriceAlert{
+		UserID: 1, UserType: "client", Ticker: "AAA", Condition: "ABOVE",
+		Threshold: 100, NotificationEmail: "e@x.com", IsActive: true,
+	}); err != nil {
+		t.Fatalf("seed alert: %v", err)
+	}
+	// Dead SMTP: the trigger path runs but the email send fails (alert not
+	// deactivated), exercising both the match and the send-failure branch.
+	email := service.NewSMTPEmailService("127.0.0.1", 1, "f@x.com")
+	service.CheckPriceAlerts(db, email, "AAA", 150) // above threshold -> triggers
+	service.CheckPriceAlerts(db, email, "AAA", 50)  // below -> no trigger
+}
+
+func TestPortfolioService_ExerciseOption_Errors(t *testing.T) {
+	db := openTestDB(t, "exercise_errors")
+	psvc := service.NewPortfolioService(
+		repository.NewPortfolioRepository(db),
+		service.NewTaxService(repository.NewTaxRepository(db), repository.NewMarketRepository(db), &mockRateProv{}),
+		repository.NewMarketRepository(db),
+		repository.NewOrderRepository(db),
+	)
+
+	if err := psvc.ExerciseOption(99999, 5); err == nil {
+		t.Error("missing holding should error")
+	}
+
+	assetID := seedAsset(t, db, "STK", 50, "USD")
+	h := &models.PortfolioHoldingRecord{
+		UserID: 1, UserType: "client", AssetID: assetID, Quantity: 10,
+		AccountID: 1, CreatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(h).Error; err != nil {
+		t.Fatalf("seed holding: %v", err)
+	}
+	if err := psvc.ExerciseOption(h.ID, 5); err == nil {
+		t.Error("exercising a non-option holding should error")
+	}
+}

--- a/exchange-service/internal/service/cron_refresh_internal_test.go
+++ b/exchange-service/internal/service/cron_refresh_internal_test.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+)
+
+func TestRefreshListingPrices(t *testing.T) {
+	db := openSagaTestDB(t, "refresh_prices")
+	now := time.Now().UTC()
+
+	exch := models.MarketExchangeRecord{Acronym: "RX", Name: "X", MICCode: "RX1", Polity: "X", Currency: "USD", Timezone: "UTC", WorkingHours: "09-17"}
+	if err := db.Create(&exch).Error; err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	for _, tk := range []string{"RFP1", "RFP2"} {
+		if err := db.Create(&models.MarketListingRecord{
+			Ticker: tk, Name: tk, Type: "stock", ExchangeID: exch.ID,
+			Price: 50, Ask: 51, Bid: 49, Volume: 100, LastRefresh: now.Add(-24 * time.Hour),
+		}).Error; err != nil {
+			t.Fatalf("listing %s: %v", tk, err)
+		}
+	}
+
+	email := NewSMTPEmailService("127.0.0.1", 1, "f@x.com")
+
+	// First pass creates today's daily snapshot; second pass updates it.
+	refreshListingPrices(db, email)
+	refreshListingPrices(db, email)
+
+	var snaps int64
+	db.Model(&models.MarketListingDailyPriceInfoRecord{}).Count(&snaps)
+	if snaps == 0 {
+		t.Error("expected daily price snapshots to be recorded")
+	}
+}

--- a/exchange-service/internal/service/executor_email_test.go
+++ b/exchange-service/internal/service/executor_email_test.go
@@ -1,0 +1,78 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+func TestSMTPEmailService_SendError(t *testing.T) {
+	// A dead SMTP endpoint makes SendMail fail fast, covering the error path.
+	svc := service.NewSMTPEmailService("127.0.0.1", 1, "from@bank.com")
+	if err := svc.Send("to@bank.com", "subj", "body"); err == nil {
+		t.Error("expected SMTP send error to a dead endpoint")
+	}
+}
+
+func TestOrderExecutor_Run_FillsBuyAndSell(t *testing.T) {
+	db := openDivTestDB(t, "oe_run")
+	assetID := seedAsset(t, db, "EXE", 50, "USD") // price 50, ask 51, bid 49
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id, raspolozivo_stanje, stanje) VALUES (10, 2, 'aktivan', 1, 100000, 100000)`)
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, firma_id, raspolozivo_stanje, stanje) VALUES (20, 2, 'aktivan', 1, 100000, 100000)`)
+
+	orderRepo := repository.NewOrderRepository(db)
+	marketRepo := repository.NewMarketRepository(db)
+	rates := &mockRateProv{rates: map[string]float64{"USD:RSD": 100}}
+	portfolioSvc := service.NewPortfolioService(
+		repository.NewPortfolioRepository(db),
+		service.NewTaxService(repository.NewTaxRepository(db), marketRepo, rates),
+		marketRepo, orderRepo,
+	)
+	exec := service.NewOrderExecutor(orderRepo, marketRepo, portfolioSvc, rates)
+
+	now := time.Now().UTC().Add(-time.Hour) // old enough to dodge after-hours delay
+	// Approved market BUY with a high committed price -> fill (at ask) below it
+	// triggers the over-reservation refund branch.
+	buy := &models.OrderRecord{
+		UserID: 1, UserType: "client", AssetID: assetID, OrderType: "market", Direction: "buy",
+		Quantity: 2, ContractSize: 1, PricePerUnit: 60, CurrencyRate: 1, Commission: 4,
+		Status: "approved", RemainingPortions: 2, AccountID: 10,
+		LastModification: now, CreatedAt: now,
+	}
+	if err := orderRepo.CreateOrder(buy); err != nil {
+		t.Fatalf("seed buy: %v", err)
+	}
+
+	// A holding so the SELL order can execute and credit proceeds + commission.
+	if err := db.Create(&models.PortfolioHoldingRecord{
+		UserID: 1, UserType: "client", AssetID: assetID, Quantity: 10, AvgBuyPrice: 40,
+		AccountID: 10, CreatedAt: now, UpdatedAt: now,
+	}).Error; err != nil {
+		t.Fatalf("seed holding: %v", err)
+	}
+	sell := &models.OrderRecord{
+		UserID: 1, UserType: "client", AssetID: assetID, OrderType: "market", Direction: "sell",
+		Quantity: 2, ContractSize: 1, PricePerUnit: 49, CurrencyRate: 1, Commission: 2,
+		Status: "approved", RemainingPortions: 2, AccountID: 10,
+		LastModification: now, CreatedAt: now,
+	}
+	if err := orderRepo.CreateOrder(sell); err != nil {
+		t.Fatalf("seed sell: %v", err)
+	}
+
+	exec.Run()
+
+	// Both orders should have recorded at least one transaction (market fills now).
+	for _, id := range []uint{buy.ID, sell.ID} {
+		txs, err := orderRepo.ListTransactionsForOrder(id)
+		if err != nil {
+			t.Fatalf("ListTransactionsForOrder(%d): %v", id, err)
+		}
+		if len(txs) == 0 {
+			t.Errorf("order %d should have a fill transaction after Run", id)
+		}
+	}
+}

--- a/exchange-service/internal/service/executor_extra_test.go
+++ b/exchange-service/internal/service/executor_extra_test.go
@@ -1,0 +1,56 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+// TestOrderExecutor_Run_AfterHoursAONLimit exercises additional Run branches:
+// the after-hours fill delay, AON fill quantity, and a limit buy filling below
+// its committed price (over-reservation refund).
+func TestOrderExecutor_Run_AfterHoursAONLimit(t *testing.T) {
+	db := openDivTestDB(t, "oe_extra")
+	assetID := seedAsset(t, db, "EXX", 50, "USD") // ask 51
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id, raspolozivo_stanje, stanje) VALUES (10, 2, 'aktivan', 1, 1000000, 1000000)`)
+
+	orderRepo := repository.NewOrderRepository(db)
+	marketRepo := repository.NewMarketRepository(db)
+	rates := &mockRateProv{rates: map[string]float64{"USD:RSD": 100}}
+	psvc := service.NewPortfolioService(repository.NewPortfolioRepository(db),
+		service.NewTaxService(repository.NewTaxRepository(db), marketRepo, rates), marketRepo, orderRepo)
+	exec := service.NewOrderExecutor(orderRepo, marketRepo, psvc, rates)
+
+	old := time.Now().UTC().Add(-time.Hour)
+	recent := time.Now().UTC()
+	limit := 60.0
+
+	// After-hours order modified just now -> blocked by the 30-min fill delay.
+	if err := orderRepo.CreateOrder(&models.OrderRecord{
+		UserID: 1, UserType: "client", AssetID: assetID, OrderType: "market", Direction: "buy",
+		Quantity: 2, ContractSize: 1, PricePerUnit: 60, CurrencyRate: 1, AfterHours: true,
+		Status: "approved", RemainingPortions: 2, AccountID: 10, LastModification: recent, CreatedAt: old,
+	}); err != nil {
+		t.Fatalf("seed after-hours: %v", err)
+	}
+	// AON limit buy that fills (at ask 51 < limit 60 -> over-reservation refund).
+	if err := orderRepo.CreateOrder(&models.OrderRecord{
+		UserID: 1, UserType: "client", AssetID: assetID, OrderType: "limit", Direction: "buy",
+		Quantity: 2, ContractSize: 1, PricePerUnit: 60, LimitValue: &limit, CurrencyRate: 1, IsAON: true,
+		Status: "approved", RemainingPortions: 2, AccountID: 10, LastModification: old, CreatedAt: old,
+	}); err != nil {
+		t.Fatalf("seed AON limit: %v", err)
+	}
+
+	exec.Run()
+
+	// The AON limit order should have filled fully (its 2 units in one go).
+	var aon models.OrderRecord
+	db.Where("asset_id = ? AND order_type = ?", assetID, "limit").First(&aon)
+	if aon.RemainingPortions != 0 {
+		t.Errorf("AON order remaining=%d, want 0", aon.RemainingPortions)
+	}
+}

--- a/exchange-service/internal/service/executor_margin_test.go
+++ b/exchange-service/internal/service/executor_margin_test.go
@@ -1,0 +1,65 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+// TestOrderExecutor_Run_SellRepaysMarginLoan covers settleMarginLoansFromProceeds:
+// a sell fill on an asset the user holds a margin loan against repays the loan
+// (FIFO) from the proceeds and credits the bank.
+func TestOrderExecutor_Run_SellRepaysMarginLoan(t *testing.T) {
+	db := openDivTestDB(t, "oe_margin_sell")
+	assetID := seedAsset(t, db, "MGS", 50, "USD")
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id, raspolozivo_stanje, stanje) VALUES (10, 2, 'aktivan', 1, 100000, 100000)`)
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, firma_id, raspolozivo_stanje, stanje) VALUES (20, 2, 'aktivan', 1, 100000, 100000)`)
+
+	orderRepo := repository.NewOrderRepository(db)
+	marketRepo := repository.NewMarketRepository(db)
+	rates := &mockRateProv{rates: map[string]float64{"USD:RSD": 100}}
+	portfolioSvc := service.NewPortfolioService(
+		repository.NewPortfolioRepository(db),
+		service.NewTaxService(repository.NewTaxRepository(db), marketRepo, rates),
+		marketRepo, orderRepo,
+	)
+	exec := service.NewOrderExecutor(orderRepo, marketRepo, portfolioSvc, rates)
+
+	now := time.Now().UTC().Add(-time.Hour)
+	// An outstanding margin BUY loan on the asset.
+	if err := orderRepo.CreateOrder(&models.OrderRecord{
+		UserID: 1, UserType: "client", AssetID: assetID, OrderType: "market", Direction: "buy",
+		Quantity: 10, ContractSize: 1, PricePerUnit: 50, CurrencyRate: 1, IsMargin: true, MarginLoan: 500,
+		Status: "done", IsDone: true, RemainingPortions: 0, AccountID: 10, LastModification: now, CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("seed margin buy: %v", err)
+	}
+	// A holding to sell from.
+	if err := db.Create(&models.PortfolioHoldingRecord{
+		UserID: 1, UserType: "client", AssetID: assetID, Quantity: 10, AvgBuyPrice: 50,
+		AccountID: 10, CreatedAt: now, UpdatedAt: now,
+	}).Error; err != nil {
+		t.Fatalf("seed holding: %v", err)
+	}
+	// An approved sell order — its fill proceeds repay the loan.
+	sell := &models.OrderRecord{
+		UserID: 1, UserType: "client", AssetID: assetID, OrderType: "market", Direction: "sell",
+		Quantity: 6, ContractSize: 1, PricePerUnit: 49, CurrencyRate: 1, Commission: 3,
+		Status: "approved", RemainingPortions: 6, AccountID: 10, LastModification: now, CreatedAt: now,
+	}
+	if err := orderRepo.CreateOrder(sell); err != nil {
+		t.Fatalf("seed sell: %v", err)
+	}
+
+	exec.Run()
+
+	// The margin loan should have been (at least partially) repaid from proceeds.
+	var loanOrder models.OrderRecord
+	db.Where("asset_id = ? AND is_margin = ?", assetID, true).First(&loanOrder)
+	if loanOrder.MarginLoan >= 500 {
+		t.Errorf("expected margin loan to be reduced from 500, got %v", loanOrder.MarginLoan)
+	}
+}

--- a/exchange-service/internal/service/exercise_option_test.go
+++ b/exchange-service/internal/service/exercise_option_test.go
@@ -1,0 +1,74 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+func TestPortfolioService_ExerciseOption_CallInTheMoney(t *testing.T) {
+	db := openDivTestDB(t, "exercise_call")
+	now := time.Now().UTC()
+
+	exch := models.MarketExchangeRecord{
+		Acronym: "OPX", Name: "X", MICCode: "OPX1", Polity: "X",
+		Currency: "USD", Timezone: "UTC", WorkingHours: "09-17",
+	}
+	if err := db.Create(&exch).Error; err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	underlying := models.MarketListingRecord{
+		Ticker: "UND", Name: "UND", Type: "stock", ExchangeID: exch.ID,
+		Price: 100, Ask: 101, Bid: 99, Volume: 1, LastRefresh: now,
+	}
+	optListing := models.MarketListingRecord{
+		Ticker: "UNDC", Name: "opt", Type: "option", ExchangeID: exch.ID,
+		Price: 5, Ask: 5, Bid: 5, Volume: 1, LastRefresh: now,
+	}
+	if err := db.Create(&underlying).Error; err != nil {
+		t.Fatalf("underlying: %v", err)
+	}
+	if err := db.Create(&optListing).Error; err != nil {
+		t.Fatalf("option listing: %v", err)
+	}
+	if err := db.Create(&models.OptionRecord{
+		ListingID: optListing.ID, StockListingID: underlying.ID, OptionType: "call",
+		StrikePrice: 50, ImpliedVolatility: 1, SettlementDate: now.AddDate(0, 0, 5),
+	}).Error; err != nil {
+		t.Fatalf("option record: %v", err)
+	}
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id, raspolozivo_stanje, stanje) VALUES (10, 2, 'aktivan', 1, 1000000, 1000000)`)
+	holding := models.PortfolioHoldingRecord{
+		UserID: 1, UserType: "client", AssetID: optListing.ID, Quantity: 1,
+		AccountID: 10, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(&holding).Error; err != nil {
+		t.Fatalf("holding: %v", err)
+	}
+
+	psvc := service.NewPortfolioService(
+		repository.NewPortfolioRepository(db),
+		service.NewTaxService(repository.NewTaxRepository(db), repository.NewMarketRepository(db), &mockRateProv{rates: map[string]float64{"USD:RSD": 100}}),
+		repository.NewMarketRepository(db),
+		repository.NewOrderRepository(db),
+	)
+
+	// CALL is in-the-money (market 100 > strike 50) -> exercises to a stock buy.
+	if err := psvc.ExerciseOption(holding.ID, 5); err != nil {
+		t.Fatalf("ExerciseOption: %v", err)
+	}
+	// The option holding is closed and an underlying stock holding now exists.
+	var stockHolding models.PortfolioHoldingRecord
+	if err := db.Where("user_id = 1 AND asset_id = ?", underlying.ID).First(&stockHolding).Error; err != nil {
+		t.Fatalf("expected underlying holding created: %v", err)
+	}
+	if stockHolding.Quantity != float64(optionContractSizeForTest()) {
+		t.Errorf("underlying qty=%v", stockHolding.Quantity)
+	}
+}
+
+// optionContractSizeForTest mirrors the package's optionContractSize (100).
+func optionContractSizeForTest() int64 { return 100 }

--- a/exchange-service/internal/service/fund_extra_branches_test.go
+++ b/exchange-service/internal/service/fund_extra_branches_test.go
@@ -1,0 +1,82 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+func TestFundService_WithdrawPartial_NoLiquidation(t *testing.T) {
+	e := newFundEnv(t, "fund_withdraw_partial")
+	fund, err := e.svc.CreateFund(service.CreateFundInput{Naziv: "Part", MinimalniUlog: 100, ManagerID: 5})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	acct := e.seedClientAccount(t, 5000)
+	if _, err := e.svc.InvestInFund(service.InvestInFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "client", SourceAccountID: acct, Amount: 1000,
+	}); err != nil {
+		t.Fatalf("invest: %v", err)
+	}
+
+	// Fund holds 1000 cash, no securities -> withdrawing 400 needs no liquidation.
+	res, err := e.svc.WithdrawFromFund(service.WithdrawFromFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "client", DestinationAccountID: acct, Amount: 400,
+	})
+	if err != nil {
+		t.Fatalf("withdraw: %v", err)
+	}
+	if res.Liquidated {
+		t.Error("no liquidation expected for a cash-covered withdrawal")
+	}
+	if res.Commission <= 0 {
+		t.Error("client withdrawal should incur a commission")
+	}
+}
+
+func TestFundService_InvestInFund_ErrorBranches(t *testing.T) {
+	e := newFundEnv(t, "fund_invest_errors")
+	fund, err := e.svc.CreateFund(service.CreateFundInput{Naziv: "Err", MinimalniUlog: 100, ManagerID: 5})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Non-positive amount.
+	if _, err := e.svc.InvestInFund(service.InvestInFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "client", SourceAccountID: 1, Amount: 0,
+	}); err == nil {
+		t.Error("zero amount should error")
+	}
+	// Unknown participant type.
+	if _, err := e.svc.InvestInFund(service.InvestInFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "alien", SourceAccountID: 1, Amount: 200,
+	}); err == nil {
+		t.Error("unknown client type should error")
+	}
+	// Missing source account.
+	if _, err := e.svc.InvestInFund(service.InvestInFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "client", SourceAccountID: 0, Amount: 200,
+	}); err == nil {
+		t.Error("missing source account should error")
+	}
+	// Insufficient balance.
+	low := e.seedClientAccount(t, 10)
+	if _, err := e.svc.InvestInFund(service.InvestInFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "client", SourceAccountID: low, Amount: 500,
+	}); err == nil {
+		t.Error("insufficient balance should error")
+	}
+	// Non-RSD source account.
+	e.db.Exec(`INSERT INTO currencies (id, kod) VALUES (2, 'USD')`)
+	now := time.Now().UTC()
+	e.db.Exec(`INSERT INTO accounts (broj_racuna, currency_id, stanje, raspolozivo_stanje, status, client_id, created_at, updated_at) VALUES (?, 2, ?, ?, 'aktivan', ?, ?, ?)`,
+		"USD-FUND", 5000.0, 5000.0, e.clientID, now, now)
+	var usdID uint
+	e.db.Table("accounts").Select("id").Where("broj_racuna = ?", "USD-FUND").Scan(&usdID)
+	if _, err := e.svc.InvestInFund(service.InvestInFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "client", SourceAccountID: usdID, Amount: 200,
+	}); err == nil {
+		t.Error("non-RSD source account should error")
+	}
+}

--- a/exchange-service/internal/service/fund_withdraw_errors_test.go
+++ b/exchange-service/internal/service/fund_withdraw_errors_test.go
@@ -1,0 +1,59 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+func TestFundService_WithdrawErrorBranches(t *testing.T) {
+	e := newFundEnv(t, "fund_withdraw_err")
+	fund, err := e.svc.CreateFund(service.CreateFundInput{Naziv: "WE", MinimalniUlog: 100, ManagerID: 5})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	acct := e.seedClientAccount(t, 5000)
+	if _, err := e.svc.InvestInFund(service.InvestInFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "client", SourceAccountID: acct, Amount: 1000,
+	}); err != nil {
+		t.Fatalf("invest: %v", err)
+	}
+
+	// Missing destination account.
+	if _, err := e.svc.WithdrawFromFund(service.WithdrawFromFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "client", DestinationAccountID: 0,
+	}); err == nil {
+		t.Error("missing destination should error")
+	}
+	// Unknown participant type.
+	if _, err := e.svc.WithdrawFromFund(service.WithdrawFromFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "alien", DestinationAccountID: acct,
+	}); err == nil {
+		t.Error("unknown type should error")
+	}
+	// Requested exceeds the client's share.
+	if _, err := e.svc.WithdrawFromFund(service.WithdrawFromFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "client", DestinationAccountID: acct, Amount: 999999,
+	}); err == nil {
+		t.Error("over-share withdrawal should error")
+	}
+	// Destination account owned by a different client.
+	now := time.Now().UTC()
+	e.db.Exec(`INSERT INTO accounts (broj_racuna, currency_id, stanje, raspolozivo_stanje, status, client_id, created_at, updated_at) VALUES (?, 1, 0, 0, 'aktivan', 777, ?, ?)`,
+		"OTHER-CLI", now, now)
+	var otherID uint
+	e.db.Table("accounts").Select("id").Where("broj_racuna = ?", "OTHER-CLI").Scan(&otherID)
+	if _, err := e.svc.WithdrawFromFund(service.WithdrawFromFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "client", DestinationAccountID: otherID, Amount: 100,
+	}); err == nil {
+		t.Error("destination not owned by client should error")
+	}
+	// No position in a different fund.
+	other, _ := e.svc.CreateFund(service.CreateFundInput{Naziv: "WE2", MinimalniUlog: 100, ManagerID: 5})
+	if _, err := e.svc.WithdrawFromFund(service.WithdrawFromFundInput{
+		FundID: other.ID, ClientID: e.clientID, ClientType: "client", DestinationAccountID: acct, WithdrawAll: true,
+	}); err == nil {
+		t.Error("withdrawing from a fund with no position should error")
+	}
+}

--- a/exchange-service/internal/service/fund_withdraw_liquidation_test.go
+++ b/exchange-service/internal/service/fund_withdraw_liquidation_test.go
@@ -1,0 +1,75 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+func TestFundService_WithdrawWithLiquidation(t *testing.T) {
+	e := newFundEnv(t, "fund_withdraw_liq")
+	fund, err := e.svc.CreateFund(service.CreateFundInput{Naziv: "Liq", MinimalniUlog: 100, ManagerID: 5})
+	if err != nil {
+		t.Fatalf("create fund: %v", err)
+	}
+	acct := e.seedClientAccount(t, 5000)
+
+	// Invest 1000 RSD -> fund cash 1000, client position 1000.
+	if _, err := e.svc.InvestInFund(service.InvestInFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "client",
+		SourceAccountID: acct, Amount: 1000,
+	}); err != nil {
+		t.Fatalf("invest: %v", err)
+	}
+
+	// Give the fund a stock holding worth ~1000 RSD (no USD:RSD rate -> price used as-is).
+	assetID := seedAsset(t, e.db, "FLQ", 50, "USD")
+	if err := e.db.Create(&models.PortfolioHoldingRecord{
+		UserID: fund.ID, UserType: "fund", AssetID: assetID, Quantity: 20,
+		AvgBuyPrice: 40, AccountID: fund.AccountID, CreatedAt: time.Now().UTC(),
+	}).Error; err != nil {
+		t.Fatalf("seed fund holding: %v", err)
+	}
+
+	// Withdraw the whole position -> requested (~2000) exceeds liquid cash (1000),
+	// so the fund auto-liquidates holdings to cover the shortfall.
+	res, err := e.svc.WithdrawFromFund(service.WithdrawFromFundInput{
+		FundID: fund.ID, ClientID: e.clientID, ClientType: "client",
+		DestinationAccountID: acct, WithdrawAll: true,
+	})
+	if err != nil {
+		t.Fatalf("WithdrawFromFund: %v", err)
+	}
+	if !res.Liquidated || len(res.LiquidatedItems) == 0 {
+		t.Errorf("expected liquidation, got %+v", res)
+	}
+	if res.NetToAccount <= 0 {
+		t.Errorf("expected positive net to account, got %v", res.NetToAccount)
+	}
+}
+
+func TestFundService_RecordDailyPerformanceAndValidateBuy(t *testing.T) {
+	e := newFundEnv(t, "fund_perf_validate")
+	fund, err := e.svc.CreateFund(service.CreateFundInput{Naziv: "Perf", MinimalniUlog: 100, ManagerID: 5})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Daily snapshot writer over all funds.
+	if err := e.svc.RecordDailyPerformance(time.Now().UTC()); err != nil {
+		t.Fatalf("RecordDailyPerformance: %v", err)
+	}
+
+	// ValidateFundBuyOrder: manager + fund account ok; wrong manager / wrong account rejected.
+	if _, err := e.svc.ValidateFundBuyOrder(fund.ID, 5, fund.AccountID); err != nil {
+		t.Errorf("valid buy-order preflight failed: %v", err)
+	}
+	if _, err := e.svc.ValidateFundBuyOrder(fund.ID, 999, fund.AccountID); err == nil {
+		t.Error("non-manager should be rejected")
+	}
+	if _, err := e.svc.ValidateFundBuyOrder(fund.ID, 5, 99999); err == nil {
+		t.Error("wrong account should be rejected")
+	}
+}

--- a/exchange-service/internal/service/interbank_reconcile_apply_test.go
+++ b/exchange-service/internal/service/interbank_reconcile_apply_test.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+func TestInterbankReconcile_ApplyAndBump(t *testing.T) {
+	db := openSagaTestDB(t, "ib_apply")
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, stanje, raspolozivo_stanje) VALUES
+		(1, 1, 'aktivan', 1000, 1000), (2, 1, 'aktivan', 1000, 1000), (3, 1, 'aktivan', 1000, 1000)`)
+
+	r := NewInterbankReconcileRunner(
+		db, nil, nil,
+		repository.NewInterbankPaymentRepository(db),
+		repository.NewInterbankPaymentWalletRepository(db),
+		repository.NewInterbankExerciseRepository(db),
+		repository.NewInterbankWalletRepository(db),
+		repository.NewInterbankOtcRepository(db),
+	)
+
+	seed := func(txid string, accountID uint, amount float64) *models.InterbankPayment {
+		acct := accountID
+		p := &models.InterbankPayment{
+			TxRoutingNumber: 444, TxID: txid, Direction: "outbound", PartnerRoutingNumber: 444,
+			SenderAccountNumber: "s", RecipientAccountNumber: "rr", Currency: "RSD", Amount: amount,
+			LocalAccountID: &acct, Status: models.InterbankPaymentStatusPending,
+		}
+		if err := db.Create(p).Error; err != nil {
+			t.Fatalf("seed payment: %v", err)
+		}
+		return p
+	}
+
+	// applyCommit: pending -> committed + debit.
+	c := seed("commit-1", 1, 100)
+	if err := r.applyCommit(c); err != nil {
+		t.Fatalf("applyCommit: %v", err)
+	}
+	if c.Status != models.InterbankPaymentStatusCommitted {
+		t.Errorf("applyCommit status=%s", c.Status)
+	}
+	// Idempotent re-apply (rows==0 path).
+	if err := r.applyCommit(c); err != nil {
+		t.Fatalf("applyCommit idempotent: %v", err)
+	}
+
+	// applyRejected: pending -> rejected + release + finalise.
+	rej := seed("rej-1", 2, 50)
+	if err := r.applyRejected(rej, "partner voted NO"); err != nil {
+		t.Fatalf("applyRejected: %v", err)
+	}
+	if rej.Status != models.InterbankPaymentStatusRejected {
+		t.Errorf("applyRejected status=%s", rej.Status)
+	}
+
+	// applyFailed: pending -> failed + release.
+	f := seed("fail-1", 3, 30)
+	if err := r.applyFailed(f, "transport error"); err != nil {
+		t.Fatalf("applyFailed: %v", err)
+	}
+
+	// markPartnerFinalised + bumpUpdatedAt are DB-only nudges.
+	r.markPartnerFinalised(c)
+	r.bumpUpdatedAt(c)
+
+	// Missing local_account_id -> each apply errors.
+	bad := &models.InterbankPayment{TxRoutingNumber: 444, TxID: "bad", Direction: "outbound", Status: models.InterbankPaymentStatusPending}
+	if err := db.Create(bad).Error; err != nil {
+		t.Fatalf("seed bad: %v", err)
+	}
+	if err := r.applyCommit(bad); err == nil {
+		t.Error("applyCommit should error without local_account_id")
+	}
+	if err := r.applyRejected(bad, "x"); err == nil {
+		t.Error("applyRejected should error without local_account_id")
+	}
+	if err := r.applyFailed(bad, "x"); err == nil {
+		t.Error("applyFailed should error without local_account_id")
+	}
+}

--- a/exchange-service/internal/service/interbank_reconcile_exercise_terminal_test.go
+++ b/exchange-service/internal/service/interbank_reconcile_exercise_terminal_test.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// TestReconcile_ExerciseTerminal resends the terminal message for committed and
+// failed outbound exercise rows and finalises them once the partner ACKs (204).
+func TestReconcile_ExerciseTerminal(t *testing.T) {
+	db := openSagaTestDB(t, "ib_recon_ex_terminal")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	registry, err := interbank.NewRegistryFromJSON(333, fmt.Sprintf(
+		`[{"code":444,"baseUrl":"%s","outboundKey":"o","inboundKey":"i","displayName":"P"}]`, srv.URL))
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	exRepo := repository.NewInterbankExerciseRepository(db)
+
+	past := time.Now().UTC().Add(-time.Hour)
+	seed := func(txid, status string) {
+		row := &models.InterbankPendingExercise{
+			TxRoutingNumber: 333, TxID: txid, Direction: models.InterbankExerciseDirectionOutbound,
+			PartnerRoutingNumber: 444, NegotiationRoutingNumber: 444, NegotiationID: "neg-" + txid,
+			StockTicker: "ACME", StockAmount: 1, PricePerUnitCurrency: "RSD", PricePerUnitAmount: 10,
+			CashAmount: 10, BuyerRoutingNumber: 333, BuyerID: "client-7",
+			SellerRoutingNumber: 444, SellerID: "client-9",
+			Status: status, CreatedAt: past, UpdatedAt: past,
+		}
+		if err := db.Create(row).Error; err != nil {
+			t.Fatalf("seed %s: %v", txid, err)
+		}
+	}
+	seed("ex-commit", models.InterbankExerciseStatusCommitted)
+	seed("ex-failed", models.InterbankExerciseStatusFailed)
+
+	r := NewInterbankReconcileRunner(
+		db, registry, interbank.NewClient(registry),
+		repository.NewInterbankPaymentRepository(db),
+		repository.NewInterbankPaymentWalletRepository(db),
+		exRepo,
+		repository.NewInterbankWalletRepository(db),
+		repository.NewInterbankOtcRepository(db),
+	).WithStaleness(time.Minute)
+
+	r.Run()
+
+	for _, id := range []string{"ex-commit", "ex-failed"} {
+		var got models.InterbankPendingExercise
+		if err := db.Where("tx_routing_number = ? AND tx_id = ?", 333, id).First(&got).Error; err != nil {
+			t.Fatalf("get %s: %v", id, err)
+		}
+		if got.PartnerFinalisedAt == nil {
+			t.Errorf("exercise %s not finalised after terminal resend", id)
+		}
+	}
+}

--- a/exchange-service/internal/service/interbank_reconcile_payments_test.go
+++ b/exchange-service/internal/service/interbank_reconcile_payments_test.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// TestReconcile_Payments_TerminalAndPending drives the payment half of Run():
+// committed/failed outbound rows get their terminal message resent (and are
+// finalised), while a stuck pending row is retried. The partner stub ACKs
+// terminal messages with 204; NEW_TX gets no vote body, exercising the
+// pending-retry transient path.
+func TestReconcile_Payments_TerminalAndPending(t *testing.T) {
+	db := openSagaTestDB(t, "ib_recon_payments")
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, stanje, raspolozivo_stanje, client_id) VALUES (1, 1, 'aktivan', 1000, 1000, 9)`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	partnersJSON := fmt.Sprintf(
+		`[{"code":444,"baseUrl":"%s","outboundKey":"out-key","inboundKey":"in-key","displayName":"Partner"}]`,
+		srv.URL)
+	registry, err := interbank.NewRegistryFromJSON(333, partnersJSON)
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	paymentRepo := repository.NewInterbankPaymentRepository(db)
+
+	acct := uint(1)
+	seed := func(txid, status string) {
+		p := &models.InterbankPayment{
+			TxRoutingNumber: 333, TxID: txid, Direction: "outbound", PartnerRoutingNumber: 444,
+			SenderAccountNumber: "s", RecipientAccountNumber: "rr", Currency: "RSD", Amount: 10,
+			LocalAccountID: &acct, Status: status,
+		}
+		if err := db.Create(p).Error; err != nil {
+			t.Fatalf("seed %s: %v", txid, err)
+		}
+		// Backdate updated_at so the staleness filter selects it.
+		db.Model(&models.InterbankPayment{}).Where("id = ?", p.ID).
+			Update("updated_at", time.Now().UTC().Add(-time.Hour))
+	}
+	seed("commit-term", models.InterbankPaymentStatusCommitted)
+	seed("failed-term", models.InterbankPaymentStatusFailed)
+	seed("stuck-pending", models.InterbankPaymentStatusPending)
+
+	r := NewInterbankReconcileRunner(
+		db, registry, interbank.NewClient(registry),
+		paymentRepo,
+		repository.NewInterbankPaymentWalletRepository(db),
+		repository.NewInterbankExerciseRepository(db),
+		repository.NewInterbankWalletRepository(db),
+		repository.NewInterbankOtcRepository(db),
+	).WithStaleness(time.Minute)
+
+	r.Run()
+
+	// Both terminal rows should now be finalised (partner ACKed).
+	for _, id := range []string{"commit-term", "failed-term"} {
+		row, err := paymentRepo.GetByTxID(333, id)
+		if err != nil {
+			t.Fatalf("get %s: %v", id, err)
+		}
+		if row == nil || row.PartnerFinalisedAt == nil {
+			t.Errorf("terminal row %s not finalised", id)
+		}
+	}
+}

--- a/exchange-service/internal/service/interbank_reconcile_yes_test.go
+++ b/exchange-service/internal/service/interbank_reconcile_yes_test.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+// TestReconcilePending_YesVoteCommits drives reconcilePending's happy path: the
+// retried NEW_TX gets a YES vote, so the row is committed locally (debit) and
+// COMMIT_TX is dispatched + finalised.
+func TestReconcilePending_YesVoteCommits(t *testing.T) {
+	db := openSagaTestDB(t, "ib_recon_yes")
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, stanje, raspolozivo_stanje, client_id) VALUES (1, 1, 'aktivan', 1000, 1000, 9)`)
+
+	// Partner stub: a YES vote for NEW_TX; the same 200+body is harmless for COMMIT_TX.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(interbank.TransactionVote{Vote: interbank.VoteYes})
+	}))
+	defer srv.Close()
+
+	registry, err := interbank.NewRegistryFromJSON(333, fmt.Sprintf(
+		`[{"code":444,"baseUrl":"%s","outboundKey":"o","inboundKey":"i","displayName":"P"}]`, srv.URL))
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	paymentRepo := repository.NewInterbankPaymentRepository(db)
+
+	acct := uint(1)
+	p := &models.InterbankPayment{
+		TxRoutingNumber: 333, TxID: "pending-yes", Direction: "outbound", PartnerRoutingNumber: 444,
+		SenderAccountNumber: "s", RecipientAccountNumber: "rr", Currency: "RSD", Amount: 25,
+		LocalAccountID: &acct, Status: models.InterbankPaymentStatusPending,
+	}
+	if err := db.Create(p).Error; err != nil {
+		t.Fatalf("seed payment: %v", err)
+	}
+	db.Model(&models.InterbankPayment{}).Where("id = ?", p.ID).
+		Update("updated_at", time.Now().UTC().Add(-time.Hour))
+
+	r := NewInterbankReconcileRunner(
+		db, registry, interbank.NewClient(registry),
+		paymentRepo,
+		repository.NewInterbankPaymentWalletRepository(db),
+		repository.NewInterbankExerciseRepository(db),
+		repository.NewInterbankWalletRepository(db),
+		repository.NewInterbankOtcRepository(db),
+	).WithStaleness(time.Minute)
+
+	r.Run()
+
+	got, err := paymentRepo.GetByTxID(333, "pending-yes")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != models.InterbankPaymentStatusCommitted {
+		t.Errorf("status=%s, want committed after YES vote", got.Status)
+	}
+}

--- a/exchange-service/internal/service/notify_cron_internal_test.go
+++ b/exchange-service/internal/service/notify_cron_internal_test.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/notify"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+func TestEmitNotifications_AllBranches(t *testing.T) {
+	n := notify.NewClient("", "") // no-op Emit
+
+	// emitOrderNotification: nil notifier / nil order / no recipient / emit.
+	emitOrderNotification(nil, nil, "T", "t", "b")
+	emitOrderNotification(n, nil, "T", "t", "b")
+	emitOrderNotification(n, &models.OrderRecord{}, "T", "t", "b")
+	emitOrderNotification(n, &models.OrderRecord{
+		NotifyUserID: 5, NotifyUserType: "client", NotifyEmail: "e@x.com",
+	}, "ORDER_DONE", "Done", "body")
+
+	// emitOtcNotification: nil / invalid recipient / invalid type / emit.
+	emitOtcNotification(nil, 5, "client", "T", "t", "b")
+	emitOtcNotification(n, 0, "client", "T", "t", "b")
+	emitOtcNotification(n, 5, "bogus", "T", "t", "b")
+	emitOtcNotification(n, 5, "client", "OTC_X", "t", "b")
+
+	// WithNotifier setter (does not dereference its repo args).
+	if NewOrderService(nil, nil, nil).WithNotifier(n) == nil {
+		t.Error("WithNotifier returned nil")
+	}
+}
+
+func TestCronHelpers_EmptyDB(t *testing.T) {
+	db := openSagaTestDB(t, "cron_helpers")
+	otcSvc := NewOtcService(repository.NewPortfolioRepository(db), repository.NewOtcRepository(db)).
+		WithNotifier(notify.NewClient("", ""))
+
+	// All no-ops on an empty DB, but exercise the cron helper bodies.
+	remindExpiringOtcContracts(otcSvc)
+	expireDueOtcContracts(otcSvc)
+	expireDueInterbankReservations(repository.NewInterbankOtcRepository(db))
+}

--- a/exchange-service/internal/service/order_create_test.go
+++ b/exchange-service/internal/service/order_create_test.go
@@ -1,0 +1,89 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+func newOrderCreateSvc(t *testing.T, name string) (*service.OrderService, uint) {
+	t.Helper()
+	db := openDivTestDB(t, name)
+	assetID := seedAsset(t, db, "CRT", 50, "USD") // price 50, ask 51, bid 49
+	_ = assetID
+	// Client USD account (currency 2 = USD) + a bank USD account for margin.
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id, raspolozivo_stanje, stanje) VALUES (10, 2, 'aktivan', 1, 1000000, 1000000)`)
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, firma_id, raspolozivo_stanje, stanje) VALUES (20, 2, 'aktivan', 1, 1000000, 1000000)`)
+	svc := service.NewOrderService(
+		repository.NewOrderRepository(db),
+		repository.NewMarketRepository(db),
+		&mockRateProv{rates: map[string]float64{"USD:RSD": 100}},
+	)
+	return svc, 10
+}
+
+func TestOrderService_CreateOrder_ClientMarketBuy(t *testing.T) {
+	svc, acct := newOrderCreateSvc(t, "oc_market_buy")
+	res, err := svc.CreateOrder(service.CreateOrderInput{
+		UserID: 1, UserType: "client", AssetTicker: "CRT", OrderType: "market",
+		Direction: "buy", Quantity: 3, ContractSize: 1, AccountID: acct,
+	})
+	if err != nil {
+		t.Fatalf("CreateOrder market buy: %v", err)
+	}
+	// Client orders auto-approve; a buy debits the account (TotalPaid > 0).
+	if res.Order.Status != "approved" || res.Order.TotalPaid <= 0 {
+		t.Errorf("unexpected order: status=%s totalPaid=%v", res.Order.Status, res.Order.TotalPaid)
+	}
+}
+
+func TestOrderService_CreateOrder_ClientLimitBuyAndSell(t *testing.T) {
+	svc, acct := newOrderCreateSvc(t, "oc_limit_sell")
+	limit := 48.0
+	if _, err := svc.CreateOrder(service.CreateOrderInput{
+		UserID: 1, UserType: "client", AssetTicker: "CRT", OrderType: "limit",
+		Direction: "buy", Quantity: 2, ContractSize: 1, AccountID: acct, LimitValue: &limit,
+	}); err != nil {
+		t.Fatalf("CreateOrder limit buy: %v", err)
+	}
+	// Sell orders don't debit at creation.
+	res, err := svc.CreateOrder(service.CreateOrderInput{
+		UserID: 1, UserType: "client", AssetTicker: "CRT", OrderType: "market",
+		Direction: "sell", Quantity: 2, ContractSize: 1, AccountID: acct,
+	})
+	if err != nil {
+		t.Fatalf("CreateOrder sell: %v", err)
+	}
+	if res.Order.TotalPaid != 0 {
+		t.Errorf("sell order should not debit, got totalPaid=%v", res.Order.TotalPaid)
+	}
+}
+
+func TestOrderService_CreateOrder_ClientMarginBuy(t *testing.T) {
+	svc, acct := newOrderCreateSvc(t, "oc_margin_buy")
+	res, err := svc.CreateOrder(service.CreateOrderInput{
+		UserID: 1, UserType: "client", AssetTicker: "CRT", OrderType: "market",
+		Direction: "buy", Quantity: 4, ContractSize: 1, AccountID: acct, IsMargin: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateOrder margin buy: %v", err)
+	}
+	// A margin buy fronts part of the cost as a bank loan.
+	if res.Order.MarginLoan <= 0 {
+		t.Errorf("expected a margin loan, got %v", res.Order.MarginLoan)
+	}
+}
+
+func TestOrderService_CreateOrder_AssetNotFoundAndInvalid(t *testing.T) {
+	svc, acct := newOrderCreateSvc(t, "oc_errors")
+	if _, err := svc.CreateOrder(service.CreateOrderInput{
+		UserID: 1, UserType: "client", AssetTicker: "NOPE", OrderType: "market",
+		Direction: "buy", Quantity: 1, ContractSize: 1, AccountID: acct,
+	}); err == nil {
+		t.Error("expected asset-not-found error")
+	}
+	if _, err := svc.CreateOrder(service.CreateOrderInput{}); err == nil {
+		t.Error("expected validation error for empty input")
+	}
+}

--- a/exchange-service/internal/service/order_lifecycle_test.go
+++ b/exchange-service/internal/service/order_lifecycle_test.go
@@ -1,0 +1,96 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+func seedPendingBuy(t *testing.T, repo *repository.OrderRepository, assetID, accountID uint, qty int64, margin bool, marginLoan float64) *models.OrderRecord {
+	t.Helper()
+	o := &models.OrderRecord{
+		UserID: 1, UserType: "client", AssetID: assetID, OrderType: "market", Direction: "buy",
+		Quantity: qty, ContractSize: 1, PricePerUnit: 50, CurrencyRate: 1, Commission: 5,
+		IsMargin: margin, MarginLoan: marginLoan, Status: "pending", RemainingPortions: qty,
+		AccountID: accountID, LastModification: time.Now().UTC(), CreatedAt: time.Now().UTC(),
+	}
+	if err := repo.CreateOrder(o); err != nil {
+		t.Fatalf("seed order: %v", err)
+	}
+	return o
+}
+
+func TestOrderService_ApproveDeclineCancel(t *testing.T) {
+	db := openDivTestDB(t, "os_lifecycle")
+	assetID := seedAsset(t, db, "ORD", 50, "USD")
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id, raspolozivo_stanje, stanje) VALUES (10, 2, 'aktivan', 1, 1000, 1000)`)
+	repo := repository.NewOrderRepository(db)
+	svc := service.NewOrderService(repo, repository.NewMarketRepository(db), &mockRateProv{rates: map[string]float64{"USD:RSD": 100}})
+
+	// Approve a pending client order.
+	o := seedPendingBuy(t, repo, assetID, 10, 2, false, 0)
+	if err := svc.ApproveOrder(o.ID, 6); err != nil {
+		t.Fatalf("ApproveOrder: %v", err)
+	}
+	if err := svc.ApproveOrder(o.ID, 6); err == nil {
+		t.Error("re-approve should fail (not pending)")
+	}
+
+	// Decline refunds the buy debit.
+	o2 := seedPendingBuy(t, repo, assetID, 10, 2, false, 0)
+	before := acctBalance(t, db, 10)
+	if err := svc.DeclineOrder(o2.ID, 6); err != nil {
+		t.Fatalf("DeclineOrder: %v", err)
+	}
+	if acctBalance(t, db, 10) <= before {
+		t.Error("decline should refund the account")
+	}
+
+	// Cancel: partial then full.
+	o3 := seedPendingBuy(t, repo, assetID, 10, 4, false, 0)
+	if err := svc.CancelOrder(o3.ID, 1, 2); err != nil {
+		t.Fatalf("partial cancel: %v", err)
+	}
+	if err := svc.CancelOrder(o3.ID, 1, 0); err != nil {
+		t.Fatalf("full cancel: %v", err)
+	}
+	if err := svc.CancelOrder(o3.ID, 1, 0); err == nil {
+		t.Error("cancel of done order should fail")
+	}
+
+	// Not-found paths.
+	if err := svc.ApproveOrder(99999, 6); err == nil {
+		t.Error("approve missing -> error")
+	}
+	if err := svc.DeclineOrder(99999, 6); err == nil {
+		t.Error("decline missing -> error")
+	}
+	if err := svc.CancelOrder(99999, 1, 0); err == nil {
+		t.Error("cancel missing -> error")
+	}
+}
+
+func TestOrderService_MarginDeclineAndCancelRepayBank(t *testing.T) {
+	db := openDivTestDB(t, "os_margin")
+	assetID := seedAsset(t, db, "MRG", 50, "USD")
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id, raspolozivo_stanje, stanje) VALUES (10, 2, 'aktivan', 1, 1000, 1000)`)
+	// Bank USD account (firma 1 = EXBanka, is_state=false) for margin repayment.
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, firma_id, raspolozivo_stanje, stanje) VALUES (20, 2, 'aktivan', 1, 100000, 100000)`)
+	repo := repository.NewOrderRepository(db)
+	svc := service.NewOrderService(repo, repository.NewMarketRepository(db), &mockRateProv{rates: map[string]float64{"USD:RSD": 100}})
+
+	// Margin decline: refunds the IMC and repays the bank's fronted loan.
+	o := seedPendingBuy(t, repo, assetID, 10, 4, true, 200)
+	if err := svc.DeclineOrder(o.ID, 6); err != nil {
+		t.Fatalf("margin DeclineOrder: %v", err)
+	}
+
+	// Margin cancel: partial cancel reduces the loan proportionally.
+	o2 := seedPendingBuy(t, repo, assetID, 10, 4, true, 200)
+	if err := svc.CancelOrder(o2.ID, 1, 2); err != nil {
+		t.Fatalf("margin CancelOrder: %v", err)
+	}
+}

--- a/exchange-service/internal/service/order_margin_option_test.go
+++ b/exchange-service/internal/service/order_margin_option_test.go
@@ -1,0 +1,44 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+// TestOrderService_CreateOrder_MarginOption covers computeInitialMarginCost's
+// "option" branch (which loads the option contract + underlying for the margin
+// maintenance calculation).
+func TestOrderService_CreateOrder_MarginOption(t *testing.T) {
+	db := openDivTestDB(t, "oc_margin_opt")
+	now := time.Now().UTC()
+
+	exch := models.MarketExchangeRecord{Acronym: "MOX", Name: "X", MICCode: "MOX1", Polity: "X", Currency: "USD", Timezone: "UTC", WorkingHours: "09-17"}
+	db.Create(&exch)
+	underlying := models.MarketListingRecord{Ticker: "MUN", Name: "u", Type: "stock", ExchangeID: exch.ID, Price: 100, Ask: 101, Bid: 99, Volume: 1, LastRefresh: now}
+	optListing := models.MarketListingRecord{Ticker: "MUNC", Name: "o", Type: "option", ExchangeID: exch.ID, Price: 5, Ask: 5, Bid: 5, Volume: 1, LastRefresh: now}
+	db.Create(&underlying)
+	db.Create(&optListing)
+	db.Create(&models.OptionRecord{ListingID: optListing.ID, StockListingID: underlying.ID, OptionType: "call", StrikePrice: 50, ImpliedVolatility: 1, SettlementDate: now.AddDate(0, 0, 5)})
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id, raspolozivo_stanje, stanje) VALUES (10, 2, 'aktivan', 1, 10000000, 10000000)`)
+
+	svc := service.NewOrderService(
+		repository.NewOrderRepository(db),
+		repository.NewMarketRepository(db),
+		&mockRateProv{rates: map[string]float64{"USD:RSD": 100}},
+	)
+
+	res, err := svc.CreateOrder(service.CreateOrderInput{
+		UserID: 1, UserType: "client", AssetTicker: "MUNC", OrderType: "market",
+		Direction: "buy", Quantity: 1, ContractSize: 1, AccountID: 10, IsMargin: true,
+	})
+	if err != nil {
+		t.Fatalf("margin option order: %v", err)
+	}
+	if res.Order.Status != "approved" {
+		t.Errorf("status=%s", res.Order.Status)
+	}
+}

--- a/exchange-service/internal/service/order_status_test.go
+++ b/exchange-service/internal/service/order_status_test.go
@@ -1,0 +1,64 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+func TestOrderService_CreateOrder_BankAndFundStatus(t *testing.T) {
+	db := openDivTestDB(t, "oc_status")
+	seedAsset(t, db, "STS", 50, "USD")
+	db.Exec(`CREATE TABLE IF NOT EXISTS actuary_profiles (
+		id INTEGER PRIMARY KEY AUTOINCREMENT, employee_id INTEGER,
+		trading_limit REAL, used_limit REAL DEFAULT 0, need_approval BOOLEAN DEFAULT 0)`)
+	// Bank USD account for buy debits.
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, firma_id, raspolozivo_stanje, stanje) VALUES (30, 2, 'aktivan', 1, 10000000, 10000000)`)
+
+	svc := service.NewOrderService(
+		repository.NewOrderRepository(db),
+		repository.NewMarketRepository(db),
+		&mockRateProv{rates: map[string]float64{"USD:RSD": 100}},
+	)
+	order := func(userType string, userID, actorID uint, qty int64) (*service.CreateOrderResult, error) {
+		return svc.CreateOrder(service.CreateOrderInput{
+			UserID: userID, UserType: userType, ActorID: actorID, AssetTicker: "STS",
+			OrderType: "market", Direction: "buy", Quantity: qty, ContractSize: 1, AccountID: 30,
+		})
+	}
+
+	// Fund order -> auto-approved.
+	if res, err := order("fund", 1, 0, 2); err != nil || res.Order.Status != "approved" {
+		t.Fatalf("fund order: status=%v err=%v", res, err)
+	}
+	// Bank order, no actuary profile -> rejected.
+	if _, err := order("bank", 0, 7, 2); err == nil {
+		t.Error("bank order without profile should error")
+	}
+	// Supervisor (NULL trading_limit) -> approved.
+	db.Exec(`INSERT INTO actuary_profiles (employee_id, trading_limit) VALUES (8, NULL)`)
+	if res, err := order("bank", 0, 8, 2); err != nil || res.Order.Status != "approved" {
+		t.Errorf("supervisor order: status=%v err=%v", res, err)
+	}
+	// Agent within limit -> approved.
+	db.Exec(`INSERT INTO actuary_profiles (employee_id, trading_limit, used_limit, need_approval) VALUES (9, 1000000, 0, 0)`)
+	if res, err := order("bank", 0, 9, 2); err != nil || res.Order.Status != "approved" {
+		t.Errorf("agent order: status=%v err=%v", res, err)
+	}
+	// Agent flagged need_approval -> pending.
+	db.Exec(`INSERT INTO actuary_profiles (employee_id, trading_limit, used_limit, need_approval) VALUES (10, 1000000, 0, 1)`)
+	if res, err := order("bank", 0, 10, 2); err != nil || res.Order.Status != "pending" {
+		t.Errorf("need-approval order: status=%v err=%v", res, err)
+	}
+	// Agent daily limit exhausted -> error.
+	db.Exec(`INSERT INTO actuary_profiles (employee_id, trading_limit, used_limit) VALUES (11, 100, 100)`)
+	if _, err := order("bank", 0, 11, 2); err == nil {
+		t.Error("exhausted-limit order should error")
+	}
+	// Agent order exceeds remaining limit -> error.
+	db.Exec(`INSERT INTO actuary_profiles (employee_id, trading_limit, used_limit) VALUES (12, 10, 0)`)
+	if _, err := order("bank", 0, 12, 100); err == nil {
+		t.Error("over-limit order should error")
+	}
+}

--- a/exchange-service/internal/service/otc_account_validation_test.go
+++ b/exchange-service/internal/service/otc_account_validation_test.go
@@ -1,0 +1,44 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+func TestOtcService_CreateOffer_AccountValidation(t *testing.T) {
+	db := openTestDB(t, "otc_acct_val")
+	seedOtcAccountTables(t, db)
+	db.Exec(`INSERT INTO currencies (id, kod) VALUES (2, 'EUR')`)
+	// 3: inactive, 4: wrong currency (EUR), 5: owned by someone else.
+	db.Exec(`INSERT INTO accounts (id, client_id, currency_id, stanje, raspolozivo_stanje, status) VALUES
+		(3, 100, 1, 1000, 1000, 'zatvoren'),
+		(4, 100, 2, 1000, 1000, 'aktivan'),
+		(5, 999, 1, 1000, 1000, 'aktivan')`)
+
+	assetID := seedAsset(t, db, "OAV", 100, "USD")
+	holding := seedOtcHolding(t, db, assetID, 200, "client", 10, 6, 1)
+	svc := service.NewOtcService(repository.NewPortfolioRepository(db), repository.NewOtcRepository(db))
+
+	base := func() service.CreateOtcOfferInput {
+		return service.CreateOtcOfferInput{
+			BuyerID: 100, BuyerType: "client", SellerHoldingID: holding.ID,
+			Amount: 3, PricePerStock: 105, SettlementDate: time.Now().UTC().AddDate(0, 1, 0), Premium: 25,
+		}
+	}
+	for name, acct := range map[string]uint{"inactive": 3, "wrong-currency": 4, "not-owned": 5} {
+		in := base()
+		in.BuyerAccountID = acct
+		if _, err := svc.CreateOffer(in); err == nil {
+			t.Errorf("%s buyer account should be rejected", name)
+		}
+	}
+	// Non-existent account too.
+	in := base()
+	in.BuyerAccountID = 9999
+	if _, err := svc.CreateOffer(in); err == nil {
+		t.Error("non-existent buyer account should be rejected")
+	}
+}

--- a/exchange-service/internal/service/otc_exercise_saga_run_test.go
+++ b/exchange-service/internal/service/otc_exercise_saga_run_test.go
@@ -1,0 +1,149 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+// TestOtcService_ExerciseContract_RunsSaga drives the full 5-step OTC exercise
+// SAGA (build steps -> reserve cash/shares -> transfer cash/ownership ->
+// finalize) through the orchestrator, covering otc_exercise_saga.go and the
+// orchestrator's forward path.
+func TestOtcService_ExerciseContract_RunsSaga(t *testing.T) {
+	db := openTestDB(t, "otc_exercise_run")
+	seedOtcAccountTables(t, db) // accounts: 1 (client 200), 2 (client 100), USD, balance 1000
+	assetID := seedAsset(t, db, "SGE", 100, "USD")
+	now := time.Now().UTC()
+
+	holding := &models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID,
+		Quantity: 10, ReservedQuantity: 3, PublicQuantity: 10, AvgBuyPrice: 90,
+		AccountID: 1, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(holding).Error; err != nil {
+		t.Fatalf("seed holding: %v", err)
+	}
+
+	contract := &models.OtcContractRecord{
+		StockListingID: assetID, SellerHoldingID: holding.ID, Amount: 3, StrikePrice: 50,
+		SettlementDate: now.AddDate(0, 0, 1),
+		BuyerID:        100, BuyerType: "client", BuyerAccountID: 2,
+		SellerID:       200, SellerType: "client", SellerAccountID: 1,
+		Status:         models.OtcContractStatusValid, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(contract).Error; err != nil {
+		t.Fatalf("seed contract: %v", err)
+	}
+
+	otcRepo := repository.NewOtcRepository(db)
+	svc := service.NewOtcService(repository.NewPortfolioRepository(db), otcRepo).
+		WithOrchestrator(service.NewSagaOrchestrator(repository.NewSagaRepository(db), db))
+
+	res, err := svc.ExerciseContract(contract.ID, 100, "client")
+	if err != nil {
+		t.Fatalf("ExerciseContract: %v", err)
+	}
+	if res.SagaID == 0 {
+		t.Error("expected a saga id")
+	}
+
+	got, err := otcRepo.GetContractByID(contract.ID)
+	if err != nil {
+		t.Fatalf("GetContractByID: %v", err)
+	}
+	if got.Status != models.OtcContractStatusExercised {
+		t.Errorf("contract status=%s, want exercised", got.Status)
+	}
+}
+
+// TestOtcService_ExerciseContract_FaultRollsBack injects a forced failure mid-saga
+// so the orchestrator runs the compensation chain — covering the rollback path
+// and the fault-injection hooks (forceFailAfter / shouldFailCompensation).
+func TestOtcService_ExerciseContract_FaultRollsBack(t *testing.T) {
+	db := openTestDB(t, "otc_exercise_fault")
+	seedOtcAccountTables(t, db)
+	assetID := seedAsset(t, db, "SGF", 100, "USD")
+	now := time.Now().UTC()
+
+	holding := &models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID,
+		Quantity: 10, ReservedQuantity: 3, PublicQuantity: 10, AvgBuyPrice: 90,
+		AccountID: 1, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(holding).Error; err != nil {
+		t.Fatalf("seed holding: %v", err)
+	}
+	contract := &models.OtcContractRecord{
+		StockListingID: assetID, SellerHoldingID: holding.ID, Amount: 3, StrikePrice: 50,
+		SettlementDate: now.AddDate(0, 0, 1),
+		BuyerID:        100, BuyerType: "client", BuyerAccountID: 2,
+		SellerID:       200, SellerType: "client", SellerAccountID: 1,
+		Status:         models.OtcContractStatusValid, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(contract).Error; err != nil {
+		t.Fatalf("seed contract: %v", err)
+	}
+
+	svc := service.NewOtcService(repository.NewPortfolioRepository(db), repository.NewOtcRepository(db)).
+		WithOrchestrator(service.NewSagaOrchestrator(repository.NewSagaRepository(db), db))
+
+	// Force step 3 to fail (and fail compensation of step 1 once) -> rollback.
+	faults := &service.SagaFaultConfig{
+		ForceFailStep: 3, ForceFailAfter: true,
+		CompensateFailStep: 1, CompensateFailTimes: 1,
+	}
+	res, _ := svc.ExerciseContractWithFaults(contract.ID, 100, "client", faults)
+	if res == nil || res.SagaID == 0 {
+		t.Fatal("expected a saga id even on rollback")
+	}
+	// The contract should NOT be exercised (the saga failed and rolled back).
+	got, _ := repository.NewOtcRepository(db).GetContractByID(contract.ID)
+	if got != nil && got.Status == models.OtcContractStatusExercised {
+		t.Error("contract should not be exercised after a forced mid-saga failure")
+	}
+}
+
+// TestOtcService_ExerciseContract_FailAtLastStep runs all forward steps then
+// fails the final step, so every prior step gets compensated — covering the
+// transfer/reverse step functions.
+func TestOtcService_ExerciseContract_FailAtLastStep(t *testing.T) {
+	db := openTestDB(t, "otc_exercise_fail5")
+	seedOtcAccountTables(t, db)
+	assetID := seedAsset(t, db, "SG5", 100, "USD")
+	now := time.Now().UTC()
+
+	holding := &models.PortfolioHoldingRecord{
+		UserID: 200, UserType: "client", AssetID: assetID,
+		Quantity: 10, ReservedQuantity: 3, PublicQuantity: 10, AvgBuyPrice: 90,
+		AccountID: 1, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(holding).Error; err != nil {
+		t.Fatalf("seed holding: %v", err)
+	}
+	contract := &models.OtcContractRecord{
+		StockListingID: assetID, SellerHoldingID: holding.ID, Amount: 3, StrikePrice: 50,
+		SettlementDate: now.AddDate(0, 0, 1),
+		BuyerID:        100, BuyerType: "client", BuyerAccountID: 2,
+		SellerID:       200, SellerType: "client", SellerAccountID: 1,
+		Status:         models.OtcContractStatusValid, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := db.Create(contract).Error; err != nil {
+		t.Fatalf("seed contract: %v", err)
+	}
+
+	svc := service.NewOtcService(repository.NewPortfolioRepository(db), repository.NewOtcRepository(db)).
+		WithOrchestrator(service.NewSagaOrchestrator(repository.NewSagaRepository(db), db))
+
+	res, _ := svc.ExerciseContractWithFaults(contract.ID, 100, "client", &service.SagaFaultConfig{ForceFailStep: 5})
+	if res == nil || res.SagaID == 0 {
+		t.Fatal("expected a saga id")
+	}
+	got, _ := repository.NewOtcRepository(db).GetContractByID(contract.ID)
+	if got != nil && got.Status == models.OtcContractStatusExercised {
+		t.Error("contract should not be exercised after a step-5 failure + rollback")
+	}
+}

--- a/exchange-service/internal/service/otc_negotiation_service_test.go
+++ b/exchange-service/internal/service/otc_negotiation_service_test.go
@@ -1,0 +1,114 @@
+package service_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+// makeOtcOffer creates a pending offer (buyer 100 -> seller 200's holding).
+func makeOtcOffer(t *testing.T, svc *service.OtcService, holdingID uint) uint {
+	t.Helper()
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID: 100, BuyerType: "client", BuyerAccountID: 2,
+		SellerHoldingID: holdingID, Amount: 3, PricePerStock: 105,
+		SettlementDate: time.Now().UTC().AddDate(0, 1, 0), Premium: 25,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+	return offer.ID
+}
+
+func TestOtcService_ListNegotiations_Filters(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_neg_list")
+	makeOtcOffer(t, svc, holding.ID)
+
+	// All negotiations for the buyer.
+	all, err := svc.ListNegotiations(100, "client", "", nil, nil, 0)
+	if err != nil || len(all) != 1 {
+		t.Fatalf("ListNegotiations all: %d err=%v", len(all), err)
+	}
+	// Status filter.
+	if pend, _ := svc.ListNegotiations(100, "client", "pending", nil, nil, 0); len(pend) != 1 {
+		t.Errorf("pending filter: %d", len(pend))
+	}
+	// Counterparty match / mismatch.
+	if cp, _ := svc.ListNegotiations(100, "client", "", nil, nil, 200); len(cp) != 1 {
+		t.Errorf("counterparty 200: %d", len(cp))
+	}
+	if cp, _ := svc.ListNegotiations(100, "client", "", nil, nil, 999); len(cp) != 0 {
+		t.Errorf("counterparty 999: %d", len(cp))
+	}
+	// Date filter: nothing after a future cutoff.
+	future := time.Now().UTC().Add(time.Hour)
+	if rec, _ := svc.ListNegotiations(100, "client", "", &future, nil, 0); len(rec) != 0 {
+		t.Errorf("from-future filter: %d", len(rec))
+	}
+	// Invalid status -> error.
+	if _, err := svc.ListNegotiations(100, "client", "bogus", nil, nil, 0); err == nil {
+		t.Error("expected invalid-status error")
+	}
+}
+
+func TestOtcService_GetNegotiationHistory(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_neg_hist")
+	offerID := makeOtcOffer(t, svc, holding.ID)
+
+	// Seller counters -> a second entry.
+	if _, err := svc.CounterOffer(service.CounterOtcOfferInput{
+		OfferID: offerID, ModifiedByID: 200, ModifiedByType: "client",
+		Amount: 4, PricePerStock: 110, SettlementDate: time.Now().UTC().AddDate(0, 1, 0), Premium: 30,
+	}); err != nil {
+		t.Fatalf("CounterOffer: %v", err)
+	}
+
+	offer, entries, err := svc.GetNegotiationHistory(offerID, 100, "client")
+	if err != nil || offer == nil {
+		t.Fatalf("GetNegotiationHistory: %v", err)
+	}
+	if len(entries) < 2 {
+		t.Errorf("expected >=2 entries (created + countered), got %d", len(entries))
+	}
+	if entries[0].Action != "created" {
+		t.Errorf("first entry should be 'created', got %q", entries[0].Action)
+	}
+
+	// Non-participant and unknown offer -> not found.
+	if _, _, err := svc.GetNegotiationHistory(offerID, 999, "client"); !errors.Is(err, service.ErrOtcOfferNotFound) {
+		t.Errorf("non-participant: want ErrOtcOfferNotFound, got %v", err)
+	}
+	if _, _, err := svc.GetNegotiationHistory(99999, 100, "client"); !errors.Is(err, service.ErrOtcOfferNotFound) {
+		t.Errorf("unknown offer: want ErrOtcOfferNotFound, got %v", err)
+	}
+}
+
+func TestOtcService_SendExpiryReminders(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_reminders")
+	// Offer settling in ~2 days; seller accepts to create the contract.
+	offer, err := svc.CreateOffer(service.CreateOtcOfferInput{
+		BuyerID: 100, BuyerType: "client", BuyerAccountID: 2,
+		SellerHoldingID: holding.ID, Amount: 2, PricePerStock: 105,
+		SettlementDate: time.Now().UTC().Add(48 * time.Hour), Premium: 10,
+	})
+	if err != nil {
+		t.Fatalf("CreateOffer: %v", err)
+	}
+	if _, err := svc.AcceptOffer(offer.ID, 200, "client"); err != nil {
+		t.Fatalf("AcceptOffer: %v", err)
+	}
+
+	// Within a 5-day window -> one reminder; a second call is deduped to zero.
+	reminded, err := svc.SendExpiryReminders(time.Now().UTC(), 5)
+	if err != nil {
+		t.Fatalf("SendExpiryReminders: %v", err)
+	}
+	if reminded != 1 {
+		t.Errorf("expected 1 contract reminded, got %d", reminded)
+	}
+	if again, _ := svc.SendExpiryReminders(time.Now().UTC(), 5); again != 0 {
+		t.Errorf("expected dedup (0) on second run, got %d", again)
+	}
+}

--- a/exchange-service/internal/service/otc_validation_test.go
+++ b/exchange-service/internal/service/otc_validation_test.go
@@ -1,0 +1,59 @@
+package service_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+func TestOtcService_CreateOffer_ValidationErrors(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_validation")
+	base := func() service.CreateOtcOfferInput {
+		return service.CreateOtcOfferInput{
+			BuyerID: 100, BuyerType: "client", BuyerAccountID: 2,
+			SellerHoldingID: holding.ID, Amount: 3, PricePerStock: 105,
+			SettlementDate: time.Now().UTC().AddDate(0, 1, 0), Premium: 25,
+		}
+	}
+	cases := map[string]func(*service.CreateOtcOfferInput){
+		"amount<=0":         func(in *service.CreateOtcOfferInput) { in.Amount = 0 },
+		"price<=0":          func(in *service.CreateOtcOfferInput) { in.PricePerStock = 0 },
+		"premium<0":         func(in *service.CreateOtcOfferInput) { in.Premium = -1 },
+		"settlement zero":   func(in *service.CreateOtcOfferInput) { in.SettlementDate = time.Time{} },
+		"settlement past":   func(in *service.CreateOtcOfferInput) { in.SettlementDate = time.Now().UTC().Add(-time.Hour) },
+		"no buyer identity": func(in *service.CreateOtcOfferInput) { in.BuyerID = 0 },
+		"no buyer account":  func(in *service.CreateOtcOfferInput) { in.BuyerAccountID = 0 },
+		"no seller holding": func(in *service.CreateOtcOfferInput) { in.SellerHoldingID = 0 },
+	}
+	for name, mut := range cases {
+		in := base()
+		mut(&in)
+		if _, err := svc.CreateOffer(in); err == nil {
+			t.Errorf("%s: expected error", name)
+		}
+	}
+}
+
+func TestOtcService_GetContractForParticipant(t *testing.T) {
+	svc, holding, _ := setupOtcServiceFixture(t, "otc_getcontract")
+	offerID := makeOtcOffer(t, svc, holding.ID)
+	contract, err := svc.AcceptOffer(offerID, 200, "client")
+	if err != nil {
+		t.Fatalf("AcceptOffer: %v", err)
+	}
+
+	// Buyer (participant) can read it.
+	if _, err := svc.GetContractForParticipant(contract.ID, 100, "client"); err != nil {
+		t.Errorf("participant should read contract: %v", err)
+	}
+	// Stranger cannot.
+	if _, err := svc.GetContractForParticipant(contract.ID, 999, "client"); !errors.Is(err, service.ErrOtcContractNotFound) {
+		t.Errorf("stranger: want ErrOtcContractNotFound, got %v", err)
+	}
+	// Unknown contract.
+	if _, err := svc.GetContractForParticipant(99999, 100, "client"); !errors.Is(err, service.ErrOtcContractNotFound) {
+		t.Errorf("unknown: want ErrOtcContractNotFound, got %v", err)
+	}
+}

--- a/exchange-service/internal/service/public_stock_cache_test.go
+++ b/exchange-service/internal/service/public_stock_cache_test.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/interbank"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+func TestPublicStockCacheRunner_Run(t *testing.T) {
+	db := openSagaTestDB(t, "public_stock_cache")
+	repo := repository.NewRemotePublicStockRepository(db)
+
+	// Empty registry -> Run returns immediately.
+	emptyReg, err := interbank.NewRegistryFromJSON(333, "[]")
+	if err != nil {
+		t.Fatalf("empty registry: %v", err)
+	}
+	NewPublicStockCacheRunner(emptyReg, interbank.NewClient(emptyReg), repo).Run()
+
+	// Live partner returning an (empty) stock list -> UpsertPayload path.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+	reg, err := interbank.NewRegistryFromJSON(333, fmt.Sprintf(
+		`[{"code":444,"baseUrl":"%s","outboundKey":"o","inboundKey":"i","displayName":"P"}]`, srv.URL))
+	if err != nil {
+		t.Fatalf("registry: %v", err)
+	}
+	NewPublicStockCacheRunner(reg, interbank.NewClient(reg), repo).Run()
+
+	// Dead partner -> fetch fails -> UpsertError (stale) path.
+	deadReg, err := interbank.NewRegistryFromJSON(333,
+		`[{"code":445,"baseUrl":"http://127.0.0.1:1","outboundKey":"o","inboundKey":"i","displayName":"Dead"}]`)
+	if err != nil {
+		t.Fatalf("dead registry: %v", err)
+	}
+	NewPublicStockCacheRunner(deadReg, interbank.NewClient(deadReg), repo).Run()
+}

--- a/exchange-service/internal/service/saga_retry_test.go
+++ b/exchange-service/internal/service/saga_retry_test.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+)
+
+func TestSagaRetryRunner_BuildStepsErrors(t *testing.T) {
+	db := openSagaTestDB(t, "saga_retry")
+	sagaRepo := repository.NewSagaRepository(db)
+	r := NewSagaRetryRunner(sagaRepo, repository.NewOtcRepository(db), NewSagaOrchestrator(sagaRepo, db))
+
+	// No stuck sagas -> early return.
+	r.Run()
+
+	past := time.Now().UTC().Add(-time.Hour)
+	seed := func(typ, payload string) uint {
+		s := &models.SagaTransactionRecord{
+			Type: typ, Status: models.SagaStatusRollingBack, Payload: payload,
+			RetryCount: 0, CreatedAt: past, UpdatedAt: past,
+		}
+		if err := db.Create(s).Error; err != nil {
+			t.Fatalf("seed saga: %v", err)
+		}
+		// Force updated_at into the past so the staleness filter selects it.
+		db.Model(&models.SagaTransactionRecord{}).Where("id = ?", s.ID).UpdateColumn("updated_at", past)
+		return s.ID
+	}
+
+	// Three sagas whose steps can't be rebuilt -> each goes to manual intervention.
+	ids := []uint{
+		seed("unknown_type", "{}"),
+		seed(models.SagaTypeOtcExercise, "not-json"),
+		seed(models.SagaTypeOtcExercise, `{"contractId":99999}`),
+	}
+
+	r.Run()
+
+	for _, id := range ids {
+		var s models.SagaTransactionRecord
+		if err := db.First(&s, id).Error; err != nil {
+			t.Fatalf("get saga %d: %v", id, err)
+		}
+		if s.Status != models.SagaStatusRequiresManualIntervention {
+			t.Errorf("saga %d status=%s, want requires_manual_intervention", id, s.Status)
+		}
+	}
+}

--- a/exchange-service/internal/service/tax_collect_test.go
+++ b/exchange-service/internal/service/tax_collect_test.go
@@ -1,0 +1,44 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/models"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/repository"
+	"github.com/RAF-SI-2025/EXBanka-3-Backend/exchange-service/internal/service"
+)
+
+func TestTaxCollector_CollectsAndRecordsDebt(t *testing.T) {
+	db := openDivTestDB(t, "tax_collect") // currency 1 = RSD
+	now := time.Now().UTC()
+	period := "2026-04"
+
+	// State treasury (RSD) + a paying client (RSD, funded) + a broke client (RSD).
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, naziv, raspolozivo_stanje, stanje) VALUES (1, 1, 'aktivan', 'Republika Srbija', 0, 0)`)
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id, raspolozivo_stanje, stanje) VALUES (10, 1, 'aktivan', 1, 1000, 1000)`)
+	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id, raspolozivo_stanje, stanje) VALUES (11, 1, 'aktivan', 2, 10, 10)`)
+
+	taxRepo := repository.NewTaxRepository(db)
+	for _, r := range []*models.TaxRecord{
+		{UserID: 1, UserType: "client", AssetID: 1, Period: period, ProfitRSD: 1000, TaxRSD: 150, Status: "unpaid", CreatedAt: now, UpdatedAt: now},
+		{UserID: 2, UserType: "client", AssetID: 1, Period: period, ProfitRSD: 2000, TaxRSD: 300, Status: "unpaid", CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := taxRepo.CreateTaxRecord(r); err != nil {
+			t.Fatalf("seed tax: %v", err)
+		}
+	}
+
+	taxSvc := service.NewTaxService(taxRepo, repository.NewMarketRepository(db), &mockRateProv{})
+	collector := service.NewTaxCollector(taxSvc, repository.NewOrderRepository(db), taxRepo)
+
+	res := collector.CollectForPeriod(period)
+
+	// Client 1 pays 150; client 2 (balance 10 < 300) becomes a debt.
+	if res.TotalCollected != 150 {
+		t.Errorf("expected 150 collected, got %v", res.TotalCollected)
+	}
+	if len(res.Debts) != 1 || res.Debts[0].UserID != 2 {
+		t.Errorf("expected client 2 recorded as a debt, got %+v", res.Debts)
+	}
+}


### PR DESCRIPTION
… fixes

Coverage push across the exchange-service packages (30 new test files):
- service (54.7→77.5%): order lifecycle + executor (Run, margin settlement, after-hours/AON/limit), CreateOrder incl. all resolveStatus agent paths, fund dividends/statistics/withdraw/liquidation, tax collection, full OTC exercise SAGA (forward + fault rollback), interbank reconcile (apply/commit/reject/fail, terminal resend, YES-vote commit, exercise terminal, bumps), public_stock_cache, price alerts, notify emits, cron helpers, refreshListingPrices.
- handler (58.9→64.6%): createOrder HTTP, the new dividend/negotiation response mappers with real data, interbank OTC/payment createNegotiation+createPayment validation, exercise-contract validation, cached public-stocks.

Two production bug fixes the new tests surfaced:
- FundPerformanceHistoryRecord: index→uniqueIndex on (fund_id, date) so the daily snapshot cron's ON CONFLICT upsert works once a fund exists.
- GetActuaryProfile: `trading_limit as limit` used a reserved word as a bare alias (fails on sqlite AND Postgres, breaking bank/agent order creation); quoted to `as "limit"`.

Also fixed a SQLite deadlock earlier in fund dividend payout (read-before-tx). Full exchange-service suite + all 9 services green; go build/vet clean.