### PR TITLE
Fix fund trading attribution + add dividend payout audit & admin over…

### DIFF
--- a/exchange-service/internal/database/database.go
+++ b/exchange-service/internal/database/database.go
@@ -58,6 +58,7 @@ func Migrate(db *gorm.DB) error {
 			&models.ClientFundPositionRecord{},
 			&models.FundPerformanceHistoryRecord{},
 			&models.FundDividendRecord{},
+			&models.FundDividendPayoutRecord{},
 			&models.InterbankInboundMessage{},
 			&models.InterbankOtcNegotiation{},
 			&models.InterbankPendingTx{},

--- a/exchange-service/internal/handler/fund_http_handler.go
+++ b/exchange-service/internal/handler/fund_http_handler.go
@@ -458,7 +458,7 @@ func (h *FundHTTPHandler) validateFundOrder(w http.ResponseWriter, r *http.Reque
 		writeJSON(w, http.StatusNotFound, map[string]string{"message": "fond nije pronadjen"})
 		return
 	}
-	if _, err := h.svc.ValidateFundBuyOrder(fundID, claims.EmployeeID, fund.AccountID); err != nil {
+	if _, err := h.svc.ValidateFundBuyOrder(fundID, claims.EmployeeID, util.HasPermission(claims, models.PermEmployeeAdmin), fund.AccountID); err != nil {
 		writeJSON(w, http.StatusForbidden, map[string]string{"message": err.Error()})
 		return
 	}
@@ -525,7 +525,31 @@ func (h *FundHTTPHandler) listFundDividends(w http.ResponseWriter, r *http.Reque
 			"paidAt":           d.PaidAt.UTC().Format(time.RFC3339),
 		})
 	}
-	writeJSON(w, http.StatusOK, map[string]interface{}{"dividends": items, "count": len(items)})
+
+	// Per-participant payout breakdown (payout-policy distributions). Best-effort:
+	// a read failure leaves the payouts list empty rather than failing the call.
+	payoutItems := make([]map[string]interface{}, 0)
+	if payouts, perr := h.svc.ListFundDividendPayouts(fundID); perr == nil {
+		for _, p := range payouts {
+			payoutItems = append(payoutItems, map[string]interface{}{
+				"id":         p.ID,
+				"assetId":    p.AssetID,
+				"ticker":     p.Ticker,
+				"period":     p.Period,
+				"clientId":   p.ClientID,
+				"clientType": p.ClientType,
+				"accountId":  p.AccountID,
+				"amountRSD":  p.AmountRSD,
+				"paidAt":     p.PaidAt.UTC().Format(time.RFC3339),
+			})
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"dividends": items,
+		"count":     len(items),
+		"payouts":   payoutItems,
+	})
 }
 
 func (h *FundHTTPHandler) setDividendPolicy(w http.ResponseWriter, r *http.Request, fundID uint) {
@@ -543,7 +567,8 @@ func (h *FundHTTPHandler) setDividendPolicy(w http.ResponseWriter, r *http.Reque
 		writeJSON(w, http.StatusBadRequest, map[string]string{"message": "neispravan zahtev"})
 		return
 	}
-	fund, err := h.svc.SetDividendPolicy(fundID, claims.EmployeeID, body.Policy)
+	isAdmin := util.HasPermission(claims, models.PermEmployeeAdmin)
+	fund, err := h.svc.SetDividendPolicy(fundID, claims.EmployeeID, isAdmin, body.Policy)
 	if err != nil {
 		if errors.Is(err, service.ErrFundNotFound) {
 			writeJSON(w, http.StatusNotFound, map[string]string{"message": "fond nije pronadjen"})

--- a/exchange-service/internal/handler/order_http_handler.go
+++ b/exchange-service/internal/handler/order_http_handler.go
@@ -128,13 +128,28 @@ func (h *OrderHTTPHandler) createOrder(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusForbidden, map[string]string{"message": "samo supervisor moze trgovati za fond"})
 			return
 		}
-		fund, err := h.fundSvc.ValidateFundBuyOrder(body.FundID, claims.EmployeeID, body.AccountID)
+		fund, err := h.fundSvc.ValidateFundBuyOrder(body.FundID, claims.EmployeeID, util.HasPermission(claims, models.PermEmployeeAdmin), body.AccountID)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"message": err.Error()})
 			return
 		}
 		userID = fund.ID
 		userType = models.PortfolioOwnerFund
+	} else if h.fundSvc != nil && body.AccountID != 0 {
+		// Defence-in-depth: a fund's dedicated cash account may only be traded
+		// against through the fund-order path above (fundId set + supervisor
+		// validation). Reject a plain bank/client order that targets a fund
+		// account — otherwise the fund's cash is debited but the holding lands
+		// on the order owner (bank/client), silently draining the fund.
+		isFund, err := h.fundSvc.IsFundAccount(body.AccountID)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"message": "neuspela provera računa"})
+			return
+		}
+		if isFund {
+			writeJSON(w, http.StatusForbidden, map[string]string{"message": "ovaj račun pripada investicionom fondu — kupovina mora ići kroz fond, ne kao obična bankarska/klijentska kupovina"})
+			return
+		}
 	}
 
 	// Auto-detect order type from provided values when the client sends "market".

--- a/exchange-service/internal/models/fund.go
+++ b/exchange-service/internal/models/fund.go
@@ -54,6 +54,28 @@ type FundDividendRecord struct {
 
 func (FundDividendRecord) TableName() string { return "fund_dividends" }
 
+// FundDividendPayoutRecord is the per-participant breakdown of a fund-dividend
+// distribution under the "payout" policy: one row per participant who received
+// cash, keyed to its parent FundDividendRecord by (fund_id, asset_id, period).
+// This is the "who was paid how much" audit trail the aggregate
+// FundDividendRecord (DistributedRSD only) lacks. Reinvest-policy distributions
+// produce no rows here (the cash buys shares instead of paying participants).
+type FundDividendPayoutRecord struct {
+	ID         uint      `gorm:"primaryKey"`
+	FundID     uint      `gorm:"column:fund_id;not null;index:idx_fund_div_payout_fund_asset_period"`
+	AssetID    uint      `gorm:"column:asset_id;not null;index:idx_fund_div_payout_fund_asset_period"`
+	Period     string    `gorm:"not null;index:idx_fund_div_payout_fund_asset_period"`
+	Ticker     string    `gorm:"not null"`
+	ClientID   uint      `gorm:"column:client_id;not null"`
+	ClientType string    `gorm:"column:client_type;not null"` // "client" or "bank"
+	AccountID  uint      `gorm:"column:account_id;not null"`
+	AmountRSD  float64   `gorm:"column:amount_rsd;not null"`
+	PaidAt     time.Time `gorm:"column:paid_at;not null"`
+	CreatedAt  time.Time
+}
+
+func (FundDividendPayoutRecord) TableName() string { return "fund_dividend_payouts" }
+
 const (
 	FundTransactionStatusPending   = "pending"
 	FundTransactionStatusCompleted = "completed"

--- a/exchange-service/internal/repository/fund_repository.go
+++ b/exchange-service/internal/repository/fund_repository.go
@@ -389,6 +389,17 @@ func (r *FundRepository) ListFundDividends(fundID uint) ([]models.FundDividendRe
 	return recs, nil
 }
 
+// ListFundDividendPayouts returns the per-participant payout breakdown for a
+// fund (newest first) — the "who got how much" audit trail for payout-policy
+// distributions.
+func (r *FundRepository) ListFundDividendPayouts(fundID uint) ([]models.FundDividendPayoutRecord, error) {
+	var recs []models.FundDividendPayoutRecord
+	if err := r.db.Where("fund_id = ?", fundID).Order("paid_at DESC, id DESC").Find(&recs).Error; err != nil {
+		return nil, err
+	}
+	return recs, nil
+}
+
 // FindParticipantRSDAccount returns an active RSD account for a fund participant
 // (client_id for clients; a non-state firm account for the bank), or 0 if none.
 func (r *FundRepository) FindParticipantRSDAccount(clientID uint, clientType string) (uint, error) {

--- a/exchange-service/internal/service/extra_coverage_test.go
+++ b/exchange-service/internal/service/extra_coverage_test.go
@@ -178,16 +178,20 @@ func TestFundService_ValidateFundBuyOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create fund: %v", err)
 	}
-	// Wrong actor.
-	if _, err := svc.ValidateFundBuyOrder(fund.ID, 99, fund.AccountID); err == nil {
+	// Wrong actor, not admin.
+	if _, err := svc.ValidateFundBuyOrder(fund.ID, 99, false, fund.AccountID); err == nil {
 		t.Fatal("expected wrong-supervisor error")
 	}
+	// Wrong actor but admin → allowed (admin override).
+	if _, err := svc.ValidateFundBuyOrder(fund.ID, 99, true, fund.AccountID); err != nil {
+		t.Fatalf("expected admin override to succeed, got %v", err)
+	}
 	// Wrong account.
-	if _, err := svc.ValidateFundBuyOrder(fund.ID, 1, 99999); err == nil {
+	if _, err := svc.ValidateFundBuyOrder(fund.ID, 1, false, 99999); err == nil {
 		t.Fatal("expected wrong-account error")
 	}
 	// Correct.
-	if _, err := svc.ValidateFundBuyOrder(fund.ID, 1, fund.AccountID); err != nil {
+	if _, err := svc.ValidateFundBuyOrder(fund.ID, 1, false, fund.AccountID); err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
 }

--- a/exchange-service/internal/service/fund_dividend_distribution_test.go
+++ b/exchange-service/internal/service/fund_dividend_distribution_test.go
@@ -106,7 +106,7 @@ func TestFundService_DistributeFundDividends_Payout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateFund: %v", err)
 	}
-	if _, err := svc.SetDividendPolicy(fund.ID, 6, models.FundDividendPolicyPayout); err != nil {
+	if _, err := svc.SetDividendPolicy(fund.ID, 6, false, models.FundDividendPolicyPayout); err != nil {
 		t.Fatalf("SetDividendPolicy: %v", err)
 	}
 
@@ -145,7 +145,7 @@ func TestFundService_DistributeFundDividends_PayoutNotifies(t *testing.T) {
 	svc := newFundSvc(db).WithNotifier(notify.NewClient("http://127.0.0.1:0", "k"))
 
 	fund, _ := svc.CreateFund(service.CreateFundInput{Naziv: "Notify Fund", Opis: "x", MinimalniUlog: 1000, ManagerID: 6})
-	_, _ = svc.SetDividendPolicy(fund.ID, 6, models.FundDividendPolicyPayout)
+	_, _ = svc.SetDividendPolicy(fund.ID, 6, false, models.FundDividendPolicyPayout)
 	assetID := seedDivStock(t, db, "FPN", "USD", 100, 0.04)
 	seedHolding(t, db, fund.ID, "fund", assetID, 100, fund.AccountID)
 	db.Exec(`INSERT INTO accounts (id, currency_id, status, client_id) VALUES (95, 1, 'aktivan', 9)`)
@@ -165,16 +165,20 @@ func TestFundService_SetDividendPolicy_Guards(t *testing.T) {
 	svc := newFundSvc(db)
 	fund, _ := svc.CreateFund(service.CreateFundInput{Naziv: "Guard Fund", Opis: "x", MinimalniUlog: 1000, ManagerID: 6})
 
-	// Wrong manager.
-	if _, err := svc.SetDividendPolicy(fund.ID, 999, models.FundDividendPolicyPayout); err == nil {
+	// Wrong manager, not admin.
+	if _, err := svc.SetDividendPolicy(fund.ID, 999, false, models.FundDividendPolicyPayout); err == nil {
 		t.Error("expected error for non-manager")
 	}
+	// Non-manager but admin → allowed (admin override).
+	if _, err := svc.SetDividendPolicy(fund.ID, 999, true, models.FundDividendPolicyReinvest); err != nil {
+		t.Errorf("expected admin override to succeed, got %v", err)
+	}
 	// Invalid policy.
-	if _, err := svc.SetDividendPolicy(fund.ID, 6, "bogus"); err == nil {
+	if _, err := svc.SetDividendPolicy(fund.ID, 6, false, "bogus"); err == nil {
 		t.Error("expected error for invalid policy")
 	}
-	// Valid.
-	updated, err := svc.SetDividendPolicy(fund.ID, 6, models.FundDividendPolicyPayout)
+	// Valid (manager).
+	updated, err := svc.SetDividendPolicy(fund.ID, 6, false, models.FundDividendPolicyPayout)
 	if err != nil || updated.DividendPolicy != models.FundDividendPolicyPayout {
 		t.Errorf("expected policy update to payout, got %v err=%v", updated, err)
 	}

--- a/exchange-service/internal/service/fund_dividend_service.go
+++ b/exchange-service/internal/service/fund_dividend_service.go
@@ -124,6 +124,16 @@ func (s *FundService) processFundDividend(fund *models.InvestmentFundRecord, h r
 				if err := repository.CreditAccountTx(tx, t.AccountID, t.AmountRSD); err != nil {
 					return err
 				}
+				// Persist the per-participant audit row so the UI can show who
+				// received how much (keyed to the parent dividend by
+				// fund_id + asset_id + period).
+				if err := tx.Create(&models.FundDividendPayoutRecord{
+					FundID: fund.ID, AssetID: h.AssetID, Period: period, Ticker: h.Ticker,
+					ClientID: t.ClientID, ClientType: t.ClientType, AccountID: t.AccountID,
+					AmountRSD: t.AmountRSD, PaidAt: now.UTC(),
+				}).Error; err != nil {
+					return err
+				}
 				distributed = round2RSD(distributed + t.AmountRSD)
 			}
 			rec.DistributedRSD = distributed
@@ -252,8 +262,15 @@ func (s *FundService) ListFundDividends(fundID uint) ([]models.FundDividendRecor
 	return s.fundRepo.ListFundDividends(fundID)
 }
 
-// SetDividendPolicy updates a fund's dividend policy (manager only).
-func (s *FundService) SetDividendPolicy(fundID, actorID uint, policy string) (*models.InvestmentFundRecord, error) {
+// ListFundDividendPayouts returns the per-participant payout breakdown for a
+// fund's payout-policy distributions.
+func (s *FundService) ListFundDividendPayouts(fundID uint) ([]models.FundDividendPayoutRecord, error) {
+	return s.fundRepo.ListFundDividendPayouts(fundID)
+}
+
+// SetDividendPolicy updates a fund's dividend policy. The managing supervisor
+// may change their own fund; an admin may change any fund (admin override).
+func (s *FundService) SetDividendPolicy(fundID, actorID uint, isAdmin bool, policy string) (*models.InvestmentFundRecord, error) {
 	if policy != models.FundDividendPolicyReinvest && policy != models.FundDividendPolicyPayout {
 		return nil, fmt.Errorf("nepoznata politika dividendi: %s", policy)
 	}
@@ -261,7 +278,7 @@ func (s *FundService) SetDividendPolicy(fundID, actorID uint, policy string) (*m
 	if err != nil {
 		return nil, err
 	}
-	if fund.ManagerID != actorID {
+	if fund.ManagerID != actorID && !isAdmin {
 		return nil, fmt.Errorf("supervisor ne upravlja ovim fondom")
 	}
 	if err := s.fundRepo.UpdateDividendPolicy(fundID, policy); err != nil {

--- a/exchange-service/internal/service/fund_service.go
+++ b/exchange-service/internal/service/fund_service.go
@@ -622,16 +622,17 @@ func (s *FundService) GetPerformance(fundID uint, granularity string) ([]models.
 
 // --- Buy-for-fund pre-flight ---
 
-// ValidateFundBuyOrder ensures that the supervisor `actorID` manages the fund
-// `fundID`, that the order's account is the fund's own account, and that the
-// fund's account is active. Called by the HTTP handler before delegating to
+// ValidateFundBuyOrder ensures that the caller may trade for the fund — either
+// the managing supervisor (`actorID == fund.ManagerID`) or an admin (`isAdmin`,
+// admin override) — that the order's account is the fund's own account, and that
+// the fund's account is active. Called by the HTTP handler before delegating to
 // OrderService.CreateOrder.
-func (s *FundService) ValidateFundBuyOrder(fundID, actorID uint, accountID uint) (*models.InvestmentFundRecord, error) {
+func (s *FundService) ValidateFundBuyOrder(fundID, actorID uint, isAdmin bool, accountID uint) (*models.InvestmentFundRecord, error) {
 	fund, err := s.GetFund(fundID)
 	if err != nil {
 		return nil, err
 	}
-	if fund.ManagerID != actorID {
+	if fund.ManagerID != actorID && !isAdmin {
 		return nil, fmt.Errorf("supervisor ne upravlja ovim fondom")
 	}
 	if accountID != fund.AccountID {
@@ -645,6 +646,25 @@ func (s *FundService) ValidateFundBuyOrder(fundID, actorID uint, accountID uint)
 		return nil, fmt.Errorf("racun fonda nije aktivan")
 	}
 	return fund, nil
+}
+
+// IsFundAccount reports whether accountID is an investment fund's dedicated
+// RSD cash account (podvrsta='fondacija'). Used as a defence-in-depth guard in
+// the order handler so a plain bank/client order can't be placed against a
+// fund's cash account without going through the fund-order path — otherwise the
+// fund's cash is debited but the resulting holding lands on the bank.
+func (s *FundService) IsFundAccount(accountID uint) (bool, error) {
+	if accountID == 0 {
+		return false, nil
+	}
+	acc, err := s.fundRepo.GetAccountByID(accountID)
+	if err != nil {
+		return false, err
+	}
+	if acc == nil {
+		return false, nil
+	}
+	return acc.IsFundAccount(), nil
 }
 
 // --- Helpers ---

--- a/exchange-service/internal/service/fund_withdraw_liquidation_test.go
+++ b/exchange-service/internal/service/fund_withdraw_liquidation_test.go
@@ -63,13 +63,13 @@ func TestFundService_RecordDailyPerformanceAndValidateBuy(t *testing.T) {
 	}
 
 	// ValidateFundBuyOrder: manager + fund account ok; wrong manager / wrong account rejected.
-	if _, err := e.svc.ValidateFundBuyOrder(fund.ID, 5, fund.AccountID); err != nil {
+	if _, err := e.svc.ValidateFundBuyOrder(fund.ID, 5, false, fund.AccountID); err != nil {
 		t.Errorf("valid buy-order preflight failed: %v", err)
 	}
-	if _, err := e.svc.ValidateFundBuyOrder(fund.ID, 999, fund.AccountID); err == nil {
+	if _, err := e.svc.ValidateFundBuyOrder(fund.ID, 999, false, fund.AccountID); err == nil {
 		t.Error("non-manager should be rejected")
 	}
-	if _, err := e.svc.ValidateFundBuyOrder(fund.ID, 5, 99999); err == nil {
+	if _, err := e.svc.ValidateFundBuyOrder(fund.ID, 5, false, 99999); err == nil {
 		t.Error("wrong account should be rejected")
 	}
 }


### PR DESCRIPTION
…rides

- Reject bank/client orders that target a fund's dedicated account: such orders debited fund cash but credited the resulting holding to the bank.
- Add per-participant fund-dividend payout audit trail (new fund_dividend_payouts table) and surface it on the dividends endpoint.
- Allow admin override for SetDividendPolicy and ValidateFundBuyOrder (manager-or-admin), matching the global supervisor-level dividend run.